### PR TITLE
MAINT Fix CI linter check and fix linting issues

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,7 +10,9 @@ jobs:
   check:
     name: A reviewer will let you know if it is required or can be bypassed
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'no changelog needed') == 0 || contains(github.event.pull_request.labels.*.name, 'CI') == 0 }}
+    if: |
+      ! contains(github.event.pull_request.labels.*.name, 'no changelog needed') &&
+      ! contains(github.event.pull_request.labels.*.name, 'CI')
     steps:
       - name: Get PR number and milestone
         run: |

--- a/.github/workflows/run-code-format-checks.yaml
+++ b/.github/workflows/run-code-format-checks.yaml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install pre-commit setup
       run: |
@@ -18,4 +18,4 @@ jobs:
         pre-commit install
 
     - name: Run checks
-      run: pre-commit run
+      run: pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/run-code-format-checks.yaml
+++ b/.github/workflows/run-code-format-checks.yaml
@@ -18,4 +18,4 @@ jobs:
         pre-commit install
 
     - name: Run checks
-      run: pre-commit run --all-files --show-diff-on-failure
+      run: pre-commit run -v --all-files --show-diff-on-failure

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -9,13 +9,11 @@ Date: June 2023
 """
 
 import math
-from utils import default_parser, find_result, monitor
-from utils.join import evaluate, fetch_big_data
-from argparse import ArgumentParser
 import numbers
-from time import perf_counter
 import warnings
+from argparse import ArgumentParser
 from collections.abc import Iterable
+from time import perf_counter
 from typing import Literal
 
 import matplotlib.pyplot as plt
@@ -23,6 +21,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from scipy.sparse import hstack, vstack
+from sklearn import random_projection
 from sklearn.feature_extraction.text import (
     HashingVectorizer,
     TfidfTransformer,
@@ -30,7 +29,8 @@ from sklearn.feature_extraction.text import (
 )
 from sklearn.neighbors import NearestNeighbors
 from sklearn.preprocessing import StandardScaler
-from sklearn import random_projection
+from utils import default_parser, find_result, monitor
+from utils.join import evaluate, fetch_big_data
 
 
 def _numeric_encoding(

--- a/benchmarks/bench_fuzzy_join_vs_others.py
+++ b/benchmarks/bench_fuzzy_join_vs_others.py
@@ -7,21 +7,22 @@ skrub's fuzzy_join outperforms all other methods.
 Date: September 2022
 """
 
-import numpy as np
-import pandas as pd
-import matplotlib.pyplot as plt
+import math
 from argparse import ArgumentParser
 from time import perf_counter
-import seaborn as sns
-import math
 
-from thefuzz.fuzz import partial_ratio
-from thefuzz import process
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 from autofj import AutoFJ
 from autofj.datasets import load_data
-from skrub import fuzzy_join
+from thefuzz import process
+from thefuzz.fuzz import partial_ratio
 from utils import default_parser, find_result, monitor
 from utils.join import evaluate
+
+from skrub import fuzzy_join
 
 
 def thefuzz_merge(
@@ -35,8 +36,10 @@ def thefuzz_merge(
         df_2: the right table to join
         left_on: key column of the left table
         right_on: key column of the right table
-        threshold: how close the matches should be to return a match, based on Levenshtein distance
-        limit: the amount of matches that will get returned, these are sorted high to low
+        threshold: how close the matches should be to return a match,
+                   based on Levenshtein distance
+        limit: the amount of matches that will get returned, these are sorted
+               high to low
 
     Return:
         Dataframe with boths keys and matches.
@@ -106,7 +109,7 @@ def benchmark(
             how="left",
             left_on="title",
             right_on="title",
-            suffixes=('_l', '_r')
+            suffixes=("_l", "_r"),
         )
         end_time = perf_counter()
         pr, re, f1 = evaluate(
@@ -125,8 +128,8 @@ def benchmark(
             list(zip(gt["title_l"], gt["title_r"])),
         )
     elif join == "thefuzz":
-        left_table.rename(columns={'title': 'title_l'}, inplace=True)
-        right_table.rename(columns={'title': 'title_r'}, inplace=True)
+        left_table.rename(columns={"title": "title_l"}, inplace=True)
+        right_table.rename(columns={"title": "title_r"}, inplace=True)
         start_time = perf_counter()
         joined_fj = thefuzz_merge(
             df_1=left_table,

--- a/benchmarks/bench_minhash_batch_number.py
+++ b/benchmarks/bench_minhash_batch_number.py
@@ -7,27 +7,24 @@ which is the batched version with batch_per_job=1
 Date: February 2023
 """
 
-from typing import Literal
+import pickle
+from argparse import ArgumentParser
 from collections.abc import Callable, Collection
+from pathlib import Path
+from typing import Literal
 
+import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
+import seaborn as sns
 from joblib import Parallel, delayed, effective_n_jobs
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices, murmurhash3_32
+from utils import default_parser, find_result, monitor
 
 from skrub._fast_hash import ngram_min_hash
 from skrub._string_distances import get_unique_ngrams
 from skrub._utils import LRUDict, check_input
-
-import pickle
-import pandas as pd
-import seaborn as sns
-import matplotlib.pyplot as plt
-from argparse import ArgumentParser
-
-from pathlib import Path
-
-from utils import monitor, find_result, default_parser
 from skrub.tests.utils import generate_data
 
 NoneType = type(None)

--- a/benchmarks/bench_tablevectorizer_tuning.py
+++ b/benchmarks/bench_tablevectorizer_tuning.py
@@ -5,32 +5,29 @@ among a selection.
 Date: September 2021
 """
 
-import seaborn as sns
-import pandas as pd
-import numpy as np
-import matplotlib.pyplot as plt
 import math
+from argparse import ArgumentParser
 
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
 from sklearn.ensemble import (
     HistGradientBoostingClassifier,
     HistGradientBoostingRegressor,
 )
-from sklearn.pipeline import Pipeline
 from sklearn.model_selection import cross_val_score
-
-
-from skrub import TableVectorizer, MinHashEncoder
-
-from argparse import ArgumentParser
+from sklearn.pipeline import Pipeline
 from utils import (
     default_parser,
     find_result,
-    monitor,
-    get_dataset,
     get_classification_datasets,
+    get_dataset,
     get_regression_datasets,
+    monitor,
 )
 
+from skrub import MinHashEncoder, TableVectorizer
 
 ###############################################
 # Benchmarking TableVectorizer parameters

--- a/benchmarks/utils/__init__.py
+++ b/benchmarks/utils/__init__.py
@@ -1,3 +1,22 @@
 from ._argparser import default_parser
-from ._various import choose_file, find_result, find_results, get_classification_datasets, get_regression_datasets, get_dataset
+from ._various import (
+    choose_file,
+    find_result,
+    find_results,
+    get_classification_datasets,
+    get_dataset,
+    get_regression_datasets,
+)
 from .monitor import monitor, repr_func
+
+__all__ = [
+    "default_parser",
+    "choose_file",
+    "find_result",
+    "find_results",
+    "get_classification_datasets",
+    "get_regression_datasets",
+    "get_dataset",
+    "monitor",
+    "repr_func",
+]

--- a/benchmarks/utils/_various.py
+++ b/benchmarks/utils/_various.py
@@ -1,18 +1,17 @@
 from pathlib import Path
 
+import pandas as pd
+
 from skrub.datasets import (
-    fetch_open_payments,
     fetch_drug_directory,
-    fetch_road_safety,
-    fetch_midwest_survey,
-    fetch_medical_charge,
     fetch_employee_salaries,
+    fetch_medical_charge,
+    fetch_midwest_survey,
+    fetch_open_payments,
+    fetch_road_safety,
     fetch_traffic_violations,
 )
-
 from skrub.datasets._fetching import DatasetAll
-
-import pandas as pd
 
 
 def find_result(bench_name: str) -> Path:

--- a/benchmarks/utils/join.py
+++ b/benchmarks/utils/join.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from skrub.datasets._utils import get_data_dir
 
 
@@ -22,7 +23,7 @@ def get_local_data(dataset_name: str, data_directory: str = None):
 def fetch_data(
     dataset_name: str, save: bool = True
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Fetch datasets from https://github.com/Yeye-He/Auto-Join/tree/master/autojoin-Benchmark
+    """Fetch datasets from https://github.com/Yeye-He/Auto-Join/tree/master/autojoin-Benchmark  # noqa
 
     Parameters
     ----------
@@ -70,7 +71,7 @@ def fetch_big_data(
     data_type: str = "Dirty",
     save: bool = True,
 ) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-    """Fetch datasets from https://github.com/anhaidgroup/deepmatcher/blob/master/Datasets.md
+    """Fetch datasets from https://github.com/anhaidgroup/deepmatcher/blob/master/Datasets.md  # noqa
 
     Parameters
     ----------

--- a/benchmarks/utils/monitor.py
+++ b/benchmarks/utils/monitor.py
@@ -1,12 +1,12 @@
 import tracemalloc
 from collections import defaultdict
+from collections.abc import Callable, Collection
 from datetime import datetime
 from itertools import product as _product
 from pathlib import Path
 from time import perf_counter
-from collections.abc import Callable, Collection
-from warnings import warn
 from typing import Any
+from warnings import warn
 
 import pandas as pd
 from tqdm import tqdm

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,9 +18,9 @@
 #
 import os
 import shutil
+import sys
 import warnings
 from datetime import datetime
-import sys
 
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory
@@ -29,7 +29,6 @@ import sys
 sys.path.insert(0, os.path.abspath("sphinxext"))
 from github_link import make_linkcode_resolve
 from sphinx_gallery.notebook import add_code_cell, add_markdown_cell
-
 
 # -- Copy files for docs --------------------------------------------------
 #
@@ -100,7 +99,10 @@ master_doc = "index"
 
 # General information about the project.
 project = "skrub"
-copyright = f"2018-2023, the dirty_cat developers, 2023-{datetime.now().year}, the skrub developers"
+copyright = (
+    f"2018-2023, the dirty_cat developers, 2023-{datetime.now().year}, the skrub"
+    " developers"
+)
 author = "skrub contributors"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -187,10 +189,13 @@ html_theme_options = {
     # "twitter_url": "https://twitter.com/PyData",
     "use_edit_page_button": True,
     "show_toc_level": 1,
-    "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
+    # "navbar_align": [left, content, right] to test that navbar items align properly
+    "navbar_align": "left",
     # "navbar_center": ["version-switcher", "navbar-nav"],
     "navbar_center": ["navbar-nav"],
-    "announcement": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/announcement.html",
+    "announcement": (
+        "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/announcement.html"
+    ),
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
@@ -317,8 +322,8 @@ intersphinx_mapping = {
 # -- sphinx-gallery configuration ---------------------------------------------
 from sphinx_gallery.sorting import FileNameSortKey  # noqa
 
-if 'dev' in release:
-    binder_branch = 'main'
+if "dev" in release:
+    binder_branch = "main"
 else:
     binder_branch = release
 
@@ -339,9 +344,9 @@ def notebook_modification_function(notebook_content, notebook_filename):
     if "06_ken_embeddings_example" in notebook_filename:
         message_class = "danger"
         message = (
-            "This example requires PyArrow, which is currently unavailable in Pyodide "
-            "(see https://github.com/pyodide/pyodide/issues/2933). Thus, this example cannot "
-            "be run in JupyterLite."
+            "This example requires PyArrow, which is currently unavailable in Pyodide"
+            " (see https://github.com/pyodide/pyodide/issues/2933). Thus, this example"
+            " cannot be run in JupyterLite."
         )
     else:
         message_class = "warning"
@@ -366,10 +371,12 @@ def notebook_modification_function(notebook_content, notebook_filename):
     code_lines.extend(
         [
             "import micropip",
-            "await micropip.install("
-            "'https://test-files.pythonhosted.org/packages/3c/03/"
-            "e1598c7abe536e56834f568f61497ad075d966c4c8fb7d0ad004b81e7bfc/"
-            "skrub-0.0.1.dev1-py3-none-any.whl')"
+            (
+                "await micropip.install("
+                "'https://test-files.pythonhosted.org/packages/3c/03/"
+                "e1598c7abe536e56834f568f61497ad075d966c4c8fb7d0ad004b81e7bfc/"
+                "skrub-0.0.1.dev1-py3-none-any.whl')"
+            ),
         ]
     )
 

--- a/doc/sphinxext/github_link.py
+++ b/doc/sphinxext/github_link.py
@@ -1,13 +1,13 @@
 """
-Taken from https://github.com/scikit-learn/scikit-learn/blob/3d4ee9e9dc384ea11724e270b51bd26a1f227f0c/doc/sphinxext/github_link.py
+Taken from https://github.com/scikit-learn/scikit-learn/blob/3d4ee9e9dc384ea11724e270b51bd26a1f227f0c/doc/sphinxext/github_link.py  # noqa
 """
 
-from operator import attrgetter
 import inspect
-import subprocess
 import os
+import subprocess
 import sys
 from functools import partial
+from operator import attrgetter
 
 REVISION_CMD = "git rev-parse --short HEAD"
 

--- a/doc/sphinxext/sphinx_issues.py
+++ b/doc/sphinxext/sphinx_issues.py
@@ -73,7 +73,6 @@ def cve_role(name, rawtext, text, lineno, inliner, options=None, content=None):
 
 
 class IssueRole(object):
-
     EXTERNAL_REPO_REGEX = re.compile(r"^(\w+)/(.+)([#@])([\w]+)$")
 
     def __init__(

--- a/examples/01_dirty_categories.py
+++ b/examples/01_dirty_categories.py
@@ -150,12 +150,7 @@ np.unique(y)
 # We will now experiment with encoders specially made for handling
 # dirty columns:
 
-from skrub import (
-    SimilarityEncoder,
-    TargetEncoder,
-    MinHashEncoder,
-    GapEncoder,
-)
+from skrub import GapEncoder, MinHashEncoder, SimilarityEncoder, TargetEncoder
 
 encoders = {
     "one-hot": one_hot,
@@ -195,8 +190,8 @@ for name, method in encoders.items():
 #
 # Finally, we plot the scores on a boxplot:
 
-import seaborn
 import matplotlib.pyplot as plt
+import seaborn
 
 plt.figure(figsize=(4, 3))
 ax = seaborn.boxplot(data=pd.DataFrame(all_scores), orient="h")

--- a/examples/02_investigating_dirty_categories.py
+++ b/examples/02_investigating_dirty_categories.py
@@ -52,7 +52,8 @@ print(data["employee_position_title"].value_counts().sort_index())
 #   will create orthogonal features, whereas it is clear that
 #   those 3 terms have a lot in common.
 #
-# * If we wanted to use word embedding methods such as `Word2vec <https://www.tensorflow.org/tutorials/text/word2vec>`_,
+# * If we wanted to use word embedding methods such as
+#   `Word2vec <https://www.tensorflow.org/tutorials/text/word2vec>`_,
 #   we would have to go through a cleaning phase: those algorithms
 #   are not trained to work on data such as "Accountant/Auditor I".
 #   However, this can be error-prone and time-consuming.

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -34,7 +34,7 @@ warnings.filterwarnings("ignore")
 import pandas as pd
 
 data = pd.read_csv(
-    "https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/air_quality_no2_long.csv"
+    "https://raw.githubusercontent.com/pandas-dev/pandas/main/doc/data/air_quality_no2_long.csv"  # noqa
 )
 y = data["value"]
 X = data[["city", "date.utc"]]
@@ -47,6 +47,7 @@ X
 # Encoders for categorical and datetime features
 # ..............................................
 from sklearn.preprocessing import OneHotEncoder
+
 from skrub import DatetimeEncoder
 
 cat_encoder = OneHotEncoder(handle_unknown="ignore")
@@ -78,13 +79,14 @@ encoder.get_feature_names_out()
 ###############################################################################
 X_
 
+from pprint import pprint
+
 ###############################################################################
 # One-liner with the |TV|
 # .......................
 # The |DtE| is used by default in the |TV|, which
 # automatically detects datetime features.
 from skrub import TableVectorizer
-from pprint import pprint
 
 table_vec = TableVectorizer()
 table_vec.fit_transform(X)

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -79,13 +79,13 @@ encoder.get_feature_names_out()
 ###############################################################################
 X_
 
-from pprint import pprint
-
 ###############################################################################
 # One-liner with the |TV|
 # .......................
 # The |DtE| is used by default in the |TV|, which
 # automatically detects datetime features.
+from pprint import pprint
+
 from skrub import TableVectorizer
 
 table_vec = TableVectorizer()

--- a/examples/04_fuzzy_joining_and_FeatureAugmenter.py
+++ b/examples/04_fuzzy_joining_and_FeatureAugmenter.py
@@ -11,8 +11,9 @@ an exact match on the other side.
 The |fj| function enables to join tables without cleaning the data by
 accounting for the label variations.
 
-To illustrate, we will join data from the `2022 World Happiness Report <https://worldhappiness.report/>`_.
-with tables provided in `the World Bank open data platform <https://data.worldbank.org/>`_
+To illustrate, we will join data from the
+`2022 World Happiness Report <https://worldhappiness.report/>`_, with tables
+provided in `the World Bank open data platform <https://data.worldbank.org/>`_
 in order to create a first prediction model.
 
 Moreover, the |fa| is a scikit-learn Transformer that makes it easy to
@@ -34,7 +35,7 @@ machine-learning pipeline. In particular, it enables tuning parameters of
 import pandas as pd
 
 df = pd.read_csv(
-    "https://raw.githubusercontent.com/dirty-cat/datasets/master/data/Happiness_report_2022.csv",
+    "https://raw.githubusercontent.com/dirty-cat/datasets/master/data/Happiness_report_2022.csv",  # noqa
     thousands=",",
 )
 df.drop(df.tail(1).index, inplace=True)
@@ -109,6 +110,9 @@ gdppc.sort_values(by="Country Name").tail(7)
 # we have extracted.
 #
 
+# We will ignore the warnings:
+import warnings
+
 ###############################################################################
 # .. _example_fuzzy_join:
 #
@@ -117,9 +121,6 @@ gdppc.sort_values(by="Country Name").tail(7)
 #
 # To join them with skrub, we only need to do the following:
 from skrub import fuzzy_join
-
-# We will ignore the warnings:
-import warnings
 
 warnings.filterwarnings("ignore")
 
@@ -151,7 +152,7 @@ df1.tail(20)
 # .. topic:: Note:
 #
 #    This would all be missed out if we were using other methods such as
-#    `pandas.merge <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html>`_,
+#    `pandas.merge <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.merge.html>`_,  # noqa
 #    which can only find exact matches.
 #    In this case, to reach the best result, we would have to `manually` clean
 #    the data (e.g. remove the * after country name) and look
@@ -385,12 +386,13 @@ df_final = fa.fit_transform(df)
 
 df_final.head(10)
 
+from sklearn.compose import make_column_transformer
+
 ##########################################################################
 # And that's it! As previously, we now have a big table
 # ready for machine learning.
 # Let's create our machine learning pipeline:
 from sklearn.pipeline import make_pipeline
-from sklearn.compose import make_column_transformer
 
 # We include only the columns that will be pertinent for our regression:
 encoder = make_column_transformer(

--- a/examples/04_fuzzy_joining_and_FeatureAugmenter.py
+++ b/examples/04_fuzzy_joining_and_FeatureAugmenter.py
@@ -386,12 +386,11 @@ df_final = fa.fit_transform(df)
 
 df_final.head(10)
 
-from sklearn.compose import make_column_transformer
-
 ##########################################################################
 # And that's it! As previously, we now have a big table
 # ready for machine learning.
 # Let's create our machine learning pipeline:
+from sklearn.compose import make_column_transformer
 from sklearn.pipeline import make_pipeline
 
 # We include only the columns that will be pertinent for our regression:

--- a/examples/05_deduplication.py
+++ b/examples/05_deduplication.py
@@ -37,6 +37,7 @@ misspelled category names in an unsupervised manner.
 
 
 import numpy as np
+
 from skrub.datasets import make_deduplication_data
 
 # our three medication names
@@ -86,12 +87,14 @@ plt.ylabel("Counts")
 # --------------------------------------------------------------------
 #
 # Below we use a heatmap to visualize the pairwise-distance between medication names.
-# A darker color means that two medication names are closer together (i.e. more similar),
-# a lighter color means a larger distance. We can see that we are dealing with three
-# clusters - the original medication names and their misspellings that cluster around them.
+# A darker color means that two medication names are closer together
+# (i.e. more similar), a lighter color means a larger distance. We can see that we are
+# dealing with three clusters - the original medication names and their misspellings
+# that cluster around them.
+
+from scipy.spatial.distance import squareform
 
 from skrub import compute_ngram_distance
-from scipy.spatial.distance import squareform
 
 ngram_distances = compute_ngram_distance(unique_examples)
 square_distances = squareform(ngram_distances)
@@ -114,7 +117,7 @@ sns.heatmap(
 #
 # The number of clusters will need some adjustment depending on the data you have.
 # If no fixed number of clusters is given, |dd| tries to set it automatically
-# via the `silhouette score <https://scikit-learn.org/stable/modules/clustering.html#silhouette-coefficient>`_.
+# via the `silhouette score <https://scikit-learn.org/stable/modules/clustering.html#silhouette-coefficient>`_.  # noqa
 
 from skrub import deduplicate
 
@@ -136,9 +139,9 @@ plt.ylabel("Counts")
 # In this example we can correct all spelling mistakes by using the ideal number
 # of clusters as determined by the silhouette score.
 #
-# However, often the translation/deduplication won't be perfect and will require some tweaks.
-# In this case, we can construct and update a translation table based on the data
-# returned by |dd|.
+# However, often the translation/deduplication won't be perfect and will require some
+# tweaks. In this case, we can construct and update a translation table based on the
+# data returned by |dd|.
 # It consists of the (potentially) misspelled category names as indices and the
 # (potentially) correct categories as values.
 

--- a/examples/06_ken_embeddings_example.py
+++ b/examples/06_ken_embeddings_example.py
@@ -58,10 +58,11 @@ X.head(3)
 y = X["Global_Sales"]
 y
 
+import matplotlib.pyplot as plt
+
 ###############################################################################
 # Let's take a look at the distribution of our target variable:
 import seaborn as sns
-import matplotlib.pyplot as plt
 
 sns.set_theme(style="ticks")
 
@@ -177,8 +178,8 @@ X_full = fa2.fit_transform(X_full)
 # that will be included in the learning process and the appropriate encoding of
 # categorical variables using the |MinHash| and |OneHotEncoder|:
 from sklearn.compose import make_column_transformer
-
 from sklearn.preprocessing import OneHotEncoder
+
 from skrub import MinHashEncoder
 
 min_hash = MinHashEncoder(n_components=100)

--- a/examples/06_ken_embeddings_example.py
+++ b/examples/06_ken_embeddings_example.py
@@ -58,10 +58,10 @@ X.head(3)
 y = X["Global_Sales"]
 y
 
-import matplotlib.pyplot as plt
 
 ###############################################################################
 # Let's take a look at the distribution of our target variable:
+import matplotlib.pyplot as plt
 import seaborn as sns
 
 sns.set_theme(style="ticks")

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,17 +82,33 @@ max-line-length = 88
 target-version = ['py310']
 # Default flake8 3.5 ignored flags
 ignore=
-    E24,   # check ignored by default in flake8. Meaning unclear.
-    E121,  # continuation line under-indented
-    E123,  # closing bracket does not match indentation
-    E126,  # continuation line over-indented for hanging indent
-    E203,  # space before : (needed for how black formats slicing)
-    E226,  # missing whitespace around arithmetic operator
-    E704,  # multiple statements on one line (def)
-    E731,  # do not assign a lambda expression, use a def
-    E741,  # do not use variables named 'l', 'O', or 'I'
-    W503,  # line break before binary operator
-    W504   # line break after binary operator
+    # check ignored by default in flake8. Meaning unclear.
+    E24,
+    # continuation line under-indented
+    E121,
+    # closing bracket does not match indentation
+    E123,
+    # continuation line over-indented for hanging indent
+    E126,
+    # space before : (needed for how black formats slicing)
+    E203,
+    # missing whitespace around arithmetic operator
+    E226,
+    # multiple statements on one line (def)
+    E704,
+    # do not assign a lambda expression, use a def
+    E731,
+    # do not use variables named 'l', 'O', or 'I'
+    E741,
+    # line break before binary operator
+    W503,
+    # line break after binary operator
+    W504
+per-file-ignores =
+# It's fine not to put the import at the top of the file in the examples
+# folder.
+    examples/*:E402
+    doc/conf.py:E402
 exclude=
     .git,
     __pycache__,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
 
-
 if __name__ == "__main__":
     setup()

--- a/skrub/_check_dependencies.py
+++ b/skrub/_check_dependencies.py
@@ -1,4 +1,5 @@
-from importlib.metadata import requires, version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, requires, version
+
 from packaging.requirements import Requirement
 
 
@@ -18,8 +19,8 @@ def check_dependencies():
             installed_dep = version(req.name)
             if not req.specifier.contains(installed_dep):
                 raise ImportError(
-                    f"{package_name} {package_version} requires {req!s} "
-                    f"but you have {req.name} {installed_dep} installed, which is incompatible."
+                    f"{package_name} {package_version} requires {req!s} but you have"
+                    f" {req.name} {installed_dep} installed, which is incompatible."
                 )
 
         except PackageNotFoundError:

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -121,9 +121,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
         return {
             "X_types": ["2darray", "categorical"],
             "allow_nan": True,
-            "_xfail_checks": {
-                "check_dtype_object": "Specific datetime error."
-            },
+            "_xfail_checks": {"check_dtype_object": "Specific datetime error."},
         }
 
     def _validate_keywords(self):

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -20,7 +20,7 @@ from sklearn.neighbors import NearestNeighbors
 from sklearn.utils import check_random_state, gen_batches
 from sklearn.utils.extmath import row_norms, safe_sparse_dot
 from sklearn.utils.fixes import _object_dtype_isnan
-from sklearn.utils.validation import check_is_fitted, _num_samples
+from sklearn.utils.validation import _num_samples, check_is_fitted
 
 from ._utils import check_input
 

--- a/skrub/_target_encoder.py
+++ b/skrub/_target_encoder.py
@@ -7,7 +7,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.preprocessing import LabelEncoder
 from sklearn.utils import check_array
 from sklearn.utils.fixes import _object_dtype_isnan
-from sklearn.utils.validation import check_is_fitted, _check_y
+from sklearn.utils.validation import _check_y, check_is_fitted
 
 from skrub._utils import check_input
 

--- a/skrub/datasets/__init__.py
+++ b/skrub/datasets/__init__.py
@@ -13,7 +13,11 @@ from ._fetching import (
     get_data_dir,
 )
 from ._generating import make_deduplication_data
-from ._ken_embeddings import fetch_ken_embeddings, fetch_ken_table_aliases, fetch_ken_types
+from ._ken_embeddings import (
+    fetch_ken_embeddings,
+    fetch_ken_table_aliases,
+    fetch_ken_types,
+)
 
 __all__ = [
     "DatasetAll",

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -397,8 +397,8 @@ def _fetch_figshare(
                     raise OSError(
                         f"{filehandle!r} SHA256 checksum differs from "
                         f"expected ({checksum}!={expected_checksum}) ; "
-                        f"file is probably corrupted. Please try again. "
-                        f"If the error persists, please open an issue on GitHub. "
+                        "file is probably corrupted. Please try again. "
+                        "If the error persists, please open an issue on GitHub. "
                     )
 
             df = ParquetFile(filehandle)

--- a/skrub/datasets/tests/test_ken_embeddings.py
+++ b/skrub/datasets/tests/test_ken_embeddings.py
@@ -1,6 +1,10 @@
 import pytest
 
-from skrub.datasets import fetch_ken_embeddings, fetch_ken_table_aliases, fetch_ken_types
+from skrub.datasets import (
+    fetch_ken_embeddings,
+    fetch_ken_table_aliases,
+    fetch_ken_types,
+)
 
 
 def test_fetch_ken_table_aliases():

--- a/skrub/tests/test_fuzzy_join.py
+++ b/skrub/tests/test_fuzzy_join.py
@@ -3,8 +3,8 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.feature_extraction.text import HashingVectorizer
 from pandas.testing import assert_frame_equal
+from sklearn.feature_extraction.text import HashingVectorizer
 
 from skrub import fuzzy_join
 
@@ -294,9 +294,7 @@ def test_numerical_column() -> None:
 
     assert fj_num.shape == (n_samples, n_cols)
 
-    fj_num2 = fuzzy_join(
-        left, right, on="int", return_score=True
-    )
+    fj_num2 = fuzzy_join(left, right, on="int", return_score=True)
     assert fj_num2.shape == (n_samples, n_cols + 1)
 
     fj_num3 = fuzzy_join(
@@ -336,9 +334,7 @@ def test_datetime_column():
             "str1": ["aa", "a", "bb"],
             "date_x": pd.to_datetime(["10/10/2022", "12/11/2021", "09/25/2011"]),
             "str2": ["aa", "bb", "a"],
-            "date_y": pd.to_datetime(
-                ["09/10/2022", "12/24/2021", "09/25/2010"]
-            ),
+            "date_y": pd.to_datetime(["09/10/2022", "12/24/2021", "09/25/2010"]),
         }
     )
     assert_frame_equal(fj_time, fj_time_expected)
@@ -348,9 +344,7 @@ def test_datetime_column():
 
     assert fj_time.shape == (n_samples, n_cols)
 
-    fj_time2 = fuzzy_join(
-        left, right, on="date", return_score=True
-    )
+    fj_time2 = fuzzy_join(left, right, on="date", return_score=True)
     assert fj_time2.shape == (n_samples, n_cols + 1)
 
     fj_time3 = fuzzy_join(
@@ -393,21 +387,19 @@ def test_mixed_joins():
     fj_num = fuzzy_join(left, right, on=["int1", "int2"])
 
     expected_fj_num = pd.DataFrame(
-            {
-                "str1": ["Paris", "Paris", "Paris"],
-                "str2": ["Texas", "France", "Greek God"],
-                "int1_x": [10, 2, 5],
-                "int2_x": [103, 250, 532],
-                "date_x": pd.to_datetime(["10/10/2022", "12/11/2021", "09/25/2011"]),
-                "str_1": ["Paris", "Paris", "dd"],
-                "str_2": ["FR", "FR", "dd"],
-                "int1_y": [6, 6, 6],
-                "int2_y": [146, 146, 612],
-                "date_y": pd.to_datetime(
-                    ["12/24/2021", "12/24/2021", "02/21/2000"]
-                )
-            }
-        )
+        {
+            "str1": ["Paris", "Paris", "Paris"],
+            "str2": ["Texas", "France", "Greek God"],
+            "int1_x": [10, 2, 5],
+            "int2_x": [103, 250, 532],
+            "date_x": pd.to_datetime(["10/10/2022", "12/11/2021", "09/25/2011"]),
+            "str_1": ["Paris", "Paris", "dd"],
+            "str_2": ["FR", "FR", "dd"],
+            "int1_y": [6, 6, 6],
+            "int2_y": [146, 146, 612],
+            "date_y": pd.to_datetime(["12/24/2021", "12/24/2021", "02/21/2000"]),
+        }
+    )
     assert_frame_equal(fj_num, expected_fj_num)
     assert fj_num.shape == (3, 10)
 
@@ -419,18 +411,20 @@ def test_mixed_joins():
         right_on=["str_1", "str_2"],
     )
 
-    expected_fj_str = pd.DataFrame({
-        "str1": ["Paris", "Paris", "Paris"],
-        "str2": ["Texas", "France", "Greek God"],
-        "int1_x": [10, 2, 5],
-        "int2_x": [103, 250, 532],
-        "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
-        "str_1": ["Paris", "Paris", "Paris"],
-        "str_2": ["TX", "FR", "GR Mytho"],
-        "int1_y": [55, 6, 2],
-        "int2_y": [554, 146, 32],
-        "date_y": pd.to_datetime(["2022-09-10", "2021-12-24", "2010-09-25"]),
-    })
+    expected_fj_str = pd.DataFrame(
+        {
+            "str1": ["Paris", "Paris", "Paris"],
+            "str2": ["Texas", "France", "Greek God"],
+            "int1_x": [10, 2, 5],
+            "int2_x": [103, 250, 532],
+            "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
+            "str_1": ["Paris", "Paris", "Paris"],
+            "str_2": ["TX", "FR", "GR Mytho"],
+            "int1_y": [55, 6, 2],
+            "int2_y": [554, 146, 32],
+            "date_y": pd.to_datetime(["2022-09-10", "2021-12-24", "2010-09-25"]),
+        }
+    )
     assert_frame_equal(fj_str, expected_fj_str)
     assert fj_str.shape == (3, 10)
 
@@ -441,18 +435,20 @@ def test_mixed_joins():
         left_on=["str1", "str2", "int2"],
         right_on=["str_1", "str_2", "int2"],
     )
-    expected_fj_mixed = pd.DataFrame({
-        "str1": ["Paris", "Paris", "Paris"],
-        "str2": ["Texas", "France", "Greek God"],
-        "int1_x": [10, 2, 5],
-        "int2_x": [103, 250, 532],
-        "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
-        "str_1": ["Paris", "Paris", "Paris"],
-        "str_2": ["FR", "FR", "TX"],
-        "int1_y": [6, 6, 55],
-        "int2_y": [146, 146, 554],
-        "date_y": pd.to_datetime(["2021-12-24", "2021-12-24", "2022-09-10"]),
-    })
+    expected_fj_mixed = pd.DataFrame(
+        {
+            "str1": ["Paris", "Paris", "Paris"],
+            "str2": ["Texas", "France", "Greek God"],
+            "int1_x": [10, 2, 5],
+            "int2_x": [103, 250, 532],
+            "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
+            "str_1": ["Paris", "Paris", "Paris"],
+            "str_2": ["FR", "FR", "TX"],
+            "int1_y": [6, 6, 55],
+            "int2_y": [146, 146, 554],
+            "date_y": pd.to_datetime(["2021-12-24", "2021-12-24", "2022-09-10"]),
+        }
+    )
     assert_frame_equal(fj_mixed, expected_fj_mixed)
     assert fj_mixed.shape == (3, 10)
 
@@ -463,18 +459,20 @@ def test_mixed_joins():
         left_on=["str1", "date"],
         right_on=["str_1", "date"],
     )
-    expected_fj_mixed2 = pd.DataFrame({
-        "str1": ["Paris", "Paris", "Paris"],
-        "str2": ["Texas", "France", "Greek God"],
-        "int1_x": [10, 2, 5],
-        "int2_x": [103, 250, 532],
-        "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
-        "str_1": ["Paris", "Paris", "Paris"],
-        "str_2": ["TX", "FR", "GR Mytho"],
-        "int1_y": [55, 6, 2],
-        "int2_y": [554, 146, 32],
-        "date_y": pd.to_datetime(["2022-09-10", "2021-12-24", "2010-09-25"]),
-    })
+    expected_fj_mixed2 = pd.DataFrame(
+        {
+            "str1": ["Paris", "Paris", "Paris"],
+            "str2": ["Texas", "France", "Greek God"],
+            "int1_x": [10, 2, 5],
+            "int2_x": [103, 250, 532],
+            "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
+            "str_1": ["Paris", "Paris", "Paris"],
+            "str_2": ["TX", "FR", "GR Mytho"],
+            "int1_y": [55, 6, 2],
+            "int2_y": [554, 146, 32],
+            "date_y": pd.to_datetime(["2022-09-10", "2021-12-24", "2010-09-25"]),
+        }
+    )
     assert_frame_equal(fj_mixed2, expected_fj_mixed2)
     assert fj_mixed2.shape == (3, 10)
 
@@ -485,18 +483,20 @@ def test_mixed_joins():
         left_on=["int1", "date"],
         right_on=["int1", "date"],
     )
-    expected_fj_mixed3 = pd.DataFrame({
-        "str1": ["Paris", "Paris", "Paris"],
-        "str2": ["Texas", "France", "Greek God"],
-        "int1_x": [10, 2, 5],
-        "int2_x": [103, 250, 532],
-        "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
-        "str_1": ["Paris", "Paris", "Paris"],
-        "str_2": ["FR", "FR", "GR Mytho"],
-        "int1_y": [6, 6, 2],
-        "int2_y": [146, 146, 32],
-        "date_y": pd.to_datetime(["2021-12-24", "2021-12-24", "2010-09-25"]),
-    })
+    expected_fj_mixed3 = pd.DataFrame(
+        {
+            "str1": ["Paris", "Paris", "Paris"],
+            "str2": ["Texas", "France", "Greek God"],
+            "int1_x": [10, 2, 5],
+            "int2_x": [103, 250, 532],
+            "date_x": pd.to_datetime(["2022-10-10", "2021-12-11", "2011-09-25"]),
+            "str_1": ["Paris", "Paris", "Paris"],
+            "str_2": ["FR", "FR", "GR Mytho"],
+            "int1_y": [6, 6, 2],
+            "int2_y": [146, 146, 32],
+            "date_y": pd.to_datetime(["2021-12-24", "2021-12-24", "2010-09-25"]),
+        }
+    )
     assert_frame_equal(fj_mixed3, expected_fj_mixed3)
     assert fj_mixed3.shape == (3, 10)
 

--- a/skrub/tests/test_similarity_encoder.py
+++ b/skrub/tests/test_similarity_encoder.py
@@ -181,7 +181,9 @@ def test_similarity_encoder() -> None:
 def test_ngram_similarity_matrix(analyzer) -> None:
     X1 = np.array(["cat1", "cat2", "cat3"])
     X2 = np.array(["cata1", "caat2", "ccat3"])
-    sim = ngram_similarity_matrix(X1, X2, ngram_range=(2, 2), analyzer=analyzer, hashing_dim=5)
+    sim = ngram_similarity_matrix(
+        X1, X2, ngram_range=(2, 2), analyzer=analyzer, hashing_dim=5
+    )
     assert sim.shape == (len(X1), len(X2))
 
 

--- a/skrub/tests/test_sklearn.py
+++ b/skrub/tests/test_sklearn.py
@@ -1,15 +1,13 @@
 import numpy as np
 import pytest
-
 import sklearn
 from sklearn.metrics.pairwise import linear_kernel, pairwise_distances
-from sklearn.utils.estimator_checks import (
-    _is_pairwise_metric,
-    parametrize_with_checks,
-)
 from sklearn.utils._tags import _safe_tags
+from sklearn.utils.estimator_checks import _is_pairwise_metric, parametrize_with_checks
 
-from skrub import (
+from skrub._utils import parse_version
+
+from skrub import (  # isort:skip
     DatetimeEncoder,
     # FeatureAugmenter,
     GapEncoder,
@@ -18,7 +16,6 @@ from skrub import (
     TableVectorizer,
     # TargetEncoder,
 )
-from skrub._utils import parse_version
 
 
 def _enforce_estimator_tags_X_monkey_patch(estimator, X, kernel=linear_kernel):

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -260,7 +260,7 @@ def test_duplicate_column_names() -> None:
     data = [(3, "a"), (2, "b"), (1, "c"), (0, "d")]
     X_dup_col_names = pd.DataFrame.from_records(data, columns=["col_1", "col_1"])
 
-    with pytest.raises(AssertionError,  match=r"Duplicate column names"):
+    with pytest.raises(AssertionError, match=r"Duplicate column names"):
         tablevectorizer.fit_transform(X_dup_col_names)
 
 


### PR DESCRIPTION
all pre-commit hooks are always skipped on the CI. I guess it's because by default pre-commit only runs on staged changes but in the CI there are no staged changes. I propose to always run on all files (it's fast).

I added new rules for flake8 to ignore imports not at top of file for examples and confs.