### PR TITLE
Fix X shape in minhash_encoder docstrings

### DIFF
--- a/skrub/_minhash_encoder.py
+++ b/skrub/_minhash_encoder.py
@@ -233,7 +233,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, ) or (n_samples, 1)
+        X : array-like, shape (n_samples, ) or (n_samples, n_columns)
             The string data to encode. Only here for compatibility.
         y : None
             Unused, only here for compatibility.
@@ -262,12 +262,12 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
 
         Parameters
         ----------
-        X : array-like, shape (n_samples, ) or (n_samples, 1)
+        X : array-like, shape (n_samples, ) or (n_samples, n_columns)
             The string data to encode.
 
         Returns
         -------
-        :obj:`~numpy.ndarray` of shape (n_samples, n_components)
+        :obj:`~numpy.ndarray` of shape (n_samples, n_columns * n_components)
             Transformed input.
         """
         check_is_fitted(self, "hash_dict_")


### PR DESCRIPTION
the `MinHashEncoder` works for data with multiple columns, but the documentation doesn't reflect this.