### PR TITLE
docs(install): add '' around pip install -e .[dev] (#695)

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -88,7 +88,7 @@ with the development requirements:
 .. code:: console
 
     $ cd skrub
-    $ pip install -e .[dev]
+    $ pip install -e '.[dev]'
 
 Next step, enable the pre-commit hooks:
 


### PR DESCRIPTION
Fixes #695