### PR TITLE
Initialize self.transformers in init to fix grid search for TableVectorizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,9 @@ Minor changes
   which provides some more information about the job title.
   :pr:`581` by :user:`Lilian Boulard <LilianBoulard>`
 
+* Fix bug preventing to grid search parameters of transformers defined in
+  `specific_transformers` of :class:`TableVectorizer`. :pr:`731` by :user:`Leo Grinsztajn <LeoGrin>`
+
 Before skrub: dirty_cat
 ========================
 

--- a/examples/08_grid_searching_with_the_tablevectorizer.py
+++ b/examples/08_grid_searching_with_the_tablevectorizer.py
@@ -109,7 +109,7 @@ pprint(tv.transformers_)
 
 from sklearn.model_selection import GridSearchCV
 from sklearn.pipeline import make_pipeline
-from sklearn.ensemble import HistGradientBoostingClassifier
+from sklearn.ensemble import HistGradientBoostingRegressor
 from skrub import GapEncoder
 
 pipeline = make_pipeline(
@@ -119,7 +119,7 @@ pipeline = make_pipeline(
             ("mh_dep_name", MinHashEncoder(), ["department_name"]),
         ],
     ),
-    HistGradientBoostingClassifier(),
+    HistGradientBoostingRegressor(),
 )
 
 params = {

--- a/examples/08_grid_searching_with_the_tablevectorizer.py
+++ b/examples/08_grid_searching_with_the_tablevectorizer.py
@@ -129,6 +129,10 @@ params = {
 
 grid_search = GridSearchCV(pipeline, param_grid=params)
 
+grid_search.fit(X, y)
+
+print(grid_search.best_params_)
+
 ###############################################################################
 # Conclusion
 # ----------

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -411,6 +411,15 @@ class TableVectorizer(ColumnTransformer):
         self.transformer_weights = transformer_weights
         self.verbose = verbose
 
+        self.transformers: list[tuple[str, Transformer, list[str]]] = [
+            ("numeric", self.numerical_transformer, []),
+            ("datetime", self.datetime_transformer, []),
+            ("low_card_cat", self.low_card_cat_transformer, []),
+            ("high_card_cat", self.high_card_cat_transformer, []),
+        ]
+        if self.specific_transformers is not None:
+            self.transformers.extend(self.specific_transformers)
+
     def _more_tags(self) -> dict:
         """
         Used internally by sklearn to ease the estimator checks.


### PR DESCRIPTION
Fix #709

If `self.transformers` is defined in init, `self._transformers` (`ColumnTransformer`'s property) is set, and thus the inherited `get_params` and `set_params` work, which means that doing this kind of things work:
```
pipeline = make_pipeline(
    TableVectorizer(
        high_card_cat_transformer=GapEncoder(),
        specific_transformers=[
            ("mh_dep_name", MinHashEncoder(), ["department_name"]),
        ],
    ),
    HistGradientBoostingClassifier(),
)

params = {
    "tablevectorizer__mh_dep_name__n_components": [25, 50],
}

grid_search = GridSearchCV(pipeline, param_grid=params)
``` 

I think that not copying the original transformers is okay, as they are copied immediately when using `fit`, but I'm not 100% sure. (If we use `_clone_transformers` in init, we'll have to rename self.low_card_cat_transformers_ etc prevent `check_is_fitted` from breaking).