### PR TITLE
TST: parallelism tests

### DIFF
--- a/skrub/tests/test_deduplicate.py
+++ b/skrub/tests/test_deduplicate.py
@@ -121,11 +121,11 @@ def test_parallelism() -> None:
     """Tests that parallelism works with different backends and n_jobs."""
 
     # This n_jobs list is sorted from the expected slowest to the fastest
-    X, y = default_deduplicate()
+    X, y = default_deduplicate(n=200)
 
     last_execution_time = np.inf
 
-    for n_jobs in [1, 4]:
+    for n_jobs in [1, 2]:
         times = []
         for _ in range(2):
             start = time.perf_counter()


### PR DESCRIPTION
Addresses two problems:
- The test was way too long (2mn)
- The test was brittle given that on CI workers there are only 2 possible CPUs