### PR TITLE
Parallelize the `GapEncoder`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Major changes
   positionally now have to be passed as keywords.
   :pr:`514` by :user:`Lilian Boulard <LilianBoulard>`.
 
+* Parallelized the `GapEncoder` column-wise. Parameters `n_jobs` and `verbose`
+  added to the signature. :pr:`582` by :user:`Lilian Boulard <LilianBoulard>`
+
 Release 0.4.1
 =============
 

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -648,8 +648,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         be denoted as `None`.
     n_jobs : int, optional
         The number of jobs to run in parallel.
-        The Gamma-Poisson factorization cannot be parallelized as it is an
-        iterative process, instead, the process is parallelized column-wise,
+        The process is parallelized column-wise,
         meaning each column is fitted in parallel. Thus, having
         `n_jobs` > X.shape[1] will not speed up the computation.
     verbose : int, default=0


### PR DESCRIPTION
Implements parallelization of the `GapEncoder` column-wise, as it is currently a simple for loop.
This could speed up the process significantly for wide datasets (intuitively, to be benchmarked).