### PR TITLE
Use modern numpy type hints

### DIFF
--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -161,7 +162,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
                     - pd.Timestamp("1970-01-01", tz="utc")
                 ) // pd.Timedelta("1s")
 
-    def fit(self, X, y=None) -> "DatetimeEncoder":
+    def fit(self, X: ArrayLike, y=None) -> "DatetimeEncoder":
         """Fit the instance to X.
 
         In practice, just stores which extracted features are not constant.
@@ -216,7 +217,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
 
         return self
 
-    def transform(self, X, y=None) -> np.ndarray:
+    def transform(self, X: ArrayLike, y=None) -> NDArray:
         """Transform `X` by replacing each datetime column with corresponding numerical features.
 
         Parameters

--- a/skrub/_deduplicate.py
+++ b/skrub/_deduplicate.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import ArrayLike, NDArray
 from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.spatial.distance import pdist, squareform
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -17,10 +18,10 @@ from sklearn.metrics import silhouette_score
 
 
 def compute_ngram_distance(
-    unique_words: Sequence[str] | np.ndarray,
+    unique_words: Sequence[str] | NDArray,
     ngram_range: tuple[int, int] = (2, 4),
     analyzer: str = "char_wb",
-) -> np.ndarray:
+) -> NDArray:
     """Compute the condensed pair-wise n-gram distance between `unique_words`.
 
     Parameters
@@ -54,15 +55,15 @@ def compute_ngram_distance(
     return distance_mat
 
 
-def _guess_clusters(Z: np.ndarray, distance_mat: np.ndarray) -> int:
+def _guess_clusters(Z: NDArray, distance_mat: NDArray) -> int:
     """Finds the number of clusters that maximize the silhouette score
     when clustering `distance_mat`.
 
     Parameters
     ----------
-    Z : np.ndarray
+    Z : numpy ndarray
         hierarchical linkage matrix, specifies which clusters to merge.
-    distance_mat : np.ndarray
+    distance_mat : numpy ndarray
         distance matrix either in square or condensed form.
 
     Returns
@@ -83,8 +84,8 @@ def _guess_clusters(Z: np.ndarray, distance_mat: np.ndarray) -> int:
 
 
 def _create_spelling_correction(
-    unique_words: Sequence[str] | np.ndarray,
-    counts: Sequence[int] | np.ndarray,
+    unique_words: Sequence[str] | NDArray[np.str_],
+    counts: Sequence[int] | NDArray[np.int_],
     clusters: Sequence[int],
 ) -> pd.Series:
     """

--- a/skrub/_fast_hash.py
+++ b/skrub/_fast_hash.py
@@ -52,7 +52,7 @@ def ngram_min_hash(
     ngram_range: tuple[int, int] = (2, 4),
     seed: int = 0,
     return_minmax=False,
-):
+) -> int | tuple[int, int]:
     """
     Compute the min/max hash of the ngrams of the string.
 

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
+from numpy.typing import ArrayLike, NDArray
 from scipy.sparse import csr_matrix, hstack, vstack
 from sklearn.feature_extraction.text import (
     HashingVectorizer,
@@ -27,7 +28,7 @@ def _numeric_encoding(
     main_cols: str | list[str],
     aux: pd.DataFrame,
     aux_cols: str | list[str],
-) -> tuple:
+) -> tuple[ArrayLike, ArrayLike]:
     """Encoding numerical columns.
 
     Parameters
@@ -63,7 +64,7 @@ def _time_encoding(
     main_cols: str | list[str],
     aux: pd.DataFrame,
     aux_cols: str | list[str],
-) -> tuple:
+) -> tuple[ArrayLike, ArrayLike]:
     """Encoding datetime columns.
 
     Parameters
@@ -104,7 +105,7 @@ def _string_encoding(
     analyzer: Literal["word", "char", "char_wb"],
     ngram_range: tuple[int, int],
     encoder: _VectorizerMixin = None,
-) -> tuple:
+) -> tuple[ArrayLike, ArrayLike]:
     """Encoding string columns.
 
     Parameters
@@ -161,7 +162,9 @@ def _string_encoding(
     return main_enc, aux_enc
 
 
-def _nearest_matches(main_array, aux_array) -> tuple[np.ndarray, np.ndarray]:
+def _nearest_matches(
+    main_array: ArrayLike, aux_array: ArrayLike
+) -> tuple[NDArray, NDArray]:
     """Find the closest matches using the nearest neighbors method.
 
     Parameters

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 from numpy.random import RandomState
+from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.cluster import KMeans, kmeans_plusplus
@@ -37,7 +38,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
     """
 
     rho_: float
-    H_dict_: dict[np.ndarray, np.ndarray]
+    H_dict_: dict[NDArray, NDArray]
 
     def __init__(
         self,
@@ -79,7 +80,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.rescale_W = rescale_W
         self.max_iter_e_step = max_iter_e_step
 
-    def _init_vars(self, X) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def _init_vars(self, X) -> tuple[NDArray, NDArray, NDArray]:
         """
         Build the bag-of-n-grams representation `V` of `X` and initialize
         the topics `W`.
@@ -134,7 +135,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             self.rho_ = self.rho ** (self.batch_size / len(X))
         return unq_X, unq_V, lookup
 
-    def _get_H(self, X: np.ndarray) -> np.ndarray:
+    def _get_H(self, X: NDArray) -> NDArray:
         """
         Return the bag-of-n-grams representation of `X`.
         """
@@ -143,7 +144,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             h_out[:] = self.H_dict_[x]
         return H_out
 
-    def _init_w(self, V: np.ndarray, X) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    def _init_w(self, V: NDArray, X) -> tuple[NDArray, NDArray, NDArray]:
         """
         Initialize the topics `W`.
         If `self.init='k-means++'`, we use the init method of
@@ -197,7 +198,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         B = A.copy()
         return W, A, B
 
-    def fit(self, X, y=None) -> "GapEncoderColumn":
+    def fit(self, X: ArrayLike, y=None) -> "GapEncoderColumn":
         """
         Fit the GapEncoder on `X`.
 
@@ -299,7 +300,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         topic_labels = [prefix + ", ".join(label) for label in topic_labels]
         return topic_labels
 
-    def score(self, X) -> float:
+    def score(self, X: ArrayLike) -> float:
         """Score this instance of `X`.
 
         Returns the Kullback-Leibler divergence between the n-grams counts
@@ -343,7 +344,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         )
         return kl_divergence
 
-    def partial_fit(self, X, y=None) -> "GapEncoderColumn":
+    def partial_fit(self, X: ArrayLike, y=None) -> "GapEncoderColumn":
         """Partial fit this instance on `X`.
 
         To be used in an online learning procedure where batches of data are
@@ -437,7 +438,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             )
             self.H_dict_.update(zip(unseen_X, unseen_H))
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: ArrayLike) -> NDArray:
         """Return the encoded vectors (activations) `H` of input strings in `X`.
 
         Parameters
@@ -747,7 +748,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
 
         return X
 
-    def fit(self, X, y=None) -> "GapEncoder":
+    def fit(self, X: ArrayLike, y=None) -> "GapEncoder":
         """Fit the instance on X.
 
         Parameters
@@ -782,7 +783,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         )
         return self
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: ArrayLike) -> NDArray:
         """Return the encoded vectors (activations) `H` of input strings in `X`.
 
         Given the learnt topics `W`, the activations `H` are tuned to fit
@@ -813,7 +814,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         X_enc = np.hstack(X_enc)
         return X_enc
 
-    def partial_fit(self, X, y=None) -> "GapEncoder":
+    def partial_fit(self, X: ArrayLike, y=None) -> "GapEncoder":
         """Partial fit this instance on X.
 
         To be used in an online learning procedure where batches of data are
@@ -900,7 +901,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
             labels.extend(col_labels)
         return labels
 
-    def score(self, X) -> float:
+    def score(self, X: ArrayLike) -> float:
         """Score this instance on `X`.
 
         Returns the sum over the columns of `X` of the Kullback-Leibler
@@ -924,7 +925,7 @@ class GapEncoder(BaseEstimator, TransformerMixin):
         return kl_divergence
 
 
-def _rescale_W(W: np.ndarray, A: np.ndarray) -> None:
+def _rescale_W(W: NDArray, A: NDArray) -> None:
     """
     Rescale the topics `W` to have a L1-norm equal to 1.
     Note that they are modified in-place.
@@ -935,14 +936,14 @@ def _rescale_W(W: np.ndarray, A: np.ndarray) -> None:
 
 
 def _multiplicative_update_w(
-    Vt: np.ndarray,
-    W: np.ndarray,
-    A: np.ndarray,
-    B: np.ndarray,
-    Ht: np.ndarray,
+    Vt: NDArray,
+    W: NDArray,
+    A: NDArray,
+    B: NDArray,
+    Ht: NDArray,
     rescale_W: bool,
     rho: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[NDArray, NDArray, NDArray]:
     """
     Multiplicative update step for the topics `W`.
     """
@@ -956,7 +957,7 @@ def _multiplicative_update_w(
     return W, A, B
 
 
-def _rescale_h(V: np.ndarray, H: np.ndarray) -> np.ndarray:
+def _rescale_h(V: NDArray, H: NDArray) -> NDArray:
     """
     Rescale the activations `H`.
     """
@@ -967,9 +968,9 @@ def _rescale_h(V: np.ndarray, H: np.ndarray) -> np.ndarray:
 
 
 def _multiplicative_update_h(
-    Vt: np.ndarray,
-    W: np.ndarray,
-    Ht: np.ndarray,
+    Vt: NDArray,
+    W: NDArray,
+    Ht: NDArray,
     epsilon: float = 1e-3,
     max_iter: int = 10,
     rescale_W: bool = False,
@@ -1004,9 +1005,9 @@ def _multiplicative_update_h(
 
 
 def batch_lookup(
-    lookup: np.ndarray,
+    lookup: NDArray,
     n: int = 1,
-) -> Generator[tuple[np.ndarray, np.ndarray], None, None]:
+) -> Generator[tuple[NDArray, NDArray], None, None]:
     """
     Make batches of the lookup array.
     """
@@ -1018,7 +1019,7 @@ def batch_lookup(
 
 
 def get_kmeans_prototypes(
-    X,
+    X: ArrayLike,
     n_prototypes: int,
     analyzer: Literal["word", "char", "char_wb"] = "char",
     hashing_dim: int = 128,
@@ -1026,7 +1027,7 @@ def get_kmeans_prototypes(
     sparse: bool = False,
     sample_weight=None,
     random_state: int | RandomState | None = None,
-):
+) -> NDArray:
     """
     Computes prototypes based on:
       - dimensionality reduction (via hashing n-grams)

--- a/skrub/_minhash_encoder.py
+++ b/skrub/_minhash_encoder.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
+from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices, murmurhash3_32
 from sklearn.utils.validation import _check_feature_names_in, check_is_fitted
@@ -142,7 +143,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
         """
         return {"X_types": ["categorical"]}
 
-    def _get_murmur_hash(self, string: str) -> np.ndarray:
+    def _get_murmur_hash(self, string: str) -> NDArray:
         """
         Encode a string using murmur hashing function.
 
@@ -170,7 +171,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
             min_hashes = np.minimum(min_hashes, hash_array)
         return min_hashes / (2**32 - 1)
 
-    def _get_fast_hash(self, string: str) -> np.ndarray:
+    def _get_fast_hash(self, string: str) -> NDArray:
         """Encode a string with fast hashing function.
 
         Fast hashing supports both min_hash and minmax_hash encoding.
@@ -201,8 +202,8 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
             )
 
     def _compute_hash_batched(
-        self, batch: Collection[str], hash_func: Callable[[str], np.ndarray]
-    ):
+        self, batch: Collection[str], hash_func: Callable[[str], NDArray]
+    ) -> NDArray:
         """Function called to compute the hashes of a batch of strings.
 
         Check if the string is in the hash dictionary, if not, compute the hash
@@ -230,7 +231,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
             res[i] = self.hash_dict_[string]
         return res
 
-    def fit(self, X, y=None) -> "MinHashEncoder":
+    def fit(self, X: ArrayLike, y=None) -> "MinHashEncoder":
         """Fit the MinHashEncoder to `X`.
 
         In practice, just initializes a dictionary
@@ -265,7 +266,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
         self.hash_dict_ = LRUDict(capacity=self._capacity)
         return self
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: ArrayLike) -> NDArray:
         """
         Transform `X` using specified encoding scheme.
 
@@ -348,7 +349,9 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
 
         return X_out.astype(np.float64)  # The output is an int32 before conversion
 
-    def get_feature_names_out(self, input_features=None):
+    def get_feature_names_out(
+        self, input_features: ArrayLike | str | None = None
+    ) -> NDArray[np.str_]:
         """Get output feature names for transformation.
 
         The output feature names look like:

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -8,6 +8,7 @@ from typing import Literal
 import numpy as np
 import sklearn
 from joblib import Parallel, delayed
+from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 from sklearn.preprocessing import OneHotEncoder
@@ -22,12 +23,12 @@ from ._utils import parse_version
 
 
 def _ngram_similarity_one_sample_inplace(
-    x_count_vector: np.ndarray,
-    vocabulary_count_matrix: np.ndarray,
+    x_count_vector: NDArray,
+    vocabulary_count_matrix: NDArray,
     str_x: str,
-    vocabulary_ngram_counts: np.ndarray,
+    vocabulary_ngram_counts: NDArray,
     se_dict: dict,
-    unq_X: np.ndarray,
+    unq_X: NDArray,
     i: int,
     ngram_range: tuple[int, int],
 ) -> None:
@@ -77,7 +78,7 @@ def ngram_similarity_matrix(
     ngram_range: tuple[int, int],
     hashing_dim: int,
     dtype: type = np.float64,
-) -> np.ndarray:
+) -> NDArray:
     """
     Similarity encoding for dirty categorical variables:
     Given two arrays of strings, returns the similarity encoding matrix
@@ -260,11 +261,11 @@ class SimilarityEncoder(OneHotEncoder):
     array(['gender_Female', 'gender_Male', 'group_1', 'group_2', 'group_3'], ...)
     """
 
-    categories_: list[np.ndarray]
+    categories_: list[NDArray]
     n_features_in_: int
-    drop_idx_: np.ndarray
+    drop_idx_: NDArray
     vectorizers_: list[CountVectorizer]
-    vocabulary_count_matrices_: list[np.ndarray]
+    vocabulary_count_matrices_: list[NDArray]
     vocabulary_ngram_counts_: list[list[int]]
     _infrequent_enabled: bool
 
@@ -295,7 +296,7 @@ class SimilarityEncoder(OneHotEncoder):
                     "'auto' or a list of prototypes. "
                 )
 
-    def fit(self, X, y=None) -> "SimilarityEncoder":
+    def fit(self, X: ArrayLike, y=None) -> "SimilarityEncoder":
         """Fit the instance to `X`.
 
         Parameters
@@ -418,7 +419,7 @@ class SimilarityEncoder(OneHotEncoder):
 
         return self
 
-    def transform(self, X, fast: bool = True) -> np.ndarray:
+    def transform(self, X: ArrayLike, fast: bool = True) -> NDArray:
         """Transform `X` using specified encoding scheme.
 
         Parameters
@@ -492,9 +493,9 @@ class SimilarityEncoder(OneHotEncoder):
 
     def _ngram_similarity_fast(
         self,
-        X: list | np.ndarray,
+        X: list | NDArray,
         col_idx: int,
-    ) -> np.ndarray:
+    ) -> NDArray:
         """
         Fast computation of ngram similarity.
 

--- a/skrub/_string_distances.py
+++ b/skrub/_string_distances.py
@@ -83,8 +83,8 @@ def get_unique_ngrams(string: str, ngram_range: tuple[int, int]):
     return ngram_set
 
 
-def get_ngrams(string, n):
-    """Return the set of different tri-grams in a string"""
+def get_ngrams(string: str, n: int) -> list[tuple]:
+    """Return the set of different n-grams in a string"""
     # Pure Python implementation: no numpy
     spaces = " "  # * (n // 2 + n % 2)
     string = spaces + " ".join(string.lower().split()) + spaces
@@ -107,9 +107,3 @@ def ngram_similarity(string1, string2, n, preprocess_strings=True):
     allgrams = len(ngrams1) + len(ngrams2)
     similarity = samegrams / (allgrams - samegrams)
     return similarity
-
-
-if __name__ == "__main__":
-    s1 = "aa"
-    s2 = "aaab"
-    print("3-gram similarity: %.3f" % ngram_similarity(s1, s2, 3))

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -11,6 +11,7 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 import sklearn
+from numpy.typing import ArrayLike, NDArray
 from pandas._libs.tslibs.parsing import guess_datetime_format
 from pandas.core.dtypes.base import ExtensionDtype
 from sklearn.base import TransformerMixin, clone
@@ -549,7 +550,7 @@ class TableVectorizer(ColumnTransformer):
             X.loc[:, col] = X[col].astype(dtype)
         return X
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X: ArrayLike, y: ArrayLike = None) -> ArrayLike:
         """Fit all transformers, transform the data, and concatenate the results.
 
         In practice, it (1) converts features to their best possible types
@@ -674,7 +675,7 @@ class TableVectorizer(ColumnTransformer):
 
         return X_enc
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: ArrayLike) -> ArrayLike:
         """Transform `X` by applying the fitted transformers on the columns.
 
         Parameters

--- a/skrub/_target_encoder.py
+++ b/skrub/_target_encoder.py
@@ -2,6 +2,7 @@ import collections
 from typing import Literal
 
 import numpy as np
+from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
@@ -110,13 +111,13 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
 
     n_features_in_: int
     _label_encoders_: list[LabelEncoder]
-    categories_: list[np.ndarray]
+    categories_: list[NDArray]
     n_: int
 
     def __init__(
         self,
         *,
-        categories: Literal["auto"] | list[list[str] | np.ndarray] = "auto",
+        categories: Literal["auto"] | list[list[str] | NDArray] = "auto",
         clf_type: Literal["regression", "binary-clf", "multiclass-clf"] = "binary-clf",
         dtype: type = np.float64,
         handle_unknown: Literal["error", "ignore"] = "error",
@@ -134,7 +135,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         """
         return {"X_types": ["categorical"]}
 
-    def fit(self, X, y) -> "TargetEncoder":
+    def fit(self, X: ArrayLike, y: ArrayLike) -> "TargetEncoder":
         """Fit the instance to `X`.
 
         Parameters
@@ -227,7 +228,7 @@ class TargetEncoder(BaseEstimator, TransformerMixin):
         self.k_ = {j: len(self.counter_[j]) for j in self.counter_}
         return self
 
-    def transform(self, X) -> np.ndarray:
+    def transform(self, X: ArrayLike) -> NDArray:
         """Transform `X` using the specified encoding scheme.
 
         Parameters

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -3,6 +3,7 @@ from collections.abc import Hashable
 from typing import Any
 
 import numpy as np
+from numpy.typing import NDArray
 from sklearn.utils import parse_version  # noqa
 from sklearn.utils import check_array
 
@@ -36,7 +37,7 @@ class LRUDict:
         return key in self.cache
 
 
-def check_input(X) -> np.ndarray:
+def check_input(X) -> NDArray:
     """
     Check input with sklearn standards.
     Also converts X to a numpy array if not already.

--- a/skrub/tests/utils.py
+++ b/skrub/tests/utils.py
@@ -1,14 +1,15 @@
 import random
 
 import numpy as np
+from numpy.typing import NDArray
 
 
 def generate_data(
-    n_samples,
-    as_list=False,
+    n_samples: int,
+    as_list: bool = False,
     random_state: int | float | str | bytes | bytearray | None = None,
     sample_length: int = 100,
-) -> np.ndarray:
+) -> NDArray:
     if random_state is not None:
         random.seed(random_state)
     MAX_LIMIT = 255  # extended ASCII Character set


### PR DESCRIPTION
Following #613, we can now use the modern type hints provided by numpy to document array-likes and n-D arrays!