### PR TITLE
FEA Add analyzer parameter to SimilarityEncoder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,9 +47,12 @@ Minor changes
 * Removed the `most_frequent` and `k-means` strategies from the :class:`SimilarityEncoder`.
   These strategy were used for scalability reasons, but we recommend using the :class:`MinHashEncoder`
   or the :class:`GapEncoder` instead. :pr:`596` by :user:`Leo Grinsztajn <LeoGrin>`
-* Removed the `similarity` argument from the :class:`SimilarityEncoder` constructor,
 
+* Removed the `similarity` argument from the :class:`SimilarityEncoder` constructor,
   as we only support the ngram similarity. :pr:`596` by :user:`Leo Grinsztajn <LeoGrin>`
+
+* Added the `analyzer` parameter to the :class:`SimilarityEncoder` to allow word counts
+  for similarity measures. :pr:`619` by :user:`Jovan Stojanovic <jovan-stojanovic>`
 
 * skrub now uses modern type hints introduced in PEP 585.
   :pr:`609` by :user:`Lilian Boulard <LilianBoulard>`

--- a/skrub/tests/test_similarity_encoder.py
+++ b/skrub/tests/test_similarity_encoder.py
@@ -177,10 +177,11 @@ def test_similarity_encoder() -> None:
             _test_missing_values_transform(input_type, missing)
 
 
-def test_ngram_similarity_matrix() -> None:
+@pytest.mark.parametrize("analyzer", ["char", "char_wb", "word"])
+def test_ngram_similarity_matrix(analyzer) -> None:
     X1 = np.array(["cat1", "cat2", "cat3"])
     X2 = np.array(["cata1", "caat2", "ccat3"])
-    sim = ngram_similarity_matrix(X1, X2, ngram_range=(2, 2), hashing_dim=5)
+    sim = ngram_similarity_matrix(X1, X2, ngram_range=(2, 2), analyzer=analyzer, hashing_dim=5)
     assert sim.shape == (len(X1), len(X2))
 
 


### PR DESCRIPTION
Fix #138
The fuzzy_join and the GapEncoder have the same parameter, it may be useful in the SimilarityEncoder as well.