### PR TITLE
Fetching improvements

### DIFF
--- a/dirty_cat/datasets/fetching.py
+++ b/dirty_cat/datasets/fetching.py
@@ -503,7 +503,7 @@ def fetch_open_payments(load_dataframe: bool = True
 
     Description of the dataset:
     > Payments given by healthcare manufacturing companies to medical doctors
-    or hospitals
+    or hospitals.
 
     Returns
     -------
@@ -535,7 +535,7 @@ def fetch_traffic_violations(load_dataframe: bool = True
 
     Description of the dataset:
     > This dataset contains traffic violation information from all electronic
-    traffic violations issued in the County. Any information that can be used
+    traffic violations issued in the Montgomery County, MD. Any information that can be used
     to uniquely identify the vehicle, the vehicle owner or the officer issuing
     the violation will not be published.
 


### PR DESCRIPTION
Various improvements to `fetching.py`, including
- Improved type hinting
- ~~Use of cleaner dataclasses instead of namedtuples~~ ; not possible because unsupported in Python <= 3.6
- Dataset descriptions are now in the docstring of their fetcher

Fixes #224 