### PR TITLE
CI Fix check changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog needed') || contains(github.event.pull_request.labels.*.name, 'CI') == 0 }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog needed') == 0 || contains(github.event.pull_request.labels.*.name, 'CI') == 0 }}
     steps:
       - name: Get PR number and milestone
         run: |


### PR DESCRIPTION
Follow-up of https://github.com/skrub-data/skrub/pull/612

The check changelog workflow is broken. Even when the label `no changelog needed` is set, the workflow still runs. See https://github.com/skrub-data/skrub/pull/649 for example.