### PR TITLE
MAINT Fix `feature_name` warning during `transform` for `MinHashEncoder`

### DIFF
--- a/skrub/_minhash_encoder.py
+++ b/skrub/_minhash_encoder.py
@@ -275,8 +275,8 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
             Transformed input.
         """
         check_is_fitted(self, "hash_dict_")
-        X = check_input(X)
         self._check_feature_names(X, reset=False)
+        X = check_input(X)
         self._check_n_features(X, reset=False)
         if self.minmax_hash:
             if self.n_components % 2 != 0:


### PR DESCRIPTION
**References**
Addresses https://github.com/skrub-data/skrub/issues/704

**What changes**
https://github.com/skrub-data/skrub/pull/647 introduced a warning upon running the `transform` method from `MinHashEncoder`. This is due to `check_input(X)` returning a numpy array, which we pass to `self._check_feature_names`. This latter method raises a warning because it's expecting a Pandas DataFrame.

**Alternative solutions**
Remove `_check_feature_names` entirely, but I wouldn't recommend that.

**Additionnal comment**
Overall, I'm concerned that skrub is becoming increasingly more coupled with scikit-learn private methods. Changes made to these private methods (like https://github.com/skrub-data/skrub/pull/722, even though https://github.com/skrub-data/skrub/pull/675 is an attempt to decouple stuff) take time to fix in skrub, and we just don't have enough maintainers as of today, IMHO.

WDYT @GaelVaroquaux and @glemaitre ?