### PR TITLE
MAINT Test against nightly dependencies

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    - cron: "30 2 * * *"
+      branches:
+        - "main"
 
 jobs:
   check_skip:
@@ -70,3 +74,36 @@ jobs:
       - uses: codecov/codecov-action@v3
         if: success()
         name: 'Upload coverage to CodeCov'
+
+  run_nightly:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ github.event_name == 'schedule' || contains(steps.get_head_commit_message.outputs.COMMIT_MSG, '[deps nightly]') }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - id: get_head_commit_message
+        name: get head commit message
+        run: echo "COMMIT_MSG=$(git show -s --format=%s)" >> "$GITHUB_OUTPUT"
+
+  nightly:
+    needs: run_nightly
+    if: ${{ needs.run_nightly.outputs.run == 'true' }}
+    runs-on: ubuntu-latest
+    name: test against nighlty dependencies
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+            python-version: "3.11"
+        name: 'Setup python'
+      - shell: bash {0}
+        run: ./build_tools/github/install.sh
+        name: 'Install skrub'
+        env:
+          INSTALL_NIGHTLY: "true"
+          DEPS_VERSION: "dev"
+      - shell: bash {0}
+        run: ./build_tools/github/test.sh
+        name: 'Run tests'

--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -1,3 +1,14 @@
 #!/bin/bash -e
 
+set -x
+
+if [[ "$INSTALL_NIGHTLY" == "true" ]]; then
+    echo "Installing development dependency wheels"
+    dev_anaconda_url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    pip install --pre --upgrade --timeout=60 --extra-index $dev_anaconda_url numpy pandas scikit-learn scipy
+
+    # pyarrow nightly builds are not hosted on anaconda.org
+    pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --prefer-binary --pre pyarrow
+fi
+
 pip install --progress-bar off --only-binary :all: --no-binary liac-arff --upgrade ".[$DEPS_VERSION]"


### PR DESCRIPTION
Setup a cron job to test against nightly dependencies. It can also be manually triggered with `[deps nightly]` in the commit message.