### PR TITLE
FIX make sure to clone remainder in TableVectorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,7 +57,7 @@ Major changes
 * Fixes a bug in :class:`TableVectorizer` where `remainder` is now cloned if this is
   a transformer such that the same instance is not shared between different
   transformers.
-  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`
+  :pr:`678` by :user:`Guillaume Lemaitre <glemaitre>`
 
 Minor changes
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,8 +54,8 @@ Major changes
   compliance with the scikit-learn API.
   :pr:`647` by :user:`Guillaume Lemaitre <glemaitre>`
 
-* Fixes a bug in :class:`TableVectorizer` where `remainder` is now cloned if this is
-  a transformer such that the same instance is not shared between different
+* Fixes a bug in :class:`TableVectorizer` with `remainder`: it is now cloned if it's
+  a transformer so that the same instance is not shared between different
   transformers.
   :pr:`678` by :user:`Guillaume Lemaitre <glemaitre>`
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,11 @@ Major changes
   compliance with the scikit-learn API.
   :pr:`647` by :user:`Guillaume Lemaitre <glemaitre>`
 
+* Fixes a bug in :class:`TableVectorizer` where `remainder` is now cloned if this is
+  a transformer such that the same instance is not shared between different
+  transformers.
+  :pr:`xxx` by :user:`Guillaume Lemaitre <glemaitre>`
+
 Minor changes
 -------------
 

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -425,7 +425,12 @@ class TableVectorizer(ColumnTransformer):
                 drop="if_binary", handle_unknown="infrequent_if_exist"
             )
         elif self.low_card_cat_transformer == "remainder":
-            self.low_card_cat_transformer_ = self.remainder
+            remainder = (
+                self.remainder
+                if isinstance(self.remainder, str)
+                else clone(self.remainder)
+            )
+            self.low_card_cat_transformer_ = remainder
         else:
             self.low_card_cat_transformer_ = self.low_card_cat_transformer
 
@@ -434,7 +439,12 @@ class TableVectorizer(ColumnTransformer):
         elif self.high_card_cat_transformer is None:
             self.high_card_cat_transformer_ = GapEncoder(n_components=30)
         elif self.high_card_cat_transformer == "remainder":
-            self.high_card_cat_transformer_ = self.remainder
+            remainder = (
+                self.remainder
+                if isinstance(self.remainder, str)
+                else clone(self.remainder)
+            )
+            self.high_card_cat_transformer_ = remainder
         else:
             self.high_card_cat_transformer_ = self.high_card_cat_transformer
 
@@ -443,7 +453,12 @@ class TableVectorizer(ColumnTransformer):
         elif self.numerical_transformer is None:
             self.numerical_transformer_ = "passthrough"
         elif self.numerical_transformer == "remainder":
-            self.numerical_transformer_ = self.remainder
+            remainder = (
+                self.remainder
+                if isinstance(self.remainder, str)
+                else clone(self.remainder)
+            )
+            self.numerical_transformer_ = remainder
         else:
             self.numerical_transformer_ = self.numerical_transformer
 
@@ -452,7 +467,12 @@ class TableVectorizer(ColumnTransformer):
         elif self.datetime_transformer is None:
             self.datetime_transformer_ = DatetimeEncoder()
         elif self.datetime_transformer == "remainder":
-            self.datetime_transformer_ = self.remainder
+            remainder = (
+                self.remainder
+                if isinstance(self.remainder, str)
+                else clone(self.remainder)
+            )
+            self.datetime_transformer_ = remainder
         else:
             self.datetime_transformer_ = self.datetime_transformer
 
@@ -581,8 +601,8 @@ class TableVectorizer(ColumnTransformer):
                     raise e
                 warnings.warn(
                     f"Value '{culprit}' could not be converted to infered type"
-                    f" {str(dtype)} in column '{col}'. Such values will be replaced by"
-                    " NaN.",
+                    f" {str(dtype)} in column '{col}'. Such values will be replaced"
+                    " by NaN.",
                     UserWarning,
                     stacklevel=2,
                 )

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -425,12 +425,11 @@ class TableVectorizer(ColumnTransformer):
                 drop="if_binary", handle_unknown="infrequent_if_exist"
             )
         elif self.low_card_cat_transformer == "remainder":
-            remainder = (
+            self.low_card_cat_transformer_ = (
                 self.remainder
                 if isinstance(self.remainder, str)
                 else clone(self.remainder)
             )
-            self.low_card_cat_transformer_ = remainder
         else:
             self.low_card_cat_transformer_ = self.low_card_cat_transformer
 
@@ -439,12 +438,11 @@ class TableVectorizer(ColumnTransformer):
         elif self.high_card_cat_transformer is None:
             self.high_card_cat_transformer_ = GapEncoder(n_components=30)
         elif self.high_card_cat_transformer == "remainder":
-            remainder = (
+            self.high_card_cat_transformer_ = (
                 self.remainder
                 if isinstance(self.remainder, str)
                 else clone(self.remainder)
             )
-            self.high_card_cat_transformer_ = remainder
         else:
             self.high_card_cat_transformer_ = self.high_card_cat_transformer
 
@@ -453,12 +451,11 @@ class TableVectorizer(ColumnTransformer):
         elif self.numerical_transformer is None:
             self.numerical_transformer_ = "passthrough"
         elif self.numerical_transformer == "remainder":
-            remainder = (
+            self.numerical_transformer_ = (
                 self.remainder
                 if isinstance(self.remainder, str)
                 else clone(self.remainder)
             )
-            self.numerical_transformer_ = remainder
         else:
             self.numerical_transformer_ = self.numerical_transformer
 
@@ -467,12 +464,11 @@ class TableVectorizer(ColumnTransformer):
         elif self.datetime_transformer is None:
             self.datetime_transformer_ = DatetimeEncoder()
         elif self.datetime_transformer == "remainder":
-            remainder = (
+            self.datetime_transformer_ = (
                 self.remainder
                 if isinstance(self.remainder, str)
                 else clone(self.remainder)
             )
-            self.datetime_transformer_ = remainder
         else:
             self.datetime_transformer_ = self.datetime_transformer
 
@@ -601,7 +597,7 @@ class TableVectorizer(ColumnTransformer):
                     raise e
                 warnings.warn(
                     f"Value '{culprit}' could not be converted to infered type"
-                    f" {str(dtype)} in column '{col}'. Such values will be replaced"
+                    f" {dtype!s} in column '{col}'. Such values will be replaced"
                     " by NaN.",
                     UserWarning,
                     stacklevel=2,

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sklearn.exceptions import NotFittedError
-from sklearn.preprocessing import StandardScaler
+from sklearn.preprocessing import FunctionTransformer, StandardScaler
 from sklearn.utils.validation import check_is_fitted
 
 from skrub import GapEncoder, SuperVectorizer, TableVectorizer
@@ -756,3 +756,22 @@ def test_changing_types_int_float():
     table_vec.fit_transform(X_fit)
     res = table_vec.transform(X_transform)
     assert np.allclose(res, np.array([[1.0], [2.0], [3.3]]))
+
+
+def test_table_vectorizer_remainder_cloning():
+    """Check that remainder is cloned when used."""
+    df1 = _get_clean_dataframe()
+    df2 = _get_datetimes_dataframe()
+    df = pd.concat([df1, df2], axis=1)
+    remainder = FunctionTransformer()
+    table_vectorizer = TableVectorizer(
+        low_card_cat_transformer="remainder",
+        high_card_cat_transformer="remainder",
+        numerical_transformer="remainder",
+        datetime_transformer="remainder",
+        remainder=remainder,
+    ).fit(df)
+    assert table_vectorizer.low_card_cat_transformer_ is not remainder
+    assert table_vectorizer.high_card_cat_transformer_ is not remainder
+    assert table_vectorizer.numerical_transformer_ is not remainder
+    assert table_vectorizer.datetime_transformer_ is not remainder


### PR DESCRIPTION
Make sure to clone `remainder` when it is a transformer such that this is not an instance shared across transformers.

This test is highly relevant for https://github.com/skrub-data/skrub/pull/675