### PR TITLE
Adding a checksum when downloading figshare files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Minor changes
   by converting them to string before type inference.
   :pr:`623`by :user:`Leo Grinsztajn <LeoGrin>`
 
+* Moved the default storage location of data to the user's home folder.
+  :pr:`652` by :user:`Felix Lefebvre <flefebv>`
+
 Before skrub: dirty_cat
 ========================
 

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -9,6 +9,7 @@ Date: June 2023
 """
 
 import math
+from pathlib import Path
 from utils import default_parser, find_result, monitor
 from utils.join import evaluate, fetch_big_data
 from argparse import ArgumentParser
@@ -526,8 +527,12 @@ def benchmark(
     dataset_name: str,
     analyzer: Literal["char_wb", "char", "word"],
     ngram_range: tuple,
+    data_home: Path = None,
+    data_directory: str = "benchmarks_data",
 ):
-    left_table, right_table, gt = fetch_big_data(dataset_name)
+    left_table, right_table, gt = fetch_big_data(
+        dataset_name=dataset_name, data_home=data_home, data_directory=data_directory
+    )
 
     start_time = perf_counter()
     joined_fj = fuzzy_join(

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -527,7 +527,7 @@ def benchmark(
     dataset_name: str,
     analyzer: Literal["char_wb", "char", "word"],
     ngram_range: tuple,
-    data_home: Path = None,
+    data_home: Path | str = None,
     data_directory: str = "benchmarks_data",
 ):
     left_table, right_table, gt = fetch_big_data(

--- a/benchmarks/utils/join.py
+++ b/benchmarks/utils/join.py
@@ -4,7 +4,7 @@ from skrub.datasets._utils import get_data_dir
 
 
 def get_local_data(
-    dataset_name: str, data_home: Path = None, data_directory: str = None
+    dataset_name: str, data_home: Path | str = None, data_directory: str = None
 ):
     """Get the path to the local datasets."""
     data_directory = get_data_dir(data_directory, data_home)
@@ -24,7 +24,7 @@ def get_local_data(
 def fetch_data(
     dataset_name: str,
     save: bool = True,
-    data_home: Path = None,
+    data_home: Path | str = None,
     data_directory: str = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Fetch datasets from https://github.com/Yeye-He/Auto-Join/tree/master/autojoin-Benchmark
@@ -37,7 +37,7 @@ def fetch_data(
     save: bool, default=true
         Wheter to save the datasets locally.
 
-    data_home: Path, default=None
+    data_home: Path or str, optional
         The path to the root data directory.
         By default, will point to the skrub data directory.
 
@@ -83,7 +83,7 @@ def fetch_big_data(
     dataset_name: str,
     data_type: str = "Dirty",
     save: bool = True,
-    data_home: Path = None,
+    data_home: Path | str = None,
     data_directory: str = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Fetch datasets from https://github.com/anhaidgroup/deepmatcher/blob/master/Datasets.md
@@ -100,7 +100,7 @@ def fetch_big_data(
     save: bool, default=true
         Wheter to save the datasets locally.
 
-    data_home: Path, default=None
+    data_home: Path or str, optional
         The path to the root data directory.
         By default, will point to the skrub data directory.
 

--- a/benchmarks/utils/join.py
+++ b/benchmarks/utils/join.py
@@ -1,11 +1,13 @@
 import pandas as pd
+from pathlib import Path
 from skrub.datasets._utils import get_data_dir
 
 
-def get_local_data(dataset_name: str, data_directory: str = None):
+def get_local_data(
+    dataset_name: str, data_home: Path = None, data_directory: str = None
+):
     """Get the path to the local datasets."""
-    if data_directory is None:
-        data_directory = get_data_dir("benchmarks_data")
+    data_directory = get_data_dir(data_directory, data_home)
     left_path = str(data_directory) + f"/left_{dataset_name}.parquet"
     right_path = str(data_directory) + f"/right_{dataset_name}.parquet"
     gt_path = str(data_directory) + f"/gt_{dataset_name}.parquet"
@@ -20,7 +22,10 @@ def get_local_data(dataset_name: str, data_directory: str = None):
 
 
 def fetch_data(
-    dataset_name: str, save: bool = True
+    dataset_name: str,
+    save: bool = True,
+    data_home: Path = None,
+    data_directory: str = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Fetch datasets from https://github.com/Yeye-He/Auto-Join/tree/master/autojoin-Benchmark
 
@@ -31,6 +36,13 @@ def fetch_data(
 
     save: bool, default=true
         Wheter to save the datasets locally.
+
+    data_home: Path, default=None
+        The path to the root data directory.
+        By default, will point to the skrub data directory.
+
+    data_directory: str, default=None
+        The name of the subdirectory in which data is stored.
 
     Returns
     -------
@@ -43,7 +55,9 @@ def fetch_data(
     gt: pd.DataFrame
         Ground truth dataset.
     """
-    left_path, right_path, gt_path, file_paths = get_local_data(dataset_name)
+    left_path, right_path, gt_path, file_paths = get_local_data(
+        dataset_name, data_home, data_directory
+    )
     if len(file_paths) == 0:
         repository = "Yeye-He/Auto-Join"
         dataset_name = dataset_name.replace(" ", "%20")
@@ -69,6 +83,8 @@ def fetch_big_data(
     dataset_name: str,
     data_type: str = "Dirty",
     save: bool = True,
+    data_home: Path = None,
+    data_directory: str = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     """Fetch datasets from https://github.com/anhaidgroup/deepmatcher/blob/master/Datasets.md
 
@@ -84,6 +100,13 @@ def fetch_big_data(
     save: bool, default=true
         Wheter to save the datasets locally.
 
+    data_home: Path, default=None
+        The path to the root data directory.
+        By default, will point to the skrub data directory.
+
+    data_directory: str, default=None
+        The name of the subdirectory in which data is stored.
+
     Returns
     -------
     left: pd.DataFrame
@@ -96,7 +119,9 @@ def fetch_big_data(
         Ground truth dataset.
     """
     link = "https://pages.cs.wisc.edu/~anhai/data1/deepmatcher_data/"
-    left_path, right_path, gt_path, file_paths = get_local_data(dataset_name)
+    left_path, right_path, gt_path, file_paths = get_local_data(
+        dataset_name, data_home, data_directory
+    )
     if len(file_paths) == 0:
         test_idx = pd.read_csv(f"{link}/{data_type}/{dataset_name}/exp_data/test.csv")
         train_idx = pd.read_csv(f"{link}/{data_type}/{dataset_name}/exp_data/train.csv")

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -140,7 +140,7 @@ class DatasetInfoOnly:
 
 def _fetch_openml_dataset(
     dataset_id: int,
-    data_home: Path | None = None,
+    data_home: Path | str | None = None,
 ) -> dict[str, Any]:
     """Gets a dataset from OpenML (https://www.openml.org).
 
@@ -148,7 +148,7 @@ def _fetch_openml_dataset(
     ----------
     dataset_id : int
         The ID of the dataset to fetch.
-    data_home : Path, optional
+    data_home : Path or str, optional
         The path to the root data directory.
         By default, the skrub data directory.
 
@@ -223,7 +223,7 @@ def _fetch_openml_dataset(
 
 def _fetch_world_bank_data(
     indicator_id: str,
-    data_home: Path | None = None,
+    data_home: Path | str | None = None,
 ) -> dict[str, Any]:
     """Gets a dataset from World Bank open data platform (https://data.worldbank.org/).
 
@@ -231,7 +231,7 @@ def _fetch_world_bank_data(
     ----------
     indicator_id : str
         The ID of the indicator's dataset to fetch.
-    data_home : Path, optional
+    data_home : Path or str, optional
         The path to the root data directory.
         By default, the skrub data directory.
 
@@ -305,7 +305,7 @@ def _fetch_world_bank_data(
 
 def _fetch_figshare(
     figshare_id: str,
-    data_home: Path | None = None,
+    data_home: Path | str | None = None,
 ) -> dict[str, Any]:
     """Fetch a dataset from figshare using the download ID number.
 
@@ -313,7 +313,7 @@ def _fetch_figshare(
     ----------
     figshare_id : str
         The ID of the dataset to fetch.
-    data_home : Path, optional
+    data_home : Path or str, optional
         The path to the root data directory.
         By default, the skrub data directory.
 
@@ -578,9 +578,6 @@ def _fetch_dataset_as_dataclass(
     :obj:`DatasetInfoOnly`
         If `load_dataframe=False`
     """
-    if isinstance(data_home, str):
-        data_home = Path(data_home)
-
     if source == "openml":
         info = _fetch_openml_dataset(dataset_id, data_home)
     elif source == "world_bank":

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -27,6 +27,7 @@ import pandas as pd
 from pyarrow.parquet import ParquetFile
 from sklearn import __version__ as sklearn_version
 from sklearn.datasets import fetch_openml
+from sklearn.datasets._base import _sha256
 
 from skrub._utils import parse_version
 from skrub.datasets._utils import get_data_dir
@@ -60,6 +61,20 @@ MEDICAL_CHARGE_ID: int = 42720
 EMPLOYEE_SALARIES_ID: int = 42125
 TRAFFIC_VIOLATIONS_ID: int = 42132
 DRUG_DIRECTORY_ID: int = 43044
+
+# A dictionnary storing the sha256 hashes of the figshare files
+figshare_id_to_hash = {
+    39142985: "47d73381ef72b050002a8642194c6718a4954ec9e6c556f4c4ddc6ed84ceec92",
+    39149066: "e479cf9741a90c40401697e7fa54409e3b9cfa09f27502877382e64e86fbfcd0",
+    39149069: "7b0dcdb15d3aeecba6022c929665ee064f6fb4b8b94186a6e89b6fbc781b3775",
+    39149072: "4f58f15168bb8a6cc8b152bd48995bc7d1a4d4d89a9e22d87aa51ccf30118122",
+    39149075: "7037603362af1d4bf73551d50644c0957cb91d2b4892e75413f57f415962029a",
+    39254360: "531130c714ba6ee9902108d4010f42388aa9c0b3167d124cd57e2c632df3e05a",
+    39266300: "37b23b2c37a1f7ff906bc7951cbed4be15d8417dad0762092282f7b491cf8c21",
+    39266678: "4e041322985e078de8b08acfd44b93a5ce347c1e501e9d869651e753de747ba1",
+    40019230: "4d43fed75dba1e59a5587bf31c1addf2647a1f15ebea66e93177ccda41e18f2f",
+    40019788: "67ae86496c8a08c6cc352f573160a094f605e7e0da022eb91c603abb7edf3747",
+}
 
 
 @dataclass(unsafe_hash=True)
@@ -370,6 +385,20 @@ def _fetch_figshare(
         )
         try:
             filehandle, _ = urllib.request.urlretrieve(url)
+
+            # checksum the file
+            checksum = _sha256(filehandle)
+            if figshare_id in figshare_id_to_hash:
+                expected_checksum = figshare_id_to_hash[figshare_id]
+                if checksum != expected_checksum:
+                    raise OSError(
+                        "{} has an SHA256 checksum ({}) "
+                        "differing from expected ({}), "
+                        "file may be corrupted.".format(
+                            filehandle, checksum, expected_checksum
+                        )
+                    )
+
             df = ParquetFile(filehandle)
             record = df.iter_batches(
                 batch_size=1_000_000,

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -1,8 +1,7 @@
-import os
 from pathlib import Path
 
 
-def get_data_home(data_home=None) -> str:
+def get_data_home(data_home: Path | None = None) -> Path:
     """Returns the path of the skrub data directory.
 
     This folder is used by some large dataset loaders to avoid downloading the
@@ -18,7 +17,7 @@ def get_data_home(data_home=None) -> str:
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : Path, default=None
         The path to skrub data directory. If `None`, the default path
         is `~/skrub_data`.
 
@@ -29,11 +28,11 @@ def get_data_home(data_home=None) -> str:
     """
     if data_home is None:
         data_home = Path("~") / "skrub_data"
-    data_home.make_dir(exist_ok=True)
+    data_home.mkdir(parents=True, exist_ok=True)
     return data_home
 
 
-def get_data_dir(name: str | None = None, data_home: str | None = None) -> Path:
+def get_data_dir(name: str | None = None, data_home: Path | None = None) -> Path:
     """
     Returns the directory in which skrub looks for data.
 
@@ -42,14 +41,14 @@ def get_data_dir(name: str | None = None, data_home: str | None = None) -> Path:
 
     Parameters
     ----------
-    data_home : str, default=None
+    data_home : Path, default=None
         The path to skrub data directory. If `None`, the default path
         is `~/skrub_data`.
     name: str, optional
         Subdirectory name. If omitted, the root data directory is returned.
     """
     data_home = get_data_home(data_home)
-    data_dir = Path(data_home).resolve()
+    data_dir = data_home.resolve()
     if name is not None:
         data_dir = data_dir / name
     return data_dir

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -17,8 +17,8 @@ def get_data_home(data_home: Path | str | None = None) -> Path:
 
     Parameters
     ----------
-    data_home : Path, default=None
-        The path to skrub data directory. If `None`, the default path
+    data_home: pathlib.Path or string, optional
+        The path to the skrub data directory. If `None`, the default path
         is `~/skrub_data`.
 
     Returns

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -23,7 +23,7 @@ def get_data_home(data_home: Path | str | None = None) -> Path:
 
     Returns
     -------
-    data_home: str or path-like, default=None
+    data_home: Path
         The validated path to the skrub data directory.
     """
     if data_home is None:

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -24,7 +24,7 @@ def get_data_home(data_home: Path | None = None) -> Path:
     Returns
     -------
     data_home: str or path-like, default=None
-        The path to skrub data directory.
+        The validated path to the skrub data directory.
     """
     if data_home is None:
         data_home = Path("~") / "skrub_data"

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -43,11 +43,11 @@ def get_data_dir(name: str | None = None, data_home: Path | str | None = None) -
 
     Parameters
     ----------
-    data_home : Path, default=None
-        The path to skrub data directory. If `None`, the default path
-        is `~/skrub_data`.
     name: str, optional
         Subdirectory name. If omitted, the root data directory is returned.
+    data_home : pathlib.Path or str, optional
+        The path to skrub data directory. If `None`, the default path
+        is `~/skrub_data`.
     """
     data_home = get_data_home(data_home)
     data_dir = data_home.resolve()

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -34,7 +34,7 @@ def get_data_home(data_home: Path | str | None = None) -> Path:
     return data_home
 
 
-def get_data_dir(name: str | None = None, data_home: Path | None = None) -> Path:
+def get_data_dir(name: str | None = None, data_home: Path | str | None = None) -> Path:
     """
     Returns the directory in which skrub looks for data.
 

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -28,6 +28,8 @@ def get_data_home(data_home: Path | None = None) -> Path:
     """
     if data_home is None:
         data_home = Path("~") / "skrub_data"
+    elif isinstance(data_home, str):
+        data_home = Path(data_home)
     data_home.mkdir(parents=True, exist_ok=True)
     return data_home
 

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def get_data_home(data_home: Path | None = None) -> Path:
+def get_data_home(data_home: Path | str | None = None) -> Path:
     """Returns the path of the skrub data directory.
 
     This folder is used by some large dataset loaders to avoid downloading the

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from pathlib import Path
 
 
@@ -33,19 +32,6 @@ def get_data_home(data_home=None) -> str:
     data_home = os.path.expanduser(data_home)
     os.makedirs(data_home, exist_ok=True)
     return data_home
-
-
-def clear_data_home(data_home=None):
-    """Delete all the content of the data home cache.
-
-    Parameters
-    ----------
-    data_home : str or path-like, default=None
-        The path to skrub data directory. If `None`, the default path
-        is `~/skrub_data`.
-    """
-    data_home = get_data_home(data_home)
-    shutil.rmtree(data_home)
 
 
 def get_data_dir(name: str | None = None, data_home: str | None = None) -> Path:

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -28,9 +28,8 @@ def get_data_home(data_home=None) -> str:
         The path to skrub data directory.
     """
     if data_home is None:
-        data_home = os.path.join("~", "skrub_data")
-    data_home = os.path.expanduser(data_home)
-    os.makedirs(data_home, exist_ok=True)
+        data_home = Path("~") / "skrub_data"
+    data_home.make_dir(exist_ok=True)
     return data_home
 
 

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -1,8 +1,54 @@
 import os
+import shutil
 from pathlib import Path
 
 
-def get_data_dir(name: str | None = None) -> Path:
+def get_data_home(data_home=None) -> str:
+    """Returns the path of the skrub data directory.
+
+    This folder is used by some large dataset loaders to avoid downloading the
+    data several times.
+
+    By default the data directory is set to a folder named 'skrub_data' in the
+    user home folder.
+
+    Alternatively, it can be set programmatically by giving an explicit folder
+    path. The '~' symbol is expanded to the user home folder.
+
+    If the folder does not already exist, it is automatically created.
+
+    Parameters
+    ----------
+    data_home : str, default=None
+        The path to skrub data directory. If `None`, the default path
+        is `~/skrub_data`.
+
+    Returns
+    -------
+    data_home: str or path-like, default=None
+        The path to skrub data directory.
+    """
+    if data_home is None:
+        data_home = os.path.join("~", "skrub_data")
+    data_home = os.path.expanduser(data_home)
+    os.makedirs(data_home, exist_ok=True)
+    return data_home
+
+
+def clear_data_home(data_home=None):
+    """Delete all the content of the data home cache.
+
+    Parameters
+    ----------
+    data_home : str or path-like, default=None
+        The path to skrub data directory. If `None`, the default path
+        is `~/skrub_data`.
+    """
+    data_home = get_data_home(data_home)
+    shutil.rmtree(data_home)
+
+
+def get_data_dir(name: str | None = None, data_home: str | None = None) -> Path:
     """
     Returns the directory in which skrub looks for data.
 
@@ -11,13 +57,14 @@ def get_data_dir(name: str | None = None) -> Path:
 
     Parameters
     ----------
+    data_home : str, default=None
+        The path to skrub data directory. If `None`, the default path
+        is `~/skrub_data`.
     name: str, optional
         Subdirectory name. If omitted, the root data directory is returned.
     """
-    # Note: we stick to os.path instead of pathlib.Path because
-    # it's easier to test, and the functionality is the same.
-    module_path = Path(os.path.dirname(__file__)).resolve()
-    data_dir = module_path / "data"
+    data_home = get_data_home(data_home)
+    data_dir = Path(data_home).resolve()
     if name is not None:
         data_dir = data_dir / name
     return data_dir

--- a/skrub/datasets/tests/test_fetching.py
+++ b/skrub/datasets/tests/test_fetching.py
@@ -32,7 +32,7 @@ def test_openml_fetching(fetch_openml_mock: mock.Mock):
     with TemporaryDirectory() as temp_dir:
         # Download the dataset without loading it in memory.
         dataset = _fetching.fetch_midwest_survey(
-            directory=temp_dir,
+            data_home=temp_dir,
             load_dataframe=False,
         )
         fetch_openml_mock.assert_called_once()
@@ -51,7 +51,7 @@ def test_openml_fetching(fetch_openml_mock: mock.Mock):
         assert str(_fetching.MIDWEST_SURVEY_ID) in dataset.source
         # Now, load it into memory, and expect `fetch_openml`
         # to not be called because the dataset is already on disk.
-        dataset = _fetching.fetch_midwest_survey(directory=temp_dir)
+        dataset = _fetching.fetch_midwest_survey(data_home=temp_dir)
         fetch_openml_mock.assert_not_called()
         fetch_openml_mock.reset_mock()
         assert dataset.X.shape == (2494, 28)
@@ -95,7 +95,7 @@ def test_openml_datasets_calls(fetch_openml_mock: mock.Mock):
             (_fetching.fetch_drug_directory, _fetching.DRUG_DIRECTORY_ID),
         ]:
             try:
-                fetching_function(directory=temp_dir)
+                fetching_function(data_home=temp_dir)
             except FileNotFoundError:
                 pass
             fetch_openml_mock.assert_called_once()
@@ -120,17 +120,17 @@ def test_fetch_world_bank_indicator():
             # First, we want to purposefully test FileNotFoundError exceptions.
             with pytest.raises(FileNotFoundError):
                 assert _fetching.fetch_world_bank_indicator(
-                    indicator_id=0, directory=temp_dir
+                    indicator_id=0, data_home=temp_dir
                 )
                 assert _fetching.fetch_world_bank_indicator(
                     indicator_id=2**32,
-                    directory=temp_dir,
+                    data_home=temp_dir,
                 )
 
             # Valid call
             returned_info = _fetching.fetch_world_bank_indicator(
                 indicator_id=test_dataset["id"],
-                directory=temp_dir,
+                data_home=temp_dir,
             )
 
         except (ConnectionError, URLError):
@@ -156,7 +156,7 @@ def test_fetch_world_bank_indicator():
             # Same valid call as above
             disk_loaded_info = _fetching.fetch_world_bank_indicator(
                 indicator_id=test_dataset["id"],
-                directory=temp_dir,
+                data_home=temp_dir,
             )
             mock_urlretrieve.assert_not_called()
             assert disk_loaded_info == returned_info

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -6,7 +6,8 @@ from skrub.datasets._utils import get_data_dir, get_data_home
 
 
 def test_get_data_dir():
-    """Check the behaviour of `get_data_dir` when passing the path to
+    """
+    Check the behaviour of `get_data_dir` when passing the path to
     an already existing folder.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -34,6 +35,25 @@ def test_get_data_home_str():
         assert not data_home.exists()
         assert not tmpdirpath.exists()
         data_home = get_data_home(data_home=tmpdirpath)
+        assert data_home.exists()
+
+
+def test_get_data_home_path():
+    """
+    Test function for ``get_data_home()`` when `data_home` is a pathlib.Path.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdirpath = Path(tmpdirname)
+        # get_data_home will point to a pre-existing folder
+        data_home = get_data_home(data_home=tmpdirname)
+        assert data_home == tmpdirpath
+        assert data_home.exists()
+
+        # if the folder is missing it will be created
+        shutil.rmtree(data_home)
+        assert not data_home.exists()
+        assert not tmpdirpath.exists()
+        data_home = get_data_home(data_home=tmpdirname)
         assert data_home.exists()
 
 

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -6,8 +6,8 @@ from skrub.datasets._utils import get_data_dir, get_data_home
 
 
 def test_get_data_dir():
-    """
-    Tests function ``get_data_dir()``.
+    """Check the behaviour of `get_data_dir` when passing the path to
+    an already existing folder.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmpdirpath = Path(tmpdirname)

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -37,7 +37,7 @@ def test_get_data_home_str():
         assert data_home.exists()
 
 
-def test_get_data_home_None():
+def test_get_data_home_default():
     """
     Test function for ``get_data_home()`` with `data_home` set to `None`.
     """

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -11,14 +10,10 @@ def test_get_data_dir():
     Tests function ``get_data_dir()``.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
-        expected_return_value_default = Path(tmpdirname)
-        assert get_data_dir(data_home=tmpdirname) == expected_return_value_default
+        tmpdirpath = Path(tmpdirname)
+        assert get_data_dir(data_home=tmpdirpath) == tmpdirpath
 
-        expected_return_value_custom = expected_return_value_default / "tests"
-        assert (
-            get_data_dir(name="tests", data_home=tmpdirname)
-            == expected_return_value_custom
-        )
+        assert get_data_dir(name="tests", data_home=tmpdirpath) == tmpdirpath / "tests"
 
 
 def test_get_data_home_str():
@@ -26,18 +21,20 @@ def test_get_data_home_str():
     Test function for ``get_data_home()`` when `data_home` is a string.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # get_data_home will point to a pre-existing folder
-        assert os.path.exists(tmpdirname)
-        data_home = get_data_home(data_home=tmpdirname)
-        assert data_home == tmpdirname
-        assert os.path.exists(data_home)
+        tmpdirpath = Path(tmpdirname)
 
-        # if the folder is missing it will be created again
+        # get_data_home will point to a pre-existing folder
+        assert tmpdirpath.exists()
+        data_home = get_data_home(data_home=tmpdirpath)
+        assert data_home == tmpdirpath
+        assert data_home.exists()
+
+        # if the folder is missing it will be created
         shutil.rmtree(data_home)
-        assert not os.path.exists(data_home)
-        assert not os.path.exists(tmpdirname)
-        data_home = get_data_home(data_home=tmpdirname)
-        assert os.path.exists(data_home)
+        assert not data_home.exists()
+        assert not tmpdirpath.exists()
+        data_home = get_data_home(data_home=tmpdirpath)
+        assert data_home.exists()
 
 
 def test_get_data_home_None():
@@ -45,14 +42,13 @@ def test_get_data_home_None():
     Test function for ``get_data_home()`` with `data_home` set to `None`.
     """
     # get path of the folder 'skrub_data' in the user home folder
-    user_path = os.path.join("~", "skrub_data")
-    user_path = os.path.expanduser(user_path)
+    user_path = Path("~") / "skrub_data"
 
     # if the folder does not exist, create it, and clear it
-    if not os.path.exists(user_path):
+    if not user_path.exists():
         data_home = get_data_home(data_home=None)
         assert data_home == user_path
-        assert os.path.exists(data_home)
+        assert data_home.exists()
 
         shutil.rmtree(data_home)
-        assert not os.path.exists(data_home)
+        assert not data_home.exists()

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_get_data_home_str():
 
 def test_get_data_home_default():
     """Test function for ``get_data_home()`` with default `data_home`."""
-    # get path of the folder 'skrub_data' in the user home folder
+    # Get the default location where we expect the data to be stored.
     user_path = Path("~") / "skrub_data"
 
     # if the folder does not exist, create it, and clear it

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -59,14 +59,24 @@ def test_get_data_home_path():
 
 def test_get_data_home_default():
     """Test function for ``get_data_home()`` with default `data_home`."""
-    # Get the default location where we expect the data to be stored.
+    # We should take care of not deleting the folder if our user
+    # already cached some data
     user_path = Path("~") / "skrub_data"
+    is_already_existing = user_path.exists()
 
-    # if the folder does not exist, create it, and clear it
-    if not user_path.exists():
+    data_home = get_data_home(data_home=None)
+    assert data_home == user_path
+    assert data_home.exists()
+
+    if not is_already_existing:
+        # In case the folder was not existing, the previous
+        # call should have created the folder. Check that we get
+        # the proper path to the folder if it already exists.
         data_home = get_data_home(data_home=None)
         assert data_home == user_path
         assert data_home.exists()
 
-        shutil.rmtree(data_home)
+    if not is_already_existing:
+        # Clear the folder if it was not already existing.
+        shutil.rmtree(user_path)
         assert not data_home.exists()

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -38,9 +38,7 @@ def test_get_data_home_str():
 
 
 def test_get_data_home_default():
-    """
-    Test function for ``get_data_home()`` with `data_home` set to `None`.
-    """
+    """Test function for ``get_data_home()`` with default `data_home`."""
     # get path of the folder 'skrub_data' in the user home folder
     user_path = Path("~") / "skrub_data"
 

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -1,18 +1,59 @@
+import os
+import tempfile
 from pathlib import Path
-from unittest import mock
+
+from skrub.datasets._utils import clear_data_home, get_data_dir, get_data_home
 
 
-@mock.patch("os.path.dirname")
-def test_get_data_dir(mock_os_path_dirname):
+def test_get_data_dir():
     """
     Tests function ``get_data_dir()``.
     """
-    from skrub.datasets._utils import get_data_dir
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        expected_return_value_default = Path(tmpdirname)
+        assert get_data_dir(data_home=tmpdirname) == expected_return_value_default
 
-    expected_return_value_default = Path("/user/directory/data").absolute()
+        expected_return_value_custom = expected_return_value_default / "tests"
+        assert (
+            get_data_dir(name="tests", data_home=tmpdirname)
+            == expected_return_value_custom
+        )
 
-    mock_os_path_dirname.return_value = expected_return_value_default.parent
-    assert get_data_dir() == expected_return_value_default
 
-    expected_return_value_custom = expected_return_value_default / "tests"
-    assert get_data_dir("tests") == expected_return_value_custom
+def test_get_data_home_str():
+    """
+    Test function for ``get_data_home()`` when data_home is a string.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        # get_data_home will point to a pre-existing folder
+        assert os.path.exists(tmpdirname)
+        data_home = get_data_home(data_home=tmpdirname)
+        assert data_home == tmpdirname
+        assert os.path.exists(data_home)
+
+        # clear_data_home will delete both the content and the folder itself
+        clear_data_home(data_home=data_home)
+        assert not os.path.exists(data_home)
+
+        # if the folder is missing it will be created again
+        assert not os.path.exists(tmpdirname)
+        data_home = get_data_home(data_home=tmpdirname)
+        assert os.path.exists(data_home)
+
+
+def test_get_data_home_None():
+    """
+    Test function for ``get_data_home()`` with data_home=None.
+    """
+    # get path of the folder 'skrub_data' in the user home folder
+    user_path = os.path.join("~", "skrub_data")
+    user_path = os.path.expanduser(user_path)
+
+    # if the folder does not exist, create it, and clear it
+    if not os.path.exists(user_path):
+        data_home = get_data_home(data_home=None)
+        assert data_home == user_path
+        assert os.path.exists(data_home)
+
+        clear_data_home()
+        assert not os.path.exists(data_home)

--- a/skrub/datasets/tests/test_utils.py
+++ b/skrub/datasets/tests/test_utils.py
@@ -1,8 +1,9 @@
 import os
+import shutil
 import tempfile
 from pathlib import Path
 
-from skrub.datasets._utils import clear_data_home, get_data_dir, get_data_home
+from skrub.datasets._utils import get_data_dir, get_data_home
 
 
 def test_get_data_dir():
@@ -22,7 +23,7 @@ def test_get_data_dir():
 
 def test_get_data_home_str():
     """
-    Test function for ``get_data_home()`` when data_home is a string.
+    Test function for ``get_data_home()`` when `data_home` is a string.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         # get_data_home will point to a pre-existing folder
@@ -31,11 +32,9 @@ def test_get_data_home_str():
         assert data_home == tmpdirname
         assert os.path.exists(data_home)
 
-        # clear_data_home will delete both the content and the folder itself
-        clear_data_home(data_home=data_home)
-        assert not os.path.exists(data_home)
-
         # if the folder is missing it will be created again
+        shutil.rmtree(data_home)
+        assert not os.path.exists(data_home)
         assert not os.path.exists(tmpdirname)
         data_home = get_data_home(data_home=tmpdirname)
         assert os.path.exists(data_home)
@@ -43,7 +42,7 @@ def test_get_data_home_str():
 
 def test_get_data_home_None():
     """
-    Test function for ``get_data_home()`` with data_home=None.
+    Test function for ``get_data_home()`` with `data_home` set to `None`.
     """
     # get path of the folder 'skrub_data' in the user home folder
     user_path = os.path.join("~", "skrub_data")
@@ -55,5 +54,5 @@ def test_get_data_home_None():
         assert data_home == user_path
         assert os.path.exists(data_home)
 
-        clear_data_home()
+        shutil.rmtree(data_home)
         assert not os.path.exists(data_home)


### PR DESCRIPTION
Closes #642

Modifies the `_fetch_figshare` function to checksum the files when downloading.

Remark: For openml, the checksum is already done within the sklearn function `fetch_openml`.

Warning: does not deal with world_bank, because world_bank does not provide checksum, and we do not have a fixed list of datasets that the user can download from world_bank.