### PR TITLE
MAINT Fix pandas nightly

### DIFF
--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -506,9 +506,11 @@ def fuzzy_join(
     if drop_unmatched:
         df_joined.drop(columns=["fj_idx"], inplace=True)
     else:
-        idx = df_joined.index[df_joined["fj_nan"] == 1]
-        if len(idx) != 0:
-            df_joined.iloc[idx, df_joined.columns.get_loc("fj_idx") :] = np.NaN
+        mask_na = df_joined["fj_nan"] == 1
+        if mask_na.sum() > 0:
+            right_cols = df_joined.columns[df_joined.columns.get_loc("fj_idx") :]
+            df_joined[right_cols] = pd.DataFrame.convert_dtypes(df_joined[right_cols])
+            df_joined.loc[mask_na, right_cols] = pd.NA
         df_joined.drop(columns=["fj_idx", "fj_nan"], inplace=True)
 
     if return_score:

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -507,7 +507,7 @@ def fuzzy_join(
         df_joined.drop(columns=["fj_idx"], inplace=True)
     else:
         mask_na = df_joined["fj_nan"] == 1
-        if mask_na.sum() > 0:
+        if mask_na.any():
             right_cols = df_joined.columns[df_joined.columns.get_loc("fj_idx") :]
             df_joined[right_cols] = pd.DataFrame.convert_dtypes(df_joined[right_cols])
             df_joined.loc[mask_na, right_cols] = pd.NA


### PR DESCRIPTION
**Reference**
Fix https://github.com/skrub-data/skrub/issues/691

**What does this PR implement?***
Pandas is deprecated setting values to columns of different types. In particular, setting np.nan across columns that are not float is deprecated.

We now need to [convert the dataframe to nullable dtypes](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.convert_dtypes.html#pandas.DataFrame.convert_dtypes), accepting pd.NA as values.