### PR TITLE
TimeSeriesSplit definition in example 3 is duplicated

### DIFF
--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -32,9 +32,6 @@ It is used by default in the |TableVectorizer|.
 .. |make_column_transformer| replace::
     :class:`~sklearn.compose.make_column_transformer`
 
-.. |TimeSeriesSplit| replace::
-    :class:`~sklearn.model_selection.TimeSeriesSplit`
-
 .. |HGBR| replace::
     :class:`~sklearn.ensemble.HistGradientBoostingRegressor`
 """


### PR DESCRIPTION
***What does this PR implement?***
Fix the [Circle CI error](https://app.circleci.com/pipelines/github/skrub-data/skrub/2616/workflows/081cb0aa-c49d-493e-be10-514619e3ad1b/jobs/5167) from PR #680

***What changes***
Remove the duplicate line:

```
.. |TimeSeriesSplit| replace::
    :class:`~sklearn.model_selection.TimeSeriesSplit`
```

In the substitute name definition of our example 3.