### PR TITLE
MAINT bump python version to 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
-      - PYTHON_VERSION: 3.10
+      - PYTHON_VERSION: "3.10"
       - OMP_NUM_THREADS: 2 # Avoid over-commit with HistGradientBoosting
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     environment:
       - MINICONDA_PATH: ~/miniconda
       - CONDA_ENV_NAME: testenv
-      - PYTHON_VERSION: 3.9
+      - PYTHON_VERSION: 3.10
       - OMP_NUM_THREADS: 2 # Avoid over-commit with HistGradientBoosting
     steps:
       - checkout

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -113,7 +113,7 @@ export PATH="miniconda/bin:$PATH"
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-mamba create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
+mamba create -n $CONDA_ENV_NAME --yes python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx \
   seaborn statsmodels pillow cython joblib pandas="${PANDAS_VERSION:-*}"

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -106,15 +106,14 @@ if [[ `type -t deactivate` ]]; then
 fi
 
 # Install dependencies with miniconda
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh \
    -O miniconda.sh
 chmod +x miniconda.sh && bash ./miniconda.sh -b -p "miniconda"
 export PATH="miniconda/bin:$PATH"
-conda update --yes --quiet conda
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
+mamba create -n $CONDA_ENV_NAME --yes --quiet python="${PYTHON_VERSION:-*}" \
   numpy="${NUMPY_VERSION:-*}" scipy="${SCIPY_VERSION:-*}" \
   pytest coverage matplotlib="${MATPLOTLIB_VERSION:-*}" sphinx \
   seaborn statsmodels pillow cython joblib pandas="${PANDAS_VERSION:-*}"


### PR DESCRIPTION
I saw that in the documentation that you have an extra colon in the docstring:

![image](https://github.com/skrub-data/skrub/assets/7454015/306ad8ac-4bbc-4fc8-900f-ba6ef4b7aa09)

Indeed, this is due to the version of `sphinx` and `docutils` used: https://github.com/sphinx-doc/sphinx/issues/10594

This has been solved in the new sphinx version but I assume that using Python 3.9 is locking the version of `sphinx` used. Just wanted to give it a try to bump from 3.9 to 3.10.

Alternatively, one can overwrite the CSS most probably with something like:

```css
dl.field-list  .colon {
    display: none;
}
```

However, it would be easier to just fix it by installing a more recent sphinx version. FYI, we use sphinx 6.0.0 in scikit-learn.