### PR TITLE
Fix Badges on README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@
    :width: 50 %
    :alt: skrub logo
 
-.. class:: center
-    |py_ver| |pypi_var| |pypi_dl| |codecov| |circleci| |black|
+
+|py_ver| |pypi_var| |pypi_dl| |codecov| |circleci| |black|
 
 .. |py_ver| image:: https://img.shields.io/pypi/pyversions/skrub
 .. |pypi_var| image:: https://img.shields.io/pypi/v/skrub?color=informational


### PR DESCRIPTION
***What does this PR implement?***
Fix https://github.com/skrub-data/skrub/issues/624

***What changes***
The centering directive needed a line break with the badges to render. After doing that, the rendering wasn't even centered, so I removed the directive entirely.