### PR TITLE
Fix randomly failing deduplicate test

### DIFF
--- a/skrub/tests/test_deduplicate.py
+++ b/skrub/tests/test_deduplicate.py
@@ -155,7 +155,7 @@ def test_backend_respected():
     """
     # Test that parallelism works
     X = make_deduplication_data(
-        examples=["black", "white"], entries_per_example=[15, 15]
+        examples=["black", "white"], entries_per_example=[15, 15], random_state=0
     )
     deduplicate(X, n_jobs=2)
 


### PR DESCRIPTION
`test_backend_respected` from `test_deduplicate` is randomly failing when `make_deduplication_data` doesn't generate enough variation (#673), which breaks the CI. This PR sets the random_state of `make_deduplication_data` to prevent the failure.

