### PR TITLE
DOC Fix url page missing in our example 3

### DIFF
--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -1,5 +1,5 @@
 """
-.. _example_datetime_encoder
+.. _example_datetime_encoder :
 
 ===================================================
 Handling datetime features with the DatetimeEncoder


### PR DESCRIPTION
***What does this PR implement?***
Fixes https://github.com/skrub-data/skrub/issues/716

***What changes***
A typo at the top of the `03_datetime_encoder.py` file generated an error during sphinx tree parsing. We had the following warning when building the doc:
```
doc/auto_examples/03_datetime_encoder.rst:21: WARNING: malformed hyperlink target.
```
Removing the typo seems to make the example accessible again.