### PR TITLE
MAINT: bump to Python 3.10

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,15 +44,13 @@ jobs:
               - os: "macos-latest"
                 os-name: "MacOS"
               - dependencies-version: "dev"
-              - dependencies-version: "dev, min-py38"
-                python-version: "3.8"
-                dependencies-version-type: "minimal"
-              - dependencies-version: "dev, min-py39"
-                python-version: "3.9"
+              - dependencies-version: "dev"
+                python-version: "3.10"
                 dependencies-version-type: "minimal"
               - dependencies-version: "dev, min-py310"
                 python-version: "3.10"
-                dependencies-version-type: "minimal"
+              - dependencies-version: "dev"
+                python-version: "3.10"
     name: ${{ matrix.os-name }} with Python ${{ matrix.python-version }} and ${{ matrix.dependencies-version-type }} dependencies
     defaults:
       run:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest", "macos-latest"]
-            python-version: ["3.8", "3.9", "3.10"]
+            python-version: ["3.10", "3.11"]
             # Install the min or latest dependencies for skrub
             # as defined in setup.cfg at [options.extra_require].
             #

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ Major changes
 * Parallelized the `GapEncoder` column-wise. Parameters `n_jobs` and `verbose`
   added to the signature. :pr:`582` by :user:`Lilian Boulard <LilianBoulard>`
 
+* Bump minimal required Python version to 3.10. :pr:`606` by
+  :user:`Gael Varoquaux <GaelVaroquaux>`
+
 Minor changes
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target_version = ['py38', 'py39', 'py310']
+target_version = ['py310', 'py311']
 preview = true
 # Exclude irrelevant directories for formatting
 exclude = '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     requests
     joblib
     pyarrow
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.extras_require]
 dev =
@@ -64,16 +64,6 @@ benchmarks =
     autofj
 # Overwrite the previous install_requires for CI testing purposes
 # as defined in testing.yml.
-min-py38 =
-    scikit-learn==0.23.0
-    numpy==1.17.3
-    scipy==1.4.0
-    pandas==1.2.0
-min-py39 =
-    scikit-learn==0.24.0
-    numpy==1.19.3
-    scipy==1.6.0
-    pandas==1.2.0
 min-py310 =
     scikit-learn==1.0.2
     numpy==1.21.3


### PR DESCRIPTION
Currently, we only want as users people who are early adopters and quite agile.

I'm in favor of dropping support for Python versions earlier than 3.10. If nothing else, it will make our build matrix lighter.