### PR TITLE
fall back to pandas if no datetime format is found

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,9 +39,10 @@ Major changes
 Minor changes
 -------------
 * Improvement of date column detection and date format inference in :class:`TableVectorizer`. The
-  format inference now finds a format which works for all non-missing values of the column, instead
-  of relying on pandas behavior. If no such format exists, the column is not casted to a date column.
+  format inference now tries to find a format which works for all non-missing values of the column, and only
+  tries pandas default inference if it fails.
   :pr:`543` by :user:`Leo Grinsztajn <LeoGrin>`
+  :pr:`587` by :user:`Leo Grinsztajn <LeoGrin>`
 
 Release 0.4.0
 =============

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -142,6 +142,10 @@ def _get_datetimes_dataframe() -> pd.DataFrame:
                 "2015/12/31 01:31:34",
                 "2014/01/31 00:32:45",
             ],
+            # this date format is not found by pandas guess_datetime_format
+            # so shoulnd't be found by our _infer_datetime_format
+            # but pandas.to_datetime can still parse it
+            "mm/dd/yy": ["12/1/22", "2/3/05", "2/1/20", "10/7/99", "1/23/04"],
         }
     )
 
@@ -255,6 +259,7 @@ def test_auto_cast() -> None:
         "dmy-": "datetime64[ns]",
         "ymd/": "datetime64[ns]",
         "ymd/_hms:": "datetime64[ns]",
+        "mm/dd/yy": "datetime64[ns]",
     }
     X_trans = vectorizer._auto_cast(X)
     for col in X_trans.columns:


### PR DESCRIPTION
Fix #555 

We now fall back on `pandas.to_datetime` format inference when we don't find a format with `_infer_datetime_format`. Indeed, this function relies on pandas' `guess_datetime_format`, which doesn't work for weirder date format, and `pandas.to_datetime` uses `dateutil` when `guess_datetime_format` doesn't work.

The code to catch warnings could maybe be simplified.