### PR TITLE
Fix TableVectorizer `get_feature_names_out`

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -839,7 +839,9 @@ class TableVectorizer(ColumnTransformer):
         ct_feature_names = super().get_feature_names_out()
         all_trans_feature_names = []
 
-        for name, trans, cols, _ in self._iter(fitted=True):
+        for name, trans, cols, _ in self._iter(
+            fitted=True, replace_strings=False, column_as_strings=False
+        ):
             if isinstance(trans, str):
                 if trans == "drop":
                     continue


### PR DESCRIPTION
**Reference**
Fix a breaking change introduced in scikit-learn private method `ColumnTransformer._iter` by https://github.com/scikit-learn/scikit-learn/pull/27005 at https://github.com/scikit-learn/scikit-learn/pull/27005/files#diff-fea489154c629a45ec01030d191f20465e809124a24260ac35fb884bc855140fR365.

**What changes**
Add keyword arguments when calling _iter within the `TableVectorizer.get_feature_names_out` method.

**Aditionnal comments**
I wonder how sustainable this is and if there's a way to avoid relying on this private method.


