### PR TITLE
[WIP] Vendor TargetEncoder from scikit-learn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,11 @@ Major changes
 
 * Removed `requests` from the requirements. :pr:`613` by :user:`Lilian Boulard <LilianBoulard>`
 
+* skrub now vendors the scikit-learn implementation of the :class:`TargetEncoder` until
+  the minimum required version of scikit-learn is 1.4, after what it will be removed and
+  should be imported from scikit-learn instead.
+  :pr:`??` by :user:`Jérémie du Boisberranger <jeremiedbb>`.
+
 Minor changes
 -------------
 

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -22,7 +22,6 @@ from ._gap_encoder import GapEncoder
 from ._minhash_encoder import MinHashEncoder
 from ._similarity_encoder import SimilarityEncoder
 from ._table_vectorizer import SuperVectorizer, TableVectorizer
-from ._target_encoder import TargetEncoder
 
 with open(_Path(__file__).parent / "VERSION.txt") as _fh:
     __version__ = _fh.read().strip()
@@ -37,7 +36,28 @@ __all__ = [
     "SimilarityEncoder",
     "SuperVectorizer",
     "TableVectorizer",
-    "TargetEncoder",
     "deduplicate",
     "compute_ngram_distance",
 ]
+
+
+def __getattr__(name):
+    if name == "TargetEncoder":
+        import warnings
+        import sklearn
+        from ._utils import parse_version
+
+        if parse_version(sklearn.__version__) >= parse_version("1.4.0"):
+            warnings.warn(
+                "Importing TargetEncoder from skrub is deprecated and will be "
+                "removed in a future version. It should be imported from sklearn."
+            )
+            from sklearn.preprocessing import TargetEncoder
+        else:
+            from ._target_encoder import TargetEncoder
+        return TargetEncoder
+    try:
+        return globals()[name]
+    except KeyError:
+        # This is turned into the appropriate ImportError
+        raise AttributeError

--- a/skrub/_target_encoder.py
+++ b/skrub/_target_encoder.py
@@ -1,322 +1,402 @@
-import collections
-from typing import Literal
+# Vendored implementation of the TargetEncoder from scikit-learn.
+# TODO remove it when sklearn min version >= 1.4.0.
 
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
-from sklearn.base import BaseEstimator, TransformerMixin
+
+from sklearn.base import OneToOneFeatureMixin
+from sklearn.utils.multiclass import type_of_target
+from sklearn.utils.validation import _check_y, check_consistent_length
+from sklearn.preprocessing._encoders import _BaseEncoder
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils import check_array
-from sklearn.utils.fixes import _object_dtype_isnan
-from sklearn.utils.validation import check_is_fitted
-
-from skrub._utils import check_input
+from sklearn.model_selection import KFold, StratifiedKFold
 
 
-def lambda_(x, n):
-    return x / (x + n)
+def _fit_encoding_fast(X_int, y, n_categories, smooth, y_mean):
+    """Fit a target encoding on X_int and y.
+
+    This implementation uses Eq 7 from [1] to compute the encoding.
+    As stated in the paper, Eq 7 is the same as Eq 3.
+
+    [1]: Micci-Barreca, Daniele. "A preprocessing scheme for high-cardinality
+         categorical attributes in classification and prediction problems"
+    """
+    n_features = X_int.shape[1]
+    smooth_sum = smooth * y_mean
+
+    encodings = [
+        np.full(n_categories[feat_idx], fill_value=y_mean)
+        for feat_idx in range(n_features)
+    ]
+
+    for feat_idx in range(n_features):
+        n_cats = n_categories[feat_idx]
+        col = X_int[:, feat_idx]
+        col_known = col[col != -1]
+
+        sums = np.bincount(col_known, weights=y, minlength=n_cats) + smooth_sum
+        counts = np.bincount(col_known, minlength=n_cats) + smooth
+
+        np.divide(sums, counts, out=encodings[feat_idx], where=counts != 0)
+
+    return encodings
 
 
-class TargetEncoder(BaseEstimator, TransformerMixin):
-    """Encode categorical features as a numeric array given a target vector.
+def _fit_encoding_fast_auto_smooth(X_int, y, n_categories, y_mean, y_variance):
+    """Fit a target encoding on X_int and y with auto smoothing.
 
-    Each category is encoded given the effect that it has in the
-    target variable :term:`y`. The method considers that categorical
-    variables can present rare categories. It represents each category by the
-    probability of :term:`y` conditional on this category.
-    In addition, it takes an empirical Bayes approach to shrink the estimate.
+    This implementation uses Eq 5 and 6 from [1].
+
+    [1]: Micci-Barreca, Daniele. "A preprocessing scheme for high-cardinality
+         categorical attributes in classification and prediction problems"
+    """
+    n_features = X_int.shape[1]
+
+    encodings = [np.empty(n_categories[feat_idx]) for feat_idx in range(n_features)]
+
+    for feat_idx in range(n_features):
+        n_cats = n_categories[feat_idx]
+
+        col = X_int[:, feat_idx]
+        col_known = col[col != -1]
+
+        counts = np.bincount(col_known, minlength=n_cats)
+        means = np.bincount(col_known, weights=y, minlength=n_cats)
+        np.divide(means, counts, out=means, where=counts != 0)
+
+        diff = y - means[col]
+        sum_of_squared_diffs = np.bincount(col, weights=diff * diff, minlength=n_cats)
+        np.divide(
+            sum_of_squared_diffs, counts, out=sum_of_squared_diffs, where=counts != 0
+        )
+
+        lambda_ = y_variance * counts
+        np.divide(
+            lambda_, lambda_ + sum_of_squared_diffs, out=lambda_, where=lambda_ != 0
+        )
+
+        encodings[feat_idx][:] = lambda_ * means + (1 - lambda_) * y_mean
+
+    return encodings
+
+
+class TargetEncoder(OneToOneFeatureMixin, _BaseEncoder):
+    """Target Encoder for regression and classification targets.
+
+    Each category is encoded based on a shrunk estimate of the average target
+    values for observations belonging to the category. The encoding scheme mixes
+    the global target mean with the target mean conditioned on the value of the
+    category. [MIC]_
+
+    :class:`TargetEncoder` considers missing values, such as `np.nan` or `None`,
+    as another category and encodes them like any other category. Categories
+    that are not seen during :meth:`fit` are encoded with the target mean, i.e.
+    `target_mean_`.
+
+    Read more in the :ref:`User Guide <target_encoder>`.
+
+    .. note::
+        `fit(X, y).transform(X)` does not equal `fit_transform(X, y)` because a
+        cross fitting scheme is used in `fit_transform` for encoding. See the
+        :ref:`User Guide <target_encoder>` for details.
+
+    .. versionadded:: 1.3
 
     Parameters
     ----------
-    categories : 'auto' or list of list of int or str
+    categories : "auto" or list of shape (n_features,) of array-like, default="auto"
         Categories (unique values) per feature:
 
-        - 'auto' : Determine categories automatically from the training data.
-        - list : `categories[i]` holds the categories expected in the `i`-th
-          column. The passed categories must be sorted and should not mix
-          strings and numeric values.
+        - `"auto"` : Determine categories automatically from the training data.
+        - list : `categories[i]` holds the categories expected in the i-th column. The
+          passed categories should not mix strings and numeric values within a single
+          feature, and should be sorted in case of numeric values.
 
-        The categories used can be found in the ``categories_`` attribute.
-    clf_type : {'regression', 'binary-clf', 'multiclass-clf'}, default='binary-clf'
-        The type of classification/regression problem.
-    dtype : number type, default=np.float64
-        Desired dtype of output.
-    handle_unknown : {'error', 'ignore'}, default='error'
-        Whether to raise an error or ignore if an unknown categorical feature is
-        present during transform (default is to raise). When this parameter
-        is set to 'ignore' and an unknown category is encountered during
-        transform, the encoded columns for this feature
-        will be assigned the prior mean of the target variable.
-    handle_missing : {'error', ''}, default=''
-        Whether to raise an error or impute with blank string '' if missing
-        values (NaN) are present during TargetEncoder.fit
-        (default is to impute).
-        When this parameter is set to '', and a missing value is encountered
-        during TargetEncoder.fit_transform, the resulting encoded
-        columns for this feature will be all zeros.
+        The used categories are stored in the `categories_` fitted attribute.
+
+    target_type : {"auto", "continuous", "binary"}, default="auto"
+        Type of target.
+
+        - `"auto"` : Type of target is inferred with
+          :func:`~sklearn.utils.multiclass.type_of_target`.
+        - `"continuous"` : Continuous target
+        - `"binary"` : Binary target
+
+        .. note::
+            The type of target inferred with `"auto"` may not be the desired target
+            type used for modeling. For example, if the target consisted of integers
+            between 0 and 100, then :func:`~sklearn.utils.multiclass.type_of_target`
+            will infer the target as `"multiclass"`. In this case, setting
+            `target_type="continuous"` will specify the target as a regression
+            problem. The `target_type_` attribute gives the target type used by the
+            encoder.
+
+    smooth : "auto" or float, default="auto"
+        The amount of mixing of the target mean conditioned on the value of the
+        category with the global target mean. A larger `smooth` value will put
+        more weight on the global target mean.
+        If `"auto"`, then `smooth` is set to an empirical Bayes estimate.
+
+    cv : int, default=5
+        Determines the number of folds in the cross fitting strategy used in
+        :meth:`fit_transform`. For classification targets, `StratifiedKFold` is used
+        and for continuous targets, `KFold` is used.
+
+    shuffle : bool, default=True
+        Whether to shuffle the data in :meth:`fit_transform` before splitting into
+        folds. Note that the samples within each split will not be shuffled.
+
+    random_state : int, RandomState instance or None, default=None
+        When `shuffle` is True, `random_state` affects the ordering of the
+        indices, which controls the randomness of each fold. Otherwise, this
+        parameter has no effect.
+        Pass an int for reproducible output across multiple function calls.
+        See :term:`Glossary <random_state>`.
 
     Attributes
     ----------
+    encodings_ : list of shape (n_features,) of ndarray
+        Encodings learnt on all of `X`.
+        For feature `i`, `encodings_[i]` are the encodings matching the
+        categories listed in `categories_[i]`.
+
+    categories_ : list of shape (n_features,) of ndarray
+        The categories of each feature determined during fitting or specified
+        in `categories`
+        (in order of the features in `X` and corresponding with the output
+        of :meth:`transform`).
+
+    target_type_ : str
+        Type of target.
+
+    target_mean_ : float
+        The overall mean of the target. This value is only used in :meth:`transform`
+        to encode categories.
+
     n_features_in_ : int
-        Number of features in the data seen during TargetEncoder.fit.
-    categories_ : list of ndarray
-        The categories of each feature determined during TargetEncoder.fit
-        (in order corresponding with output of TargetEncoder.transform).
-    n_ : int
-        Length of :term:`y`
+        Number of features seen during :term:`fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of features seen during :term:`fit`. Defined only when `X`
+        has feature names that are all strings.
 
     See Also
     --------
-    GapEncoder
-        Encodes dirty categories (strings) by constructing latent topics with
-        continuous encoding.
-    MinHashEncoder
-        Encode string columns as a numeric array with the minhash method.
-    SimilarityEncoder
-        Encode string columns as a numeric array with n-gram string similarity.
+    OrdinalEncoder : Performs an ordinal (integer) encoding of the categorical features.
+        Contrary to TargetEncoder, this encoding is not supervised. Treating the
+        resulting encoding as a numerical features therefore lead arbitrarily
+        ordered values and therefore typically lead to lower predictive performance
+        when used as preprocessing for a classifier or regressor.
+    OneHotEncoder : Performs a one-hot encoding of categorical features. This
+        unsupervised encoding is better suited for low cardinality categorical
+        variables as it generate one new feature per unique category.
 
     References
     ----------
-    For more details, see Micci-Barreca, 2001: A preprocessing scheme for
-    high-cardinality categorical attributes in classification and prediction
-    problems.
+    .. [MIC] :doi:`Micci-Barreca, Daniele. "A preprocessing scheme for high-cardinality
+       categorical attributes in classification and prediction problems"
+       SIGKDD Explor. Newsl. 3, 1 (July 2001), 27–32. <10.1145/507533.507538>`
 
     Examples
     --------
-    >>> enc = TargetEncoder(handle_unknown='ignore')
-    >>> X = [['male'], ['Male'], ['Female'], ['male'], ['Female']]
-    >>> y = np.array([1, 2, 3, 4, 5])
+    With `smooth="auto"`, the smoothing parameter is set to an empirical Bayes estimate:
 
-    >>> enc.fit(X, y)
-    TargetEncoder(handle_unknown='ignore')
+    >>> import numpy as np
+    >>> from sklearn.preprocessing import TargetEncoder
+    >>> X = np.array([["dog"] * 20 + ["cat"] * 30 + ["snake"] * 38], dtype=object).T
+    >>> y = [90.3] * 5 + [80.1] * 15 + [20.4] * 5 + [20.1] * 25 + [21.2] * 8 + [49] * 30
+    >>> enc_auto = TargetEncoder(smooth="auto")
+    >>> X_trans = enc_auto.fit_transform(X, y)
 
-    The encoder has found the following categories:
+    >>> # A high `smooth` parameter puts more weight on global mean on the categorical
+    >>> # encodings:
+    >>> enc_high_smooth = TargetEncoder(smooth=5000.0).fit(X, y)
+    >>> enc_high_smooth.target_mean_
+    44...
+    >>> enc_high_smooth.encodings_
+    [array([44..., 44..., 44...])]
 
-    >>> enc.categories_
-    [array(['Female', 'Male', 'male'], dtype='<U6')]
-
-    We will encode the following categories, of which the first two are unknown :
-
-    >>> X2 = [['MALE'], ['FEMALE'], ['Female'], ['male'], ['Female']]
-
-    >>> enc.transform(X2)
-    array([[3.        ],
-        [3.        ],
-        [3.54545455],
-        [2.72727273],
-        [3.54545455]])
-
-    As expected, they were encoded according to their influence on y.
-    The unknown categories were assigned the mean of the target variable.
+    >>> # On the other hand, a low `smooth` parameter puts more weight on target
+    >>> # conditioned on the value of the categorical:
+    >>> enc_low_smooth = TargetEncoder(smooth=1.0).fit(X, y)
+    >>> enc_low_smooth.encodings_
+    [array([20..., 80..., 43...])]
     """
-
-    n_features_in_: int
-    _label_encoders_: list[LabelEncoder]
-    categories_: list[NDArray]
-    n_: int
 
     def __init__(
         self,
-        *,
-        categories: Literal["auto"] | list[list[str] | NDArray] = "auto",
-        clf_type: Literal["regression", "binary-clf", "multiclass-clf"] = "binary-clf",
-        dtype: type = np.float64,
-        handle_unknown: Literal["error", "ignore"] = "error",
-        handle_missing: Literal["error", ""] = "",
+        categories="auto",
+        target_type="auto",
+        smooth="auto",
+        cv=5,
+        shuffle=True,
+        random_state=None,
     ):
         self.categories = categories
-        self.dtype = dtype
-        self.clf_type = clf_type
-        self.handle_unknown = handle_unknown
-        self.handle_missing = handle_missing
+        self.smooth = smooth
+        self.target_type = target_type
+        self.cv = cv
+        self.shuffle = shuffle
+        self.random_state = random_state
 
-    def _more_tags(self) -> dict[str, list[str]]:
-        """
-        Used internally by sklearn to ease the estimator checks.
-        """
-        return {"X_types": ["categorical"]}
-
-    def fit(self, X: ArrayLike, y: ArrayLike) -> "TargetEncoder":
-        """Fit the instance to `X`.
+    def fit(self, X, y):
+        """Fit the :class:`TargetEncoder` to X and y.
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features]
+        X : array-like of shape (n_samples, n_features)
             The data to determine the categories of each feature.
-        y : ndarray
-            The associated target vector.
+
+        y : array-like of shape (n_samples,)
+            The target data used to encode the categories.
 
         Returns
         -------
-        TargetEncoder
-            Fitted TargetEncoder instance (self).
+        self : object
+            Fitted encoder.
         """
-        X = check_input(X)
-        self.n_features_in_ = X.shape[1]
-        if self.handle_missing not in ["error", ""]:
-            raise ValueError(
-                f"Got handle_missing={self.handle_missing!r}, but expected "
-                "any of {'error', ''}. "
-            )
-
-        mask = _object_dtype_isnan(X)
-        if mask.any():
-            if self.handle_missing == "error":
-                raise ValueError(
-                    "Found missing values in input data; set "
-                    "handle_missing='' to encode with missing values. "
-                )
-            else:
-                X[mask] = self.handle_missing
-
-        if self.handle_unknown not in ["error", "ignore"]:
-            raise ValueError(
-                f"Got handle_unknown={self.handle_unknown!r}, but expected "
-                "any of {'error', 'ignore'}. "
-            )
-
-        if self.categories != "auto":
-            for cats in self.categories:
-                if not np.all(np.sort(cats) == np.array(cats)):
-                    raise ValueError("Unsorted categories are not yet supported. ")
-
-        X_temp = check_array(X, dtype=None)
-        X = X_temp
-
-        n_samples, n_features = X.shape
-
-        self._label_encoders_ = [LabelEncoder() for _ in range(n_features)]
-
-        for j in range(n_features):
-            le = self._label_encoders_[j]
-            Xj = X[:, j]
-            if self.categories == "auto":
-                le.fit(Xj)
-            else:
-                if self.handle_unknown == "error":
-                    valid_mask = np.in1d(Xj, self.categories[j])
-                    if not np.all(valid_mask):
-                        diff = np.unique(Xj[~valid_mask])
-                        raise ValueError(
-                            f"Found unknown categories {diff} in column {j} during fit"
-                        )
-                le.classes_ = np.array(self.categories[j])
-
-        self.categories_ = [le.classes_ for le in self._label_encoders_]
-        self.n_ = len(y)
-        if self.clf_type in ["binary-clf", "regression"]:
-            self.Eyx_ = [
-                {cat: np.mean(y[X[:, j] == cat]) for cat in self.categories_[j]}
-                for j in range(len(self.categories_))
-            ]
-            self.Ey_ = np.mean(y)
-            self.counter_ = {j: collections.Counter(X[:, j]) for j in range(n_features)}
-        if self.clf_type in ["multiclass-clf"]:
-            self.classes_ = np.unique(y)
-
-            self.Eyx_ = {
-                c: [
-                    {
-                        cat: np.mean((y == c)[X[:, j] == cat])
-                        for cat in self.categories_[j]
-                    }
-                    for j in range(len(self.categories_))
-                ]
-                for c in self.classes_
-            }
-            self.Ey_ = {c: np.mean(y == c) for c in self.classes_}
-            self.counter_ = {j: collections.Counter(X[:, j]) for j in range(n_features)}
-        self.k_ = {j: len(self.counter_[j]) for j in self.counter_}
+        self._fit_encodings_all(X, y)
         return self
 
-    def transform(self, X: ArrayLike) -> NDArray:
-        """Transform `X` using the specified encoding scheme.
+    def fit_transform(self, X, y):
+        """Fit :class:`TargetEncoder` and transform X with the target encoding.
+
+        .. note::
+            `fit(X, y).transform(X)` does not equal `fit_transform(X, y)` because a
+            cross fitting scheme is used in `fit_transform` for encoding. See the
+            :ref:`User Guide <target_encoder>`. for details.
 
         Parameters
         ----------
-        X : array-like, shape [n_samples, n_features_new]
-            The data to encode.
+        X : array-like of shape (n_samples, n_features)
+            The data to determine the categories of each feature.
+
+        y : array-like of shape (n_samples,)
+            The target data used to encode the categories.
 
         Returns
         -------
-        2-d ndarray
+        X_trans : ndarray of shape (n_samples, n_features)
             Transformed input.
         """
-        check_is_fitted(self, attributes=["n_features_in_"])
-        X = check_input(X)
-        if X.shape[1] != self.n_features_in_:
-            raise ValueError(
-                f"The number of features in the input data ({X.shape[1]}) "
-                "does not match the number of features "
-                f"seen during fit ({self.n_features_in_})."
+        X_ordinal, X_known_mask, y, n_categories = self._fit_encodings_all(X, y)
+
+        # The cv splitter is voluntarily restricted to *KFold to enforce non
+        # overlapping validation folds, otherwise the fit_transform output will
+        # not be well-specified.
+        if self.target_type_ == "continuous":
+            cv = KFold(self.cv, shuffle=self.shuffle, random_state=self.random_state)
+        else:
+            cv = StratifiedKFold(
+                self.cv, shuffle=self.shuffle, random_state=self.random_state
             )
-        mask = _object_dtype_isnan(X)
-        if mask.any():
-            if self.handle_missing == "error":
-                raise ValueError(
-                    "Found missing values in input data; set "
-                    "handle_missing='' to encode with missing values. "
+
+        X_out = np.empty_like(X_ordinal, dtype=np.float64)
+        X_unknown_mask = ~X_known_mask
+
+        for train_idx, test_idx in cv.split(X, y):
+            X_train, y_train = X_ordinal[train_idx, :], y[train_idx]
+            y_mean = np.mean(y_train)
+
+            if self.smooth == "auto":
+                y_variance = np.var(y_train)
+                encodings = _fit_encoding_fast_auto_smooth(
+                    X_train, y_train, n_categories, y_mean, y_variance
                 )
             else:
-                X[mask] = self.handle_missing
+                encodings = _fit_encoding_fast(
+                    X_train, y_train, n_categories, self.smooth, y_mean
+                )
+            self._transform_X_ordinal(
+                X_out, X_ordinal, X_unknown_mask, test_idx, encodings, y_mean
+            )
+        return X_out
 
-        X_temp = check_array(X, dtype=None)
-        X = X_temp
+    def transform(self, X):
+        """Transform X with the target encoding.
 
-        n_samples, n_features = X.shape
-        X_int = np.zeros_like(X, dtype=int)
-        X_mask = np.ones_like(X, dtype=bool)
+        .. note::
+            `fit(X, y).transform(X)` does not equal `fit_transform(X, y)` because a
+            cross fitting scheme is used in `fit_transform` for encoding. See the
+            :ref:`User Guide <target_encoder>`. for details.
 
-        for i in range(n_features):
-            Xi = X[:, i]
-            valid_mask = np.in1d(Xi, self.categories_[i])
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data to determine the categories of each feature.
 
-            if not np.all(valid_mask):
-                if self.handle_unknown == "error":
-                    diff = np.unique(X[~valid_mask, i])
-                    raise ValueError(
-                        f"Found unknown categories {diff} in column {i} "
-                        "during transform."
-                    )
-                else:
-                    # Set the problematic rows to an acceptable value and
-                    # continue `The rows are marked `X_mask` and will be
-                    # removed later.
-                    X_mask[:, i] = valid_mask
-                    Xi = Xi.copy()
-                    Xi[~valid_mask] = self.categories_[i][0]
-            X_int[:, i] = self._label_encoders_[i].transform(Xi)
+        Returns
+        -------
+        X_trans : ndarray of shape (n_samples, n_features)
+            Transformed input.
+        """
+        X_ordinal, X_valid = self._transform(
+            X, handle_unknown="ignore", force_all_finite="allow-nan"
+        )
+        X_out = np.empty_like(X_ordinal, dtype=np.float64)
+        self._transform_X_ordinal(
+            X_out,
+            X_ordinal,
+            ~X_valid,
+            slice(None),
+            self.encodings_,
+            self.target_mean_,
+        )
+        return X_out
 
-        out = []
+    def _fit_encodings_all(self, X, y):
+        """Fit a target encoding with all the data."""
 
-        for j, cats in enumerate(self.categories_):
-            unqX = np.unique(X[:, j])
-            encoder = {x: 0 for x in unqX}
-            if self.clf_type in ["binary-clf", "regression"]:
-                for x in unqX:
-                    if x not in cats:
-                        Eyx = 0
-                    else:
-                        Eyx = self.Eyx_[j][x]
-                    lambda_n = lambda_(self.counter_[j][x], self.n_ / self.k_[j])
-                    encoder[x] = lambda_n * Eyx + (1 - lambda_n) * self.Ey_
-                x_out = np.zeros((len(X[:, j]), 1))
-                for i, x in enumerate(X[:, j]):
-                    x_out[i, 0] = encoder[x]
-                out.append(x_out.reshape(-1, 1))
-            if self.clf_type == "multiclass-clf":
-                x_out = np.zeros((len(X[:, j]), len(self.classes_)))
-                lambda_n = {x: 0 for x in unqX}
-                for x in unqX:
-                    lambda_n[x] = lambda_(self.counter_[j][x], self.n_ / self.k_[j])
-                for k, c in enumerate(np.unique(self.classes_)):
-                    for x in unqX:
-                        if x not in cats:
-                            Eyx = 0
-                        else:
-                            Eyx = self.Eyx_[c][j][x]
-                        encoder[x] = lambda_n[x] * Eyx + (1 - lambda_n[x]) * self.Ey_[c]
-                    for i, x in enumerate(X[:, j]):
-                        x_out[i, k] = encoder[x]
-                out.append(x_out)
-        out = np.hstack(out)
-        return out
+        check_consistent_length(X, y)
+        self._fit(X, handle_unknown="ignore", force_all_finite="allow-nan")
+
+        if self.target_type == "auto":
+            accepted_target_types = ("binary", "continuous")
+            inferred_type_of_target = type_of_target(y, input_name="y")
+            if inferred_type_of_target not in accepted_target_types:
+                raise ValueError(
+                    f"Target type was inferred to be {inferred_type_of_target!r}. Only"
+                    f" {accepted_target_types} are supported."
+                )
+            self.target_type_ = inferred_type_of_target
+        else:
+            self.target_type_ = self.target_type
+
+        if self.target_type_ == "binary":
+            y = LabelEncoder().fit_transform(y)
+        else:  # continuous
+            y = _check_y(y, y_numeric=True, estimator=self)
+
+        self.target_mean_ = np.mean(y)
+
+        X_ordinal, X_known_mask = self._transform(
+            X, handle_unknown="ignore", force_all_finite="allow-nan"
+        )
+        n_categories = np.fromiter(
+            (len(category_for_feature) for category_for_feature in self.categories_),
+            dtype=np.int64,
+            count=len(self.categories_),
+        )
+        if self.smooth == "auto":
+            y_variance = np.var(y)
+            print(X_ordinal)
+            self.encodings_ = _fit_encoding_fast_auto_smooth(
+                X_ordinal, y, n_categories, self.target_mean_, y_variance
+            )
+        else:
+            self.encodings_ = _fit_encoding_fast(
+                X_ordinal, y, n_categories, self.smooth, self.target_mean_
+            )
+
+        return X_ordinal, X_known_mask, y, n_categories
+
+    @staticmethod
+    def _transform_X_ordinal(
+        X_out, X_ordinal, X_unknown_mask, indices, encodings, y_mean
+    ):
+        """Transform X_ordinal using encodings."""
+        for f_idx, encoding in enumerate(encodings):
+            X_out[indices, f_idx] = encoding[X_ordinal[indices, f_idx]]
+            X_out[X_unknown_mask[:, f_idx], f_idx] = y_mean
+
+    def _more_tags(self):
+        return {"requires_y": True}

--- a/skrub/tests/test_target_encoder.py
+++ b/skrub/tests/test_target_encoder.py
@@ -1,287 +1,559 @@
 import numpy as np
 import pytest
-from sklearn.exceptions import NotFittedError
 
-from skrub import _target_encoder
+from sklearn.utils._testing import assert_allclose, assert_array_equal
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.linear_model import Ridge
+from sklearn.model_selection import (
+    KFold,
+    ShuffleSplit,
+    StratifiedKFold,
+    cross_val_score,
+    train_test_split,
+)
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import (
+    KBinsDiscretizer,
+    LabelEncoder,
+)
 
-
-def test_target_encoder() -> None:
-    lambda_ = _target_encoder.lambda_
-    X1 = np.array(
-        ["Red", "red", "green", "blue", "green", "green", "blue", "red"]
-    ).reshape(-1, 1)
-    X2 = np.array(
-        ["male", "male", "female", "male", "female", "female", "female", "male"]
-    ).reshape(-1, 1)
-    X = np.hstack([X1, X2])
-
-    # Case 1: binary-classification and regression
-    y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
-    n = len(y)
-
-    Ey_ = 3 / 8
-    Eyx_ = {
-        "color": {"Red": 1, "red": 0, "green": 1 / 3, "blue": 0.5},
-        "gender": {"male": 0.5, "female": 0.25},
-    }
-    count_ = {
-        "color": {"Red": 1, "red": 2, "green": 3, "blue": 2},
-        "gender": {"male": 4, "female": 4},
-    }
-
-    encoder = _target_encoder.TargetEncoder()
-    encoder.fit(X, y)
-    for j in range(X.shape[1]):
-        assert np.array_equal(encoder.categories_[j], np.unique(X[:, j]))
-    assert Ey_ == encoder.Ey_
-    assert encoder.Eyx_[0] == Eyx_["color"]
-    assert encoder.Eyx_[1] == Eyx_["gender"]
-
-    Xtest1 = np.array(
-        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
-    ).reshape(-1, 1)
-    Xtest2 = np.array(
-        ["male", "male", "male", "male", "female", "female", "female", "female"]
-    ).reshape(-1, 1)
-    Xtest = np.hstack([Xtest1, Xtest2])
-
-    Xout = encoder.transform(Xtest)
-
-    ans_dict = {
-        var: {
-            cat: Eyx_[var][cat] * lambda_(count_[var][cat], n / len(count_[var]))
-            + Ey_ * (1 - lambda_(count_[var][cat], n / len(count_[var])))
-            for cat in Eyx_[var]
-        }
-        for var in Eyx_
-    }
-    ans = np.zeros((n, 2))
-    for j, col in enumerate(["color", "gender"]):
-        for i in range(n):
-            ans[i, j] = ans_dict[col][Xtest[i, j]]
-    assert np.array_equal(Xout, ans)
-
-    # Case 2: multiclass-classification
-    y = np.array([1, 0, 2, 1, 0, 1, 0, 0])
-    n = len(y)
-
-    encoder = _target_encoder.TargetEncoder(clf_type="multiclass-clf")
-    encoder.fit(X, y)
-
-    Ey_ = {0: 4 / 8, 1: 3 / 8, 2: 1 / 8}
-    Eyx_ = {
-        0: {
-            "color": {"Red": 0, "red": 1, "green": 1 / 3, "blue": 0.5},
-            "gender": {"male": 0.5, "female": 0.5},
-        },
-        1: {
-            "color": {"Red": 1, "red": 0, "green": 1 / 3, "blue": 0.5},
-            "gender": {"male": 0.5, "female": 0.25},
-        },
-        2: {
-            "color": {"Red": 0, "red": 0, "green": 1 / 3, "blue": 0},
-            "gender": {"male": 0, "female": 0.25},
-        },
-    }
-    assert np.array_equal(np.unique(y), encoder.classes_)
-    for k in [0, 1, 2]:
-        assert Ey_[k] == encoder.Ey_[k]
-        assert encoder.Eyx_[k][0] == Eyx_[k]["color"]
-        assert encoder.Eyx_[k][1] == Eyx_[k]["gender"]
-
-    count_ = {
-        "color": {"Red": 1, "red": 2, "green": 3, "blue": 2},
-        "gender": {"male": 4, "female": 4},
-    }
-    assert count_["color"] == encoder.counter_[0]
-    assert count_["gender"] == encoder.counter_[1]
-
-    ans_dict = {0: {}, 1: {}, 2: {}}
-    for k in [0, 1, 2]:
-        ans_dict[k] = {
-            var: {
-                cat: Eyx_[k][var][cat] * lambda_(count_[var][cat], n / len(count_[var]))
-                + Ey_[k] * (1 - lambda_(count_[var][cat], n / len(count_[var])))
-                for cat in Eyx_[k][var]
-            }
-            for var in Eyx_[k]
-        }
-
-    ans = np.zeros((n, 2 * 3))
-    Xtest1 = np.array(
-        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
-    ).reshape(-1, 1)
-    Xtest2 = np.array(
-        ["male", "male", "male", "male", "female", "female", "female", "female"]
-    ).reshape(-1, 1)
-    Xtest = np.hstack([Xtest1, Xtest2])
-    for k in [0, 1, 2]:
-        for j, col in enumerate(["color", "gender"]):
-            for i in range(n):
-                ans[i, 2 * j + k] = ans_dict[k][col][Xtest[i, j]]
-
-    Xout = encoder.transform(Xtest)
-    ans = np.zeros((n, 2 * 3))
-    Xtest1 = np.array(
-        ["Red", "red", "blue", "green", "Red", "red", "blue", "green"]
-    ).reshape(-1, 1)
-    Xtest2 = np.array(
-        ["male", "male", "male", "male", "female", "female", "female", "female"]
-    ).reshape(-1, 1)
-    Xtest = np.hstack([Xtest1, Xtest2])
-    for k in [0, 1, 2]:
-        for j, col in enumerate(["color", "gender"]):
-            for i in range(n):
-                ans[i, j * 3 + k] = ans_dict[k][col][Xtest[i, j]]
-    encoder = _target_encoder.TargetEncoder(clf_type="multiclass-clf")
-    encoder.fit(X, y)
-    Xout = encoder.transform(Xtest)
-    assert np.array_equal(Xout, ans)
+from skrub._target_encoder import TargetEncoder
 
 
-@pytest.mark.parametrize("input_type", ["list", "numpy", "pandas"])
-@pytest.mark.parametrize("missing", ["", "aaa", "error"])
-def test_missing_values(input_type, missing) -> None:
-    X = [
-        ["Red", "male"],
-        [np.nan, "male"],
-        ["green", "female"],
-        ["blue", "male"],
-        ["green", "female"],
-        ["green", "female"],
-        ["blue", "female"],
-        [np.nan, np.nan],
-    ]
+@pytest.fixture()
+def global_random_seed():
+    """Set a global random seed for all tests."""
+    return 42
 
-    color_cat = ["Red", "", "green", "blue"]
-    gender_cat = ["male", "", "female"]
 
-    if input_type == "numpy":
-        X = np.array(X, dtype=object)
-    elif input_type == "pandas":
-        pd = pytest.importorskip("pandas")
-        X = pd.DataFrame(X)
+def _encode_target(X_ordinal, y_int, n_categories, smooth):
+    """Simple Python implementation of target encoding."""
+    cur_encodings = np.zeros(n_categories, dtype=np.float64)
+    y_mean = np.mean(y_int)
 
-    # Case 1: binary-classification and regression
-    y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
+    if smooth == "auto":
+        y_variance = np.var(y_int)
+        for c in range(n_categories):
+            y_subset = y_int[X_ordinal == c]
+            n_i = y_subset.shape[0]
 
-    Ey_ = 3 / 8
-    Eyx_ = {
-        "color": {"Red": 1, "": 0, "green": 1 / 3, "blue": 0.5},
-        "gender": {"male": 2 / 3, "female": 0.25, "": 0},
-    }
-    count_ = {
-        "color": {"Red": 1, "": 2, "green": 3, "blue": 2},
-        "gender": {"male": 3, "female": 4, "": 1},
-    }
+            if n_i == 0:
+                cur_encodings[c] = y_mean
+                continue
 
-    encoder = _target_encoder.TargetEncoder(handle_missing=missing)
-    if missing == "error":
-        with pytest.raises(ValueError, match=r"Found missing values in input"):
-            encoder.fit_transform(X, y)
-        return
-    elif missing == "":
-        encoder.fit_transform(X, y)
+            y_subset_variance = np.var(y_subset)
+            m = y_subset_variance / y_variance
+            lambda_ = n_i / (n_i + m)
 
-        assert set(encoder.categories_[0]) == set(color_cat)
-        assert set(encoder.categories_[1]) == set(gender_cat)
-        assert Ey_ == encoder.Ey_
-        assert encoder.Eyx_[0] == Eyx_["color"]
-        assert encoder.Eyx_[1] == Eyx_["gender"]
-        assert dict(encoder.counter_[0]) == count_["color"]
-        assert dict(encoder.counter_[1]) == count_["gender"]
+            cur_encodings[c] = lambda_ * np.mean(y_subset) + (1 - lambda_) * y_mean
+        return cur_encodings
+    else:  # float
+        for c in range(n_categories):
+            y_subset = y_int[X_ordinal == c]
+            current_sum = np.sum(y_subset) + y_mean * smooth
+            current_cnt = y_subset.shape[0] + smooth
+            cur_encodings[c] = current_sum / current_cnt
+        return cur_encodings
+
+
+@pytest.mark.parametrize(
+    "categories, unknown_value",
+    [
+        ([np.array([0, 1, 2], dtype=np.int64)], 4),
+        ([np.array([1.0, 3.0, np.nan], dtype=np.float64)], 6.0),
+        ([np.array(["cat", "dog", "snake"], dtype=object)], "bear"),
+        ("auto", 3),
+    ],
+)
+@pytest.mark.parametrize("smooth", [5.0, "auto"])
+@pytest.mark.parametrize("target_type", ["binary", "continuous"])
+def test_encoding(categories, unknown_value, global_random_seed, smooth, target_type):
+    """Check encoding for binary and continuous targets."""
+
+    X_train_array = np.array([[0] * 20 + [1] * 30 + [2] * 40], dtype=np.int64).T
+    X_test_array = np.array([[0, 1, 2]], dtype=np.int64).T
+    n_categories = 3
+    n_samples = X_train_array.shape[0]
+
+    if categories == "auto":
+        X_train = X_train_array
     else:
-        with pytest.raises(ValueError, match=r"expected any of"):
-            encoder.fit_transform(X, y)
-        return
+        X_train = categories[0][X_train_array]
 
+    if categories == "auto":
+        X_test = X_test_array
+    else:
+        X_test = categories[0][X_test_array]
+    X_test = np.concatenate((X_test, [[unknown_value]]))
 
-@pytest.mark.parametrize("input_type", ["list", "numpy", "pandas"])
-@pytest.mark.parametrize("missing", ["", "aaa", "error"])
-def test_missing_values_transform(input_type, missing) -> None:
-    X = [
-        ["Red", "male"],
-        ["red", "male"],
-        ["green", "female"],
-        ["blue", "male"],
-        ["green", "female"],
-        ["green", "female"],
-        ["blue", "female"],
-        ["red", "male"],
-    ]
+    rng = np.random.RandomState(global_random_seed)
 
-    X_test = [
-        ["Red", "male"],
-        [np.nan, "male"],
-        ["green", "female"],
-        ["blue", "male"],
-        ["green", "female"],
-        ["green", "female"],
-        ["blue", "female"],
-        [np.nan, np.nan],
-    ]
+    if target_type == "binary":
+        y_int = rng.randint(low=0, high=2, size=n_samples)
+        target_names = np.array(["cat", "dog"], dtype=object)
+        y_train = target_names[y_int]
+        cv = StratifiedKFold(n_splits=3, random_state=0, shuffle=True)
+    else:  # target_type == continuous
+        y_int = rng.uniform(low=-10, high=20, size=n_samples)
+        y_train = y_int
+        cv = KFold(n_splits=3, random_state=0, shuffle=True)
 
-    if input_type == "numpy":
-        X_test = np.array(X_test, dtype=object)
-    elif input_type == "pandas":
-        pd = pytest.importorskip("pandas")
-        X_test = pd.DataFrame(X_test)
+    shuffled_idx = rng.permutation(n_samples)
+    X_train_array = X_train_array[shuffled_idx]
+    X_train = X_train[shuffled_idx]
+    y_train = y_train[shuffled_idx]
+    y_int = y_int[shuffled_idx]
 
-    # Case 1: binary-classification and regression
-    y = np.array([1, 0, 0, 1, 0, 1, 0, 0])
+    # Get encodings for cv splits to validate `fit_transform`
+    expected_X_fit_transform = np.empty_like(X_train_array, dtype=np.float64)
 
-    Ey_ = 3 / 8
+    for train_idx, test_idx in cv.split(X_train_array, y_train):
+        X_, y_ = X_train_array[train_idx, 0], y_int[train_idx]
+        cur_encodings = _encode_target(X_, y_, n_categories, smooth)
+        expected_X_fit_transform[test_idx, 0] = cur_encodings[
+            X_train_array[test_idx, 0]
+        ]
 
-    encoder = _target_encoder.TargetEncoder(
-        handle_unknown="ignore", handle_missing=missing
+    target_encoder = TargetEncoder(
+        smooth=smooth, categories=categories, cv=3, random_state=0
     )
-    if missing == "error":
-        encoder.fit_transform(X, y)
-        with pytest.raises(ValueError, match=r"Found missing values in input"):
-            encoder.transform(X_test)
-    elif missing == "":
-        encoder.fit_transform(X, y)
-        ans = encoder.transform(X_test)
 
-        assert np.allclose(ans[1, 0], Ey_)
-        assert np.allclose(ans[-1, 0], Ey_)
+    X_fit_transform = target_encoder.fit_transform(X_train, y_train)
 
+    assert target_encoder.target_type_ == target_type
+    assert_allclose(X_fit_transform, expected_X_fit_transform)
+    assert len(target_encoder.encodings_) == 1
 
-def test_errors() -> None:
-    """Test the different errors that may be raised during fit and transform"""
-    enc = _target_encoder.TargetEncoder(handle_unknown="blabla")
-    X = [[1], [2], [2], [3], [4]]
-    y = np.array([1, 2, 3, 4, 5])
+    # compute encodings for all data to validate `transform`
+    y_mean = np.mean(y_int)
+    expected_encodings = _encode_target(
+        X_train_array[:, 0], y_int, n_categories, smooth
+    )
+    assert_allclose(target_encoder.encodings_[0], expected_encodings)
+    assert target_encoder.target_mean_ == pytest.approx(y_mean)
 
-    with pytest.raises(ValueError, match="Got handle_unknown='blabla', but expected"):
-        enc.fit(X, y)
+    # Transform on test data, the last value is unknown is it is encoded as the target
+    # mean
+    expected_X_test_transform = np.concatenate(
+        (expected_encodings, np.array([y_mean]))
+    ).reshape(-1, 1)
 
-    enc2 = _target_encoder.TargetEncoder(categories=[["blabla", "aa"]])
-    with pytest.raises(ValueError, match="Unsorted categories are not yet supported. "):
-        enc2.fit(X, y)
-
-    enc3 = _target_encoder.TargetEncoder(categories=[["aa", "blabla"]])
-    with pytest.raises(ValueError, match="Found unknown categories"):
-        enc3.fit(X, y)
-
-    X2 = [[1, "a"], [2, "b"], [4, "c"]]
-    X3 = [[5], [1], [4], [2]]
-    enc4 = _target_encoder.TargetEncoder()
-    enc4.fit(X, y)
-    with pytest.raises(ValueError, match="The number of features in the input data "):
-        enc4.transform(X2)
-    with pytest.raises(ValueError, match="Found unknown categories "):
-        enc4.transform(X3)
+    X_test_transform = target_encoder.transform(X_test)
+    assert_allclose(X_test_transform, expected_X_test_transform)
 
 
-def test_check_fitted_target_encoder() -> None:
-    """Test that calling transform before fit raises an error"""
-    enc = _target_encoder.TargetEncoder()
-    X = [[1], [2], [2], [3], [4]]
-    y = np.array([1, 2, 3, 4, 5])
+@pytest.mark.parametrize(
+    "X, categories",
+    [
+        (
+            np.array([[0] * 10 + [1] * 10 + [3]], dtype=np.int64).T,  # 3 is unknown
+            [[0, 1, 2]],
+        ),
+        (
+            np.array(
+                [["cat"] * 10 + ["dog"] * 10 + ["snake"]], dtype=object
+            ).T,  # snake is unknown
+            [["dog", "cat", "cow"]],
+        ),
+    ],
+)
+@pytest.mark.parametrize("smooth", [4.0, "auto"])
+def test_custom_categories(X, categories, smooth):
+    """Custom categories with unknown categories that are not in training data."""
+    rng = np.random.RandomState(0)
+    y = rng.uniform(low=-10, high=20, size=X.shape[0])
+    enc = TargetEncoder(categories=categories, smooth=smooth, random_state=0).fit(X, y)
 
-    with pytest.raises(NotFittedError, match="not fitted"):
-        enc.transform(X)
+    # The last element is unknown and encoded as the mean
+    y_mean = y.mean()
+    X_trans = enc.transform(X[-1:])
+    assert X_trans[0, 0] == pytest.approx(y_mean)
 
-    enc.fit(X, y)
-    enc.transform(X)
+    assert len(enc.encodings_) == 1
+    # custom category that is not in training data
+    assert enc.encodings_[0][-1] == pytest.approx(y_mean)
+
+
+@pytest.mark.parametrize(
+    "y, msg",
+    [
+        ([1, 2, 0, 1], "Found input variables with inconsistent"),
+        (
+            np.array([[1, 2, 0], [1, 2, 3]]).T,
+            "Target type was inferred to be 'multiclass-multioutput'",
+        ),
+        (["cat", "dog", "bear"], "Target type was inferred to be 'multiclass'"),
+    ],
+)
+def test_errors(y, msg):
+    """Check invalidate input."""
+    X = np.array([[1, 0, 1]]).T
+
+    enc = TargetEncoder()
+    with pytest.raises(ValueError, match=msg):
+        enc.fit_transform(X, y)
+
+
+def test_use_regression_target():
+    """Custom target_type to avoid inferring the target type."""
+    X = np.array([[0, 1, 0, 1, 0, 1]]).T
+
+    # XXX: When multiclass is supported, then the following `y`
+    # is considered a multiclass problem and `TargetEncoder` will not error.
+    # type_of_target would be 'multiclass'
+    y = np.array([1.0, 2.0, 3.0, 2.0, 3.0, 4.0])
+    enc = TargetEncoder()
+    msg = "Target type was inferred to be 'multiclass'"
+    with pytest.raises(ValueError, match=msg):
+        enc.fit_transform(X, y)
+
+    enc = TargetEncoder(target_type="continuous")
+    enc.fit_transform(X, y)
+    assert enc.target_type_ == "continuous"
+
+
+def test_feature_names_out_set_output():
+    """Check TargetEncoder works with set_output."""
+    pd = pytest.importorskip("pandas")
+
+    X_df = pd.DataFrame({"A": ["a", "b"] * 10, "B": [1, 2] * 10})
+    y = [1, 2] * 10
+
+    enc_default = TargetEncoder(cv=2, smooth=3.0, random_state=0)
+    enc_default.set_output(transform="default")
+    enc_pandas = TargetEncoder(cv=2, smooth=3.0, random_state=0)
+    enc_pandas.set_output(transform="pandas")
+
+    X_default = enc_default.fit_transform(X_df, y)
+    X_pandas = enc_pandas.fit_transform(X_df, y)
+
+    assert_allclose(X_pandas.to_numpy(), X_default)
+    assert_array_equal(enc_pandas.get_feature_names_out(), ["A", "B"])
+    assert_array_equal(enc_pandas.get_feature_names_out(), X_pandas.columns)
+
+
+@pytest.mark.parametrize("to_pandas", [True, False])
+@pytest.mark.parametrize("smooth", [1.0, "auto"])
+@pytest.mark.parametrize("target_type", ["binary-ints", "binary-str", "continuous"])
+def test_multiple_features_quick(to_pandas, smooth, target_type):
+    """Check target encoder with multiple features."""
+    X_ordinal = np.array(
+        [[1, 1], [0, 1], [1, 1], [2, 1], [1, 0], [0, 1], [1, 0], [0, 0]], dtype=np.int64
+    )
+    if target_type == "binary-str":
+        y_train = np.array(["a", "b", "a", "a", "b", "b", "a", "b"])
+        y_integer = LabelEncoder().fit_transform(y_train)
+        cv = StratifiedKFold(2, random_state=0, shuffle=True)
+    elif target_type == "binary-ints":
+        y_train = np.array([3, 4, 3, 3, 3, 4, 4, 4])
+        y_integer = LabelEncoder().fit_transform(y_train)
+        cv = StratifiedKFold(2, random_state=0, shuffle=True)
+    else:
+        y_train = np.array([3.0, 5.1, 2.4, 3.5, 4.1, 5.5, 10.3, 7.3])
+        y_integer = y_train
+        cv = KFold(2, random_state=0, shuffle=True)
+    y_mean = np.mean(y_integer)
+    categories = [[0, 1, 2], [0, 1]]
+
+    X_test = np.array(
+        [
+            [0, 1],
+            [3, 0],  # 3 is unknown
+            [1, 10],  # 10 is unknown
+        ],
+        dtype=np.int64,
+    )
+
+    if to_pandas:
+        pd = pytest.importorskip("pandas")
+        # convert second feature to an object
+        X_train = pd.DataFrame(
+            {
+                "feat0": X_ordinal[:, 0],
+                "feat1": np.array(["cat", "dog"], dtype=object)[X_ordinal[:, 1]],
+            }
+        )
+        # "snake" is unknown
+        X_test = pd.DataFrame({"feat0": X_test[:, 0], "feat1": ["dog", "cat", "snake"]})
+    else:
+        X_train = X_ordinal
+
+    # manually compute encoding for fit_transform
+    expected_X_fit_transform = np.empty_like(X_ordinal, dtype=np.float64)
+    for f_idx, cats in enumerate(categories):
+        for train_idx, test_idx in cv.split(X_ordinal, y_integer):
+            X_, y_ = X_ordinal[train_idx, f_idx], y_integer[train_idx]
+            current_encoding = _encode_target(X_, y_, len(cats), smooth)
+            expected_X_fit_transform[test_idx, f_idx] = current_encoding[
+                X_ordinal[test_idx, f_idx]
+            ]
+
+    # manually compute encoding for transform
+    expected_encodings = []
+    for f_idx, cats in enumerate(categories):
+        current_encoding = _encode_target(
+            X_ordinal[:, f_idx], y_integer, len(cats), smooth
+        )
+        expected_encodings.append(current_encoding)
+
+    expected_X_test_transform = np.array(
+        [
+            [expected_encodings[0][0], expected_encodings[1][1]],
+            [y_mean, expected_encodings[1][0]],
+            [expected_encodings[0][1], y_mean],
+        ],
+        dtype=np.float64,
+    )
+
+    enc = TargetEncoder(smooth=smooth, cv=2, random_state=0)
+    X_fit_transform = enc.fit_transform(X_train, y_train)
+    assert_allclose(X_fit_transform, expected_X_fit_transform)
+
+    assert len(enc.encodings_) == 2
+    for i in range(2):
+        assert_allclose(enc.encodings_[i], expected_encodings[i])
+
+    X_test_transform = enc.transform(X_test)
+    assert_allclose(X_test_transform, expected_X_test_transform)
+
+
+@pytest.mark.parametrize(
+    "y, y_mean",
+    [
+        (np.array([3.4] * 20), 3.4),
+        (np.array([0] * 20), 0),
+        (np.array(["a"] * 20, dtype=object), 0),
+    ],
+    ids=["continuous", "binary", "binary-string"],
+)
+@pytest.mark.parametrize("smooth", ["auto", 4.0, 0.0])
+def test_constant_target_and_feature(y, y_mean, smooth):
+    """Check edge case where feature and target is constant."""
+    X = np.array([[1] * 20]).T
+    n_samples = X.shape[0]
+
+    enc = TargetEncoder(cv=2, smooth=smooth, random_state=0)
+    X_trans = enc.fit_transform(X, y)
+    assert_allclose(X_trans, np.repeat([[y_mean]], n_samples, axis=0))
+    assert enc.encodings_[0][0] == pytest.approx(y_mean)
+    assert enc.target_mean_ == pytest.approx(y_mean)
+
+    X_test = np.array([[1], [0]])
+    X_test_trans = enc.transform(X_test)
+    assert_allclose(X_test_trans, np.repeat([[y_mean]], 2, axis=0))
+
+
+def test_fit_transform_not_associated_with_y_if_ordinal_categorical_is_not(
+    global_random_seed,
+):
+    cardinality = 30  # not too large, otherwise we need a very large n_samples
+    n_samples = 3000
+    rng = np.random.RandomState(global_random_seed)
+    y_train = rng.normal(size=n_samples)
+    X_train = rng.randint(0, cardinality, size=n_samples).reshape(-1, 1)
+
+    # Sort by y_train to attempt to cause a leak
+    y_sorted_indices = y_train.argsort()
+    y_train = y_train[y_sorted_indices]
+    X_train = X_train[y_sorted_indices]
+
+    target_encoder = TargetEncoder(shuffle=True, random_state=global_random_seed)
+    X_encoded_train_shuffled = target_encoder.fit_transform(X_train, y_train)
+
+    target_encoder = TargetEncoder(shuffle=False)
+    X_encoded_train_no_shuffled = target_encoder.fit_transform(X_train, y_train)
+
+    # Check that no information about y_train has leaked into X_train:
+    regressor = RandomForestRegressor(
+        n_estimators=10, min_samples_leaf=20, random_state=global_random_seed
+    )
+
+    # It's impossible to learn a good predictive model on the training set when
+    # using the original representation X_train or the target encoded
+    # representation with shuffled inner CV. For the latter, no information
+    # about y_train has inadvertently leaked into the prior used to generate
+    # `X_encoded_train_shuffled`:
+    cv = ShuffleSplit(n_splits=50, random_state=global_random_seed)
+    assert cross_val_score(regressor, X_train, y_train, cv=cv).mean() < 0.1
+    assert (
+        cross_val_score(regressor, X_encoded_train_shuffled, y_train, cv=cv).mean()
+        < 0.1
+    )
+
+    # Without the inner CV shuffling, a lot of information about y_train goes into the
+    # the per-fold y_train.mean() priors: shrinkage is no longer effective in this
+    # case and would no longer be able to prevent downstream over-fitting.
+    assert (
+        cross_val_score(regressor, X_encoded_train_no_shuffled, y_train, cv=cv).mean()
+        > 0.5
+    )
+
+
+def test_smooth_zero():
+    """Check edge case with zero smoothing and cv does not contain category."""
+    X = np.array([[0, 0, 0, 0, 0, 1, 1, 1, 1, 1]]).T
+    y = np.array([2.1, 4.3, 1.2, 3.1, 1.0, 9.0, 10.3, 14.2, 13.3, 15.0])
+
+    enc = TargetEncoder(smooth=0.0, shuffle=False, cv=2)
+    X_trans = enc.fit_transform(X, y)
+
+    # With cv = 2, category 0 does not exist in the second half, thus
+    # it will be encoded as the mean of the second half
+    assert_allclose(X_trans[0], np.mean(y[5:]))
+
+    # category 1 does nto exist in the first half, thus it will be encoded as
+    # the mean of the first half
+    assert_allclose(X_trans[-1], np.mean(y[:5]))
+
+
+@pytest.mark.parametrize("smooth", [0.0, 1e3, "auto"])
+def test_invariance_of_encoding_under_label_permutation(smooth, global_random_seed):
+    # Check that the encoding does not depend on the integer of the value of
+    # the integer labels. This is quite of a trivial property but it is helpful
+    # to understand the following test.
+    rng = np.random.RandomState(global_random_seed)
+
+    # Random y and informative categorical X to make the test non-trivial when
+    # using smoothing.
+    y = rng.normal(size=1000)
+    n_categories = 30
+    X = KBinsDiscretizer(n_bins=n_categories, encode="ordinal").fit_transform(
+        y.reshape(-1, 1)
+    )
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, random_state=global_random_seed
+    )
+
+    # Shuffle the labels to make sure that the encoding is invariant to the
+    # permutation of the labels
+    permutated_labels = rng.permutation(n_categories)
+    X_train_permuted = permutated_labels[X_train.astype(np.int32)]
+    X_test_permuted = permutated_labels[X_test.astype(np.int32)]
+
+    target_encoder = TargetEncoder(smooth=smooth, random_state=global_random_seed)
+    X_train_encoded = target_encoder.fit_transform(X_train, y_train)
+    X_test_encoded = target_encoder.transform(X_test)
+
+    X_train_permuted_encoded = target_encoder.fit_transform(X_train_permuted, y_train)
+    X_test_permuted_encoded = target_encoder.transform(X_test_permuted)
+
+    assert_allclose(X_train_encoded, X_train_permuted_encoded)
+    assert_allclose(X_test_encoded, X_test_permuted_encoded)
+
+
+# TODO(1.5) remove warning filter when kbd's subsample default is changed
+@pytest.mark.filterwarnings("ignore:In version 1.5 onwards, subsample=200_000")
+@pytest.mark.parametrize("smooth", [0.0, "auto"])
+def test_target_encoding_for_linear_regression(smooth, global_random_seed):
+    # Check some expected statistical properties when fitting a linear
+    # regression model on target encoded features depending on there relation
+    # with that target.
+
+    # In this test, we use the Ridge class with the "lsqr" solver and a little
+    # bit of regularization to implement a linear regression model that
+    # converges quickly for large `n_samples` and robustly in case of
+    # correlated features. Since we will fit this model on a mean centered
+    # target, we do not need to fit an intercept and this will help simplify
+    # the analysis with respect to the expected coefficients.
+    linear_regression = Ridge(alpha=1e-6, solver="lsqr", fit_intercept=False)
+
+    # Construct a random target variable. We need a large number of samples for
+    # this test to be stable across all values of the random seed.
+    n_samples = 50_000
+    rng = np.random.RandomState(global_random_seed)
+    y = rng.randn(n_samples)
+
+    # Generate a single informative ordinal feature with medium cardinality.
+    # Inject some irreducible noise to make it harder for a multivariate model
+    # to identify the informative feature from other pure noise features.
+    noise = 0.8 * rng.randn(n_samples)
+    n_categories = 100
+    X_informative = KBinsDiscretizer(
+        n_bins=n_categories,
+        encode="ordinal",
+        strategy="uniform",
+        random_state=rng,
+    ).fit_transform((y + noise).reshape(-1, 1))
+
+    # Let's permute the labels to hide the fact that this feature is
+    # informative to naive linear regression model trained on the raw ordinal
+    # values. As highlighted in the previous test, the target encoding should be
+    # invariant to such a permutation.
+    permutated_labels = rng.permutation(n_categories)
+    X_informative = permutated_labels[X_informative.astype(np.int32)]
+
+    # Generate a shuffled copy of the informative feature to destroy the
+    # relationship with the target.
+    X_shuffled = rng.permutation(X_informative)
+
+    # Also include a very high cardinality categorical feature that is by
+    # itself independent of the target variable: target encoding such a feature
+    # without internal cross-validation should cause catastrophic overfitting
+    # for the downstream regressor, even with shrinkage. This kind of features
+    # typically represents near unique idenfiers of samples. In general they
+    # should be removed from a machine learning datasets but here we want to
+    # study the ability of the default behavior of TargetEncoder to mitigate
+    # them automatically.
+    X_near_unique_categories = rng.choice(
+        int(0.9 * n_samples), size=n_samples, replace=True
+    ).reshape(-1, 1)
+
+    # Assemble the dataset and do a train-test split:
+    X = np.concatenate(
+        [X_informative, X_shuffled, X_near_unique_categories],
+        axis=1,
+    )
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+
+    # Let's first check that a linear regression model trained on the raw
+    # features underfits because of the meaning-less ordinal encoding of the
+    # labels.
+    raw_model = linear_regression.fit(X_train, y_train)
+    assert raw_model.score(X_train, y_train) < 0.1
+    assert raw_model.score(X_test, y_test) < 0.1
+
+    # Now do the same with target encoding using the internal CV mechanism
+    # implemented when using fit_transform.
+    model_with_cv = make_pipeline(
+        TargetEncoder(smooth=smooth, random_state=rng), linear_regression
+    ).fit(X_train, y_train)
+
+    # This model should be able to fit the data well and also generalise to the
+    # test data (assuming that the binning is fine-grained enough). The R2
+    # scores are not perfect because of the noise injected during the
+    # generation of the unique informative feature.
+    coef = model_with_cv[-1].coef_
+    assert model_with_cv.score(X_train, y_train) > 0.5, coef
+    assert model_with_cv.score(X_test, y_test) > 0.5, coef
+
+    # The target encoder recovers the linear relationship with slope 1 between
+    # the target encoded unique informative predictor and the target. Since the
+    # target encoding of the 2 other features is not informative thanks to the
+    # use of internal cross-validation, the multivariate linear regressor
+    # assigns a coef of 1 to the first feature and 0 to the other 2.
+    assert coef[0] == pytest.approx(1, abs=1e-2)
+    assert (np.abs(coef[1:]) < 0.2).all()
+
+    # Let's now disable the internal cross-validation by calling fit and then
+    # transform separately on the training set:
+    target_encoder = TargetEncoder(smooth=smooth, random_state=rng).fit(
+        X_train, y_train
+    )
+    X_enc_no_cv_train = target_encoder.transform(X_train)
+    X_enc_no_cv_test = target_encoder.transform(X_test)
+    model_no_cv = linear_regression.fit(X_enc_no_cv_train, y_train)
+
+    # The linear regression model should always overfit because it assigns
+    # too much weight to the extremely high cardinality feature relatively to
+    # the informative feature. Note that this is the case even when using
+    # the empirical Bayes smoothing which is not enough to prevent such
+    # overfitting alone.
+    coef = model_no_cv.coef_
+    assert model_no_cv.score(X_enc_no_cv_train, y_train) > 0.7, coef
+    assert model_no_cv.score(X_enc_no_cv_test, y_test) < 0.5, coef
+
+    # The model overfits because it assigns too much weight to the high
+    # cardinality yet non-informative feature instead of the lower
+    # cardinality yet informative feature:
+    assert abs(coef[0]) < abs(coef[2])


### PR DESCRIPTION
The long-term goal is to remove the `TargetEncoder` from `skrub` and use the one from `scikit-learn`. But since it's only available in 1.3 and `multiclass` support will only be available in 1.4, this PR proposes to vendor it in the mean time.

If the version of the installed `scikit-learn` is recent enough, i.e. 1.4 (which is not possible right now as it does not exist), `skrub` directly uses the `scikit-learn` version.

The vendored version reimplements the compiled parts in pure python and thus is slower than the `scikit-learn` version (approx 2x slower). This acceptable since as soon as `sklearn` 1.4 is release we can advise them to upgrade `sklearn` to get the best performance.

This PR proposes to warn the user who is importing the `TargetEncoder` from `skrub` when the version of `scikit-learn` is >= 1.4, saying that it should be imported from `sklearn`. When the `scikit-learn` version is lower, I chose to not raise a warning otherwise there would be no way to use it without getting a warning because `scikit-learn` 1.4 does not exist yet. I think it's better to completely deprecate the class after `scikit-learn` 1.4 is released.

There's still one thing missing in this PR: the support for multiclass. There's a PR in `scikit-learn` that is not merged yet (https://github.com/scikit-learn/scikit-learn/pull/26674).

TODO:
- [ ] synchronize with https://github.com/scikit-learn/scikit-learn/pull/26674 when it's merged.