### PR TITLE
Use RandomState rng instead of np.random in `make_duplicate()`

### DIFF
--- a/skrub/datasets/_generating.py
+++ b/skrub/datasets/_generating.py
@@ -52,7 +52,7 @@ def make_deduplication_data(
         # Randomly pick with which character to replace
         replacements = [
             string.ascii_lowercase[i]
-            for i in np.random.choice(np.arange(26), len(mis_idx)).astype(int)
+            for i in rng.choice(np.arange(26), len(mis_idx)).astype(int)
         ]
         # Introduce spelling mistakes at right examples and char locations per example
         str_as_list[mis_idx // len_ex, mis_idx % len_ex] = replacements


### PR DESCRIPTION
***What does this PR implement?***
PR #700 experienced what seems to be [a rare error](https://github.com/skrub-data/skrub/actions/runs/5928122276/job/16073058088?pr=700) from a non-deterministic function, making the test unstable.

***What changes***
Replace np.random.choice with the random state provided in input to make the test stable.

***Additional comments***
This rare error might mean the deduplicate function returns unexpected results when the problem is ill-conditioned. This instability will need further investigation.