### PR TITLE
MAINT Use importlib + packaging instead of pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,4 @@ filterwarnings = [
     # Ignore warning from np.in1d since the future behavior is already the desired
     # behavior. TODO remove when numpy min version >= 1.25.
     'ignore:elementwise\ comparison\ failed:FutureWarning',
-
-    # TODO we should probably deal with those
-    'ignore:pkg_resources\ is\ deprecated\ as\ an\ API:DeprecationWarning',
-    'ignore:Deprecated\ call\ to\ `pkg_resources:DeprecationWarning',
 ]

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
     import warnings
 
     warnings.warn(
-        "pkg_resources is not available, dependencies versions will not be checked."
+        "packaging is not available, dependencies versions will not be checked."
     )
 
 from ._datetime_encoder import DatetimeEncoder

--- a/skrub/_check_dependencies.py
+++ b/skrub/_check_dependencies.py
@@ -1,30 +1,29 @@
-import pkg_resources
+from importlib.metadata import requires, version, PackageNotFoundError
+from packaging.requirements import Requirement
 
 
 def check_dependencies():
     package_name = "skrub"
-    env = pkg_resources.Environment()
-    package = env[package_name][0]
-    requirements = package.requires()
-    for req in requirements:
-        try:
-            installed_dep = next(
-                iter(
-                    (
-                        installed_dep
-                        for installed_dep in env[req.name]
-                        if installed_dep.project_name == req.name
-                    )
-                )
-            )
-        except StopIteration:
-            raise ImportError(
-                f"{package_name} {package.version} requires {req}, "
-                "which you don't have."
-            )
+    package_version = version(package_name)
+    requirements = requires(package_name)
 
-        if installed_dep not in req:
+    for req in requirements:
+        req = Requirement(req)
+
+        if req.marker is not None:
+            # skip extra requirements
+            continue
+
+        try:
+            installed_dep = version(req.name)
+            if not req.specifier.contains(installed_dep):
+                raise ImportError(
+                    f"{package_name} {package_version} requires {str(req)} "
+                    f"but you have {req.name}={installed_dep}, which is not compatible."
+                )
+
+        except PackageNotFoundError:
             raise ImportError(
-                f"{package_name} {package.version} requires {req} "
-                f"but you have {installed_dep}, which is not compatible."
+                f"{package_name} {package_version} requires {str(req)}, "
+                "which you don't have."
             )


### PR DESCRIPTION
Fixes https://github.com/skrub-data/skrub/issues/550

usage of `pkg_resources` is deprecated. There's still no way to use only `importlib` to do the same thing, at least without having to manually parse the requirements. This PR uses `packaging` instead that provides tools to parse the requirements.

Like `pkg_resources`, `packaging` is not in the std lib, but is very likely to be installed since it comes with `pip`. And at least this one is not deprecated :)