### PR TITLE
Bump requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,9 +37,9 @@ Major changes
   - numpy >= 1.23.5
   - scipy >= 1.9.3
   - scikit-learn >= 1.2.1
-  - pandas >= 1.5.3
+  - pandas >= 1.5.3 :pr:`613` by :user:`Lilian Boulard <LilianBoulard>`
 
-* Removed `requests` from the requirements.
+* Removed `requests` from the requirements. :pr:`613` by :user:`Lilian Boulard <LilianBoulard>`
 
 Minor changes
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,8 +30,16 @@ Major changes
   and :func:`fetch_ken_types` have been renamed.
   :pr:`602` by :user:`Jovan Stojanovic <jovan-stojanovic>`
 
-* Bump minimal required Python version to 3.10. :pr:`606` by
+* Bumped minimal required Python version to 3.10. :pr:`606` by
   :user:`Gael Varoquaux <GaelVaroquaux>`
+
+* Bumped minimal required versions for the dependencies:
+  - numpy >= 1.23.5
+  - scipy >= 1.9.3
+  - scikit-learn >= 1.2.1
+  - pandas >= 1.5.3
+
+* Removed `requests` from the requirements.
 
 Minor changes
 -------------

--- a/examples/01_dirty_categories.py
+++ b/examples/01_dirty_categories.py
@@ -122,11 +122,7 @@ encoder = make_column_transformer(
 #
 # We will use a |HGBR|,
 # which is a good predictor for data with heterogeneous columns
-# (we need to require the experimental feature for scikit-learn versions
-# earlier than 1.0):
-from sklearn.experimental import enable_hist_gradient_boosting
 
-# We can now import the |HGBR| from ensemble
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 # We then create a pipeline chaining our encoders to a learner

--- a/examples/04_fuzzy_joining_and_FeatureAugmenter.py
+++ b/examples/04_fuzzy_joining_and_FeatureAugmenter.py
@@ -312,10 +312,7 @@ y = df3[["Happiness score"]]
 
 ###################################################################
 # Let us now define the model that will be used to predict the happiness score:
-from sklearn import __version__ as sklearn_version
 
-if sklearn_version < "1.0":
-    from sklearn.experimental import enable_hist_gradient_boosting
 from sklearn.ensemble import HistGradientBoostingRegressor
 from sklearn.model_selection import KFold
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,10 @@ project_urls =
 include_package_data = True
 packages = find:
 install_requires =
-    scikit-learn>=0.23.0
-    numpy>=1.17.3
-    scipy>=1.4.0
-    pandas>=1.2.0
-    requests
-    joblib
+    scikit-learn>=1.2.1
+    numpy>=1.23.5
+    scipy>=1.9.3
+    pandas>=1.5.3
     pyarrow
 python_requires = >=3.10
 
@@ -67,10 +65,10 @@ benchmarks =
 # Overwrite the previous install_requires for CI testing purposes
 # as defined in testing.yml.
 min-py310 =
-    scikit-learn==1.0.2
-    numpy==1.21.3
-    scipy==1.8.0
-    pandas==1.3.5
+    scikit-learn==1.2.1
+    numpy==1.23.5
+    scipy==1.9.3
+    pandas==1.5.3
 
 [flake8]
 # max line length for black

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -1,13 +1,11 @@
 from typing import Dict, List, Literal, Optional
-from warnings import warn
 
 import numpy as np
 import pandas as pd
-from sklearn import __version__ as sklearn_version
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from skrub._utils import check_input, parse_version
+from skrub._utils import check_input
 
 # Required for ignoring lines too long in the docstrings
 # flake8: noqa: E501
@@ -279,28 +277,3 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
             for feature in self.features_per_column_[i]:
                 feature_names.append(f"{prefix}_{feature}")
         return feature_names
-
-    def get_feature_names(self, input_features=None) -> List[str]:
-        """Return clean feature names. Compatibility method for sklearn < 1.0.
-
-        Use :func:`~DatetimeEncoder.get_feature_names_out` instead.
-
-        Parameters
-        ----------
-        input_features : None
-            Unused, only here for compatibility.
-
-        Returns
-        -------
-        list of str
-            List of feature names.
-        """
-        if parse_version(sklearn_version) >= parse_version("1.0"):
-            warn(
-                "Following the changes in scikit-learn 1.0, "
-                "get_feature_names is deprecated. "
-                "Use get_feature_names_out instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        return self.get_feature_names_out()

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -410,10 +410,11 @@ class SimilarityEncoder(OneHotEncoder):
                 ]
             )
 
+        self._infrequent_enabled = False
         if parse_version(sklearn.__version__) >= parse_version("1.2.2"):
             self.drop_idx_ = self._set_drop_idx()
         else:
-            self._infrequent_enabled = False
+            self.drop_idx_ = self._compute_drop_idx()
 
         return self
 

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -17,6 +17,9 @@ from sklearn.utils.validation import check_is_fitted
 from ._string_distances import get_ngram_count, preprocess
 from ._utils import parse_version
 
+# Ignore lines too long, first docstring lines can't be cut
+# flake8: noqa: E501
+
 
 def _ngram_similarity_one_sample_inplace(
     x_count_vector: np.ndarray,
@@ -407,12 +410,10 @@ class SimilarityEncoder(OneHotEncoder):
                 ]
             )
 
-        if parse_version(sklearn.__version__) >= parse_version("1.1.0"):
-            self._infrequent_enabled = False
         if parse_version(sklearn.__version__) >= parse_version("1.2.2"):
             self.drop_idx_ = self._set_drop_idx()
         else:
-            self.drop_idx_ = self._compute_drop_idx()
+            self._infrequent_enabled = False
 
         return self
 

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -416,10 +416,10 @@ class TableVectorizer(ColumnTransformer):
             self.low_card_cat_transformer_ = clone(self.low_card_cat_transformer)
         elif self.low_card_cat_transformer is None:
             # sklearn is lenient and lets us use both
-            # `handle_unknown="infrequent_if_exists"` and `drop="if_binary"`
+            # `handle_unknown="infrequent_if_exist"` and `drop="if_binary"`
             # at the same time
             self.low_card_cat_transformer_ = OneHotEncoder(
-                drop="if_binary", handle_unknown="infrequent_if_exists"
+                drop="if_binary", handle_unknown="infrequent_if_exist"
             )
         elif self.low_card_cat_transformer == "remainder":
             self.low_card_cat_transformer_ = self.remainder

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -2,14 +2,8 @@ import collections
 from typing import Any, Hashable
 
 import numpy as np
+from sklearn.utils import parse_version  # noqa
 from sklearn.utils import check_array
-
-try:
-    # Works for sklearn >= 1.0
-    from sklearn.utils import parse_version  # noqa
-except ImportError:
-    # Works for sklearn < 1.0
-    from sklearn.utils.fixes import _parse_version as parse_version  # noqa
 
 
 class LRUDict:

--- a/skrub/tests/test_gap_encoder.py
+++ b/skrub/tests/test_gap_encoder.py
@@ -1,12 +1,10 @@
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn import __version__ as sklearn_version
 from sklearn.exceptions import NotFittedError
 from sklearn.model_selection import train_test_split
 
 from skrub import GapEncoder
-from skrub._utils import parse_version
 from skrub.datasets import fetch_midwest_survey
 from skrub.tests.utils import generate_data
 
@@ -168,12 +166,7 @@ def test_get_feature_names_out(n_samples=70) -> None:
     X = generate_data(n_samples, random_state=0)
     enc = GapEncoder(random_state=42)
     enc.fit(X)
-    # Expect a warning if sklearn >= 1.0
-    if parse_version(sklearn_version) < parse_version("1.0"):
-        feature_names_1 = enc.get_feature_names()
-    else:
-        with pytest.warns(DeprecationWarning):
-            feature_names_1 = enc.get_feature_names()
+    feature_names_1 = enc.get_feature_names_out()
     feature_names_2 = enc.get_feature_names_out()
     for topic_labels in [feature_names_1, feature_names_2]:
         # Check number of labels

--- a/skrub/tests/test_similarity_encoder.py
+++ b/skrub/tests/test_similarity_encoder.py
@@ -3,13 +3,11 @@ from typing import Callable, Optional
 import numpy as np
 import numpy.testing
 import pytest
-from sklearn import __version__ as sklearn_version
 from sklearn.exceptions import NotFittedError
 
 from skrub import SimilarityEncoder
 from skrub._similarity_encoder import ngram_similarity_matrix
 from skrub._string_distances import ngram_similarity
-from skrub._utils import parse_version
 
 
 def test_specifying_categories() -> None:
@@ -211,11 +209,7 @@ def test_get_features() -> None:
     sim_enc = SimilarityEncoder()
     X = np.array(["%s" % chr(i) for i in range(32, 127)]).reshape((-1, 1))
     sim_enc.fit(X)
-    if parse_version(sklearn_version) < parse_version("1.0"):
-        feature_names = sim_enc.get_feature_names()
-    else:
-        feature_names = sim_enc.get_feature_names_out()
-    assert feature_names.tolist() == [
+    assert sim_enc.get_feature_names_out().tolist() == [
         "x0_ ",
         "x0_!",
         'x0_"',


### PR DESCRIPTION
Bump the minimal versions of all dependencies and removes the requirement on `requests` (we don't use directly).

For numpy, scipy and pandas, versions date back to mid/late 2022, and scikit-learn 1.2.1 was released in January.