### PR TITLE
FIX check_dependencies takes prereleases into account

### DIFF
--- a/skrub/_check_dependencies.py
+++ b/skrub/_check_dependencies.py
@@ -16,7 +16,7 @@ def check_dependencies():
 
         try:
             installed_dep = version(req.name)
-            if not req.specifier.contains(installed_dep):
+            if not req.specifier.contains(installed_dep, prereleases=True):
                 raise ImportError(
                     f"{package_name} {package_version} requires {req!s} "
                     f"but you have {req.name} {installed_dep} installed, which is incompatible."


### PR DESCRIPTION
currently check_dependencies fails when scikit-learn=1.4.0.dev0 for instance.

The fix is to include prereleases in the version check, as documented here
https://packaging.pypa.io/en/stable/specifiers.html#packaging.specifiers.Specifier.contains