### PR TITLE
FEAT Add `aggregate` and `join` functions for Pandas and Polars

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -52,6 +52,8 @@ jobs:
               - dependencies-version: "dev"
               - dependencies-version: "dev, pyarrow"
                 python-version: "3.11"
+              - dependencies-version: "dev, polars"
+                python-version: "3.11"
               - dependencies-version: "dev, min-py310"
                 python-version: "3.10"
                 dependencies-version-type: "minimal"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ development and backward compatibility is not ensured.
 Major changes
 -------------
 
+* :func:`dataframe.pd_join`, :func:`dataframe.pd_aggregate`,
+  :func:`dataframe.pl_join` and :func:`dataframe.pl_aggregate`
+  are now available in the dataframe submodule.
+  :pr:`??` by :user:`Vincent Maladiere <Vincent-Maladiere>`
+
 * :class:`FeatureAugmenter` is renamed to :class:`Joiner`.
   :pr:`674` by :user:`Jovan Stojanovic <jovan-stojanovic>`
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Major changes
 * :func:`dataframe.pd_join`, :func:`dataframe.pd_aggregate`,
   :func:`dataframe.pl_join` and :func:`dataframe.pl_aggregate`
   are now available in the dataframe submodule.
-  :pr:`??` by :user:`Vincent Maladiere <Vincent-Maladiere>`
+  :pr:`733` by :user:`Vincent Maladiere <Vincent-Maladiere>`
 
 * :class:`FeatureAugmenter` is renamed to :class:`Joiner`.
   :pr:`674` by :user:`Jovan Stojanovic <jovan-stojanovic>`

--- a/build_tools/github/install.sh
+++ b/build_tools/github/install.sh
@@ -13,7 +13,7 @@ fi
 
 pip install --progress-bar off --only-binary :all: --no-binary liac-arff --upgrade ".[$DEPS_VERSION]"
 
-if [[ "$DEPS_VERSION" != *"pyarrow"* ]]; then
+if [[ "$DEPS_VERSION" != *"pyarrow"* && "$DEPS_VERSION" != *"polars"* ]]; then
     # Since pyarrow is a dependency of pandas, we need to uninstall it explicitly
     pip uninstall -y pyarrow
 fi

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -84,6 +84,46 @@ This page lists all available functions and classes of `skrub`.
 
    deduplicate
 
+.. raw:: html   
+
+   <h2>Dataframes operations</h2>
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+   :nosignatures:
+   :caption: DataFrames operations
+
+   dataframe.get_df_namespace
+
+.. raw:: html
+
+   <h3>Pandas</h3>
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+   :nosignatures:
+   :caption: DataFrames operations
+
+   dataframe.is_pandas
+   dataframe.pd_aggregate
+   dataframe.pd_join
+
+.. raw:: html
+
+   <h3>Polars</h3>
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+   :nosignatures:
+   :caption: DataFrames operations
+
+   dataframe.is_polars
+   dataframe.pl_aggregate
+   dataframe.pl_join
+
 .. raw:: html
 
    <h2>Data download and generation</h2>

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -104,7 +104,7 @@ This page lists all available functions and classes of `skrub`.
    :toctree: generated/
    :template: function.rst
    :nosignatures:
-   :caption: DataFrames operations
+   :caption: Pandas operations
 
    dataframe.is_pandas
    dataframe.pd_aggregate
@@ -118,7 +118,7 @@ This page lists all available functions and classes of `skrub`.
    :toctree: generated/
    :template: function.rst
    :nosignatures:
-   :caption: DataFrames operations
+   :caption: Polars operations
 
    dataframe.is_polars
    dataframe.pl_aggregate

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ dev =
     pre-commit
 pyarrow =
     pyarrow
+polars =
+    pyarrow
+    polars
 doc =
     sphinx-gallery@git+https://github.com/sphinx-gallery/sphinx-gallery
     pydata-sphinx-theme

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -121,3 +121,10 @@ def parse_astype_error_message(e):
         if match:
             culprit = match.group(1)
     return culprit
+
+
+def atleast_1d_or_none(x):
+    """``np.atleast_1d`` helper returning an empty list when x is None"""
+    if x is None:
+        return []
+    return np.atleast_1d(x).tolist()

--- a/skrub/dataframe/__init__.py
+++ b/skrub/dataframe/__init__.py
@@ -1,0 +1,19 @@
+from skrub.dataframe._namespace import get_df_namespace, is_pandas, is_polars
+from skrub.dataframe._pandas import aggregate as pd_aggregate
+from skrub.dataframe._pandas import join as pd_join
+from skrub.dataframe._polars import aggregate as pl_aggregate
+from skrub.dataframe._polars import join as pl_join
+from skrub.dataframe._types import POLARS_SETUP, DataFrameLike, SeriesLike
+
+__all__ = [
+    POLARS_SETUP,
+    DataFrameLike,
+    SeriesLike,
+    get_df_namespace,
+    is_pandas,
+    is_polars,
+    pd_join,
+    pd_aggregate,
+    pl_join,
+    pl_aggregate,
+]

--- a/skrub/dataframe/_namespace.py
+++ b/skrub/dataframe/_namespace.py
@@ -45,7 +45,9 @@ def is_polars(dataframe: DataFrameLike) -> bool:
     return isinstance(dataframe, (pl.DataFrame, pl.LazyFrame))
 
 
-def get_df_namespace(*dfs: list[DataFrameLike]) -> tuple[ModuleType, ModuleType]:
+def get_df_namespace(
+    *dfs: DataFrameLike | list[DataFrameLike],
+) -> tuple[ModuleType, ModuleType]:
     """Get the namespaces of dataframes.
 
     Introspects dataframes and returns their skrub namespace object
@@ -62,7 +64,7 @@ def get_df_namespace(*dfs: list[DataFrameLike]) -> tuple[ModuleType, ModuleType]
 
     Parameters
     ----------
-    dfs : list[DataFrameLike],
+    dfs : DataFrameLike | list[DataFrameLike],
         The dataframes to extract modules from.
 
     Returns
@@ -85,7 +87,7 @@ def get_df_namespace(*dfs: list[DataFrameLike]) -> tuple[ModuleType, ModuleType]
         ):
             return skrub_pl, pl
         else:
-            raise TypeError("Mixing polars lazyframes and dataframes is not supported.")
+            raise TypeError("Mixing Polars lazyframes and dataframes is not supported.")
 
     else:
         modules = [type(df).__module__ for df in dfs]

--- a/skrub/dataframe/_namespace.py
+++ b/skrub/dataframe/_namespace.py
@@ -1,0 +1,101 @@
+import sys
+from types import ModuleType
+
+import pandas as pd
+
+import skrub.dataframe._pandas as skrub_pd
+import skrub.dataframe._polars as skrub_pl
+from skrub.dataframe._types import DataFrameLike
+
+
+def is_pandas(dataframe: DataFrameLike) -> bool:
+    """Check whether the input is a Pandas dataframe.
+
+    Parameters
+    ----------
+    dataframe : DataFrameLike
+        The input dataframe
+
+    Returns
+    -------
+    is_pandas : bool
+        Whether the dataframe is a Pandas dataframe or not.
+    """
+    return isinstance(dataframe, pd.DataFrame)
+
+
+def is_polars(dataframe: DataFrameLike) -> bool:
+    """Check whether the input is a Polars dataframe or lazyframe.
+
+    Parameters
+    ----------
+    dataframe : DataFrameLike
+        The input dataframe
+
+    Returns
+    -------
+    is_polars : bool
+        Whether the dataframe is a Polars dataframe/lazyframe or not.
+    """
+    if "polars" not in sys.modules:
+        return False
+
+    import polars as pl
+
+    return isinstance(dataframe, (pl.DataFrame, pl.LazyFrame))
+
+
+def get_df_namespace(*dfs: list[DataFrameLike]) -> tuple[ModuleType, ModuleType]:
+    """Get the namespaces of dataframes.
+
+    Introspects dataframes and returns their skrub namespace object
+    ``skrub.dataframe._{pandas, polars}`` and the dataframe module
+    ``{polars, pandas}`` itself.
+
+    The dataframes passed in input need to come from the same module, otherwise a
+    ``TypeError`` will be raised.
+
+    The outputs of this function are denoted ``skrub_px`` and ``px`` in reference to
+    the array API, returning namespace (NumPy, PyTorch and CuPy) as ``nx``.
+    Since we deal with Polars (``pl``) and Pandas (``pd``), we use ``px``
+    as a variable name.
+
+    Parameters
+    ----------
+    dfs : list[DataFrameLike],
+        The dataframes to extract modules from.
+
+    Returns
+    -------
+    skrub_px : ModuleType
+        Skrub namespace shared by dataframe objects.
+
+    px : ModuleType
+        Dataframe namespace, i.e. Pandas or Polars module.
+    """
+    # FIXME Pandas and Polars series will raise errors.
+    if all([is_pandas(df) for df in dfs]):
+        return skrub_pd, pd
+
+    elif all([is_polars(df) for df in dfs]):
+        import polars as pl
+
+        if all([isinstance(df, pl.DataFrame) for df in dfs]) or all(
+            [isinstance(df, pl.LazyFrame) for df in dfs]
+        ):
+            return skrub_pl, pl
+        else:
+            raise TypeError("Mixing polars lazyframes and dataframes is not supported.")
+
+    else:
+        modules = [type(df).__module__ for df in dfs]
+        if all([is_polars(df) or is_pandas(df) for df in dfs]):
+            raise TypeError(
+                "Mixing Pandas and Polars dataframes is not supported, "
+                f"got {modules=!r}."
+            )
+        else:
+            raise TypeError(
+                "Only Pandas or Polars dataframes are currently supported, "
+                f"got {modules=!r}."
+            )

--- a/skrub/dataframe/_pandas.py
+++ b/skrub/dataframe/_pandas.py
@@ -1,0 +1,294 @@
+"""
+Pandas specialization of the aggregate and join operation.
+"""
+import re
+from collections.abc import Callable
+from itertools import product
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from skrub._utils import atleast_1d_or_none
+
+
+def aggregate(
+    table: pd.DataFrame,
+    key: str | Iterable[str],
+    cols_to_agg: str | Iterable[str],
+    num_operations: str | Iterable[str] = ("mean",),
+    categ_operations: str | Iterable[str] = ("mode",),
+    suffix: str | None = None,
+) -> pd.DataFrame:
+    """Aggregate a Pandas dataframe.
+
+    This function uses the ``dataframe.groupby(key).agg`` method from Pandas.
+
+    Parameters
+    ----------
+    table : pd.DataFrame,
+        The input dataframe to aggregate.
+
+    key : str or Iterable[str],
+        The columns used as keys to aggregate on.
+
+    cols_to_agg : str or Iterable[str],
+        The columns to aggregate.
+
+    num_operations : str or Iterable[str],
+        The reduction functions to apply on numerical columns
+        in ``cols_to_agg`` during the aggregation.
+
+    categ_operations : str or Iterable[str],
+        The reduction functions to apply on categorical columns
+        in ``cols_to_agg`` during the aggregation.
+
+    suffix : str, optional
+        The suffix appended to output columns.
+
+    Returns
+    -------
+    group : pd.DataFrame,
+        The aggregated output.
+    """
+    if not isinstance(table, pd.DataFrame):
+        raise TypeError(f"'table' must be a pandas dataframe, got {type(table)!r}.")
+
+    key = atleast_1d_or_none(key)
+    cols_to_agg = atleast_1d_or_none(cols_to_agg)
+    num_operations = atleast_1d_or_none(num_operations)
+    categ_operations = atleast_1d_or_none(categ_operations)
+    suffix = "" if suffix is None else suffix
+
+    num_cols, categ_cols = split_num_categ_cols(table[cols_to_agg])
+
+    num_named_agg, num_value_counts = get_named_agg(table, num_cols, num_operations)
+    categ_named_agg, categ_value_counts = get_named_agg(
+        table, categ_cols, categ_operations
+    )
+
+    named_agg = {**num_named_agg, **categ_named_agg}
+    if named_agg:
+        base_group = table.groupby(key).agg(**named_agg)
+    else:
+        base_group = None
+
+    # 'histogram' and 'value_counts' requires a pivot
+    value_counts = {**num_value_counts, **categ_value_counts}
+    for output_key, (col_to_agg, kwargs) in value_counts.items():
+        serie_group = table.groupby(key)[col_to_agg].value_counts(**kwargs)
+        serie_group.name = output_key
+        pivot = (
+            serie_group.reset_index()
+            .pivot(index=key, columns=col_to_agg)
+            .reset_index()
+            .fillna(0)
+        )
+        cols = pivot.columns.droplevel(0)
+        index_cols = np.atleast_1d(key).tolist()
+        feature_cols = (f"{col_to_agg}_" + cols[len(index_cols) :].astype(str)).tolist()
+        cols = [*index_cols, *feature_cols]
+        pivot.columns = cols
+
+        if base_group is None:
+            base_group = pivot
+        else:
+            base_group = base_group.merge(pivot, on=key, how="left")
+
+    if base_group is None:
+        raise ValueError("No aggregation to perform.")
+
+    base_group.columns = [
+        f"{col}{suffix}" if col not in key else col for col in base_group.columns
+    ]
+    sorted_cols = sorted(base_group.columns)
+
+    return base_group[sorted_cols]
+
+
+def join(
+    left: pd.DataFrame,
+    right: pd.DataFrame,
+    left_on: str | Iterable[str],
+    right_on: str | Iterable[str],
+) -> pd.DataFrame:
+    """Left join two Pandas dataframes.
+
+    This function uses the ``dataframe.merge`` method from Pandas.
+
+    Parameters
+    ----------
+    left : pd.DataFrame,
+        The left dataframe to left-join.
+
+    right : pd.DataFrame,
+        The right dataframe to left-join.
+
+    left_on : str or Iterable[str],
+        Left keys to merge on.
+
+    right_on : str or Iterable[str],
+        Right keys to merge on.
+
+    Returns
+    -------
+    merged : pd.DataFrame,
+        The merged output.
+    """
+    if not (isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame)):
+        raise TypeError(
+            "'left' and 'right' must be pandas dataframes, "
+            f"got {type(left)!r} and {type(right)!r}."
+        )
+    return left.merge(
+        right,
+        how="left",
+        left_on=left_on,
+        right_on=right_on,
+    )
+
+
+def get_named_agg(
+    table: pd.DataFrame, cols: list[str], operations: list[str]
+) -> tuple[dict, dict]:
+    """Map aggregation tuples to their output key.
+
+    The dictionary has the form: output_key = (column, aggfunc).
+    This is used as input for the ``dataframe.agg`` method from Pandas.
+
+    'value_counts' and 'hist' operation require to pivot
+    the tables and treated in a separate mapping.
+
+    Parameters
+    ----------
+    table : pd.DataFrame,
+        Input dataframe, only used to compute bins values if
+        'value_counts' or 'hist' are operations.
+
+    cols : list,
+        The columns to aggregate.
+
+    operations : list,
+        The reduce operations to perform.
+
+    Returns
+    -------
+    named_agg : dict,
+        Named aggregation mapping.
+
+    value_counts : dict,
+        ``value_counts`` operations mapping.
+    """
+    named_agg, value_counts = {}, {}
+    for col, operation in product(cols, operations):
+        op_root, bin_args = _parse_argument(operation)
+        aggfunc, bin_args = _get_aggfunc(table[col], op_root, bin_args)
+
+        output_key = f"{col}_{op_root}"
+        # 'value_counts' change the index of the resulting frame
+        # and must be treated separately.
+        if aggfunc == "value_counts":
+            value_counts[output_key] = (col, bin_args)
+        else:
+            named_agg[output_key] = (col, aggfunc)
+
+    return named_agg, value_counts
+
+
+def _parse_argument(operation: str) -> tuple[str, int | None]:
+    """Split a text input into a function name and its argument.
+
+    Parameters
+    ----------
+    operation : str,
+        The operation to parse.
+
+    Returns
+    -------
+    operation_root : str,
+        The name of the operation before parenthesis, if any.
+
+    bin_args : int,
+        The number of bin to create for ``hist`` or ``value_counts``.
+
+    Examples
+    --------
+    >>> _parse_argument("hist(10)")
+    "hist", 10
+
+    """
+    split = re.split("\\(.+\\)", operation)
+    op_root = split[0]
+    if len(split) > 1:
+        # remove op_root
+        bin_args = re.split(f"^{op_root}", operation)
+        bin_args = bin_args[1]
+        # remove parenthesis
+        bin_args = re.sub("\\(|\\)", "", bin_args)
+        bin_args = int(bin_args)
+        return op_root, bin_args
+    else:
+        return op_root, None
+
+
+PANDAS_OPS_MAPPING = {
+    "mode": pd.Series.mode,
+    "quantile": pd.Series.quantile,
+    "hist": "value_counts",
+}
+
+
+def _get_aggfunc(
+    serie: pd.Series, op_root: str, n_bins: int
+) -> tuple[str | Callable, dict]:
+    """Map operation roots to their pandas agg functions.
+
+    When args is provided for histogram or value_counts,
+    we create args
+
+    Parameters
+    ----------
+    serie : pd.Series,
+        Input series, used to compute the bins if n_bins is provided.
+
+    op_root : str,
+        Operation root, the operation without the bin argument, if any.
+
+    n_bins : int,
+        The number of bin to create when value_counts or hist operation are used.
+
+    Returns
+    -------
+    aggfunc : str or callable,
+        The pandas agg functions to perform
+
+    bins_args : dict,
+        The bins to create when using value_counts or hist.
+    """
+    aggfunc = PANDAS_OPS_MAPPING.get(op_root, op_root)
+
+    if n_bins is not None:
+        # histogram and value_counts
+        if aggfunc == "value_counts":
+            # If bins is a number, we need to set a fix bin range,
+            # otherwise bins edges will be defined dynamically for
+            # each rows.
+            min_, max_ = serie.min(), serie.max()
+            bins = np.linspace(min_, max_, n_bins + 1)
+            bins_args = dict(bins=bins)
+        else:
+            raise ValueError(
+                f"Operator {op_root!r} doesn't take any argument, got {n_bins!r}"
+            )
+    else:
+        bins_args = {}
+
+    return aggfunc, bins_args
+
+
+def split_num_categ_cols(table):
+    """Split dataframe columns between numerical and categorical."""
+    num_cols = table.select_dtypes("number").columns
+    categ_cols = table.select_dtypes(["object", "string", "category"]).columns
+
+    return num_cols, categ_cols

--- a/skrub/dataframe/_pandas.py
+++ b/skrub/dataframe/_pandas.py
@@ -20,7 +20,7 @@ def aggregate(
     categ_operations: str | Iterable[str] = ("mode",),
     suffix: str | None = None,
 ) -> pd.DataFrame:
-    """Aggregate a Pandas dataframe.
+    """Aggregates a :obj:`pandas.DataFrame`.
 
     This function uses the ``dataframe.groupby(key).agg`` method from Pandas.
 
@@ -112,7 +112,7 @@ def join(
     left_on: str | Iterable[str],
     right_on: str | Iterable[str],
 ) -> pd.DataFrame:
-    """Left join two Pandas dataframes.
+    """Left join two :obj:`pandas.DataFrame`.
 
     This function uses the ``dataframe.merge`` method from Pandas.
 

--- a/skrub/dataframe/_polars.py
+++ b/skrub/dataframe/_polars.py
@@ -22,7 +22,7 @@ def aggregate(
     categ_operations: str | Iterable[str] = ("mode",),
     suffix: str | None = None,
 ) -> DataFrameLike:
-    """Aggregate a Polars dataframe or lazyframe.
+    """Aggregate a :obj:`polars.DataFrame` or :obj:`polars.LazyFrame`.
 
     This function uses the ``dataframe.group_by(key).agg`` method from Polars.
 
@@ -93,7 +93,7 @@ def join(
     left_on: str | Iterable[str],
     right_on: str | Iterable[str],
 ) -> DataFrameLike:
-    """Left join two Polars dataframes or lazyframes.
+    """Left join two :obj:`polars.DataFrame` or :obj:`polars.LazyFrame`.
 
     This function uses the ``dataframe.join`` method from Polars.
 

--- a/skrub/dataframe/_polars.py
+++ b/skrub/dataframe/_polars.py
@@ -1,0 +1,218 @@
+"""
+Polars specialization of the aggregate and join operations.
+"""
+from typing import Iterable
+
+from skrub.dataframe._types import POLARS_SETUP, DataFrameLike
+
+if POLARS_SETUP:
+    import polars as pl
+    import polars.selectors as cs
+
+from itertools import product
+
+from skrub._utils import atleast_1d_or_none
+
+
+def aggregate(
+    table: DataFrameLike,
+    key: str | Iterable[str],
+    cols_to_agg: str | Iterable[str],
+    num_operations: str | Iterable[str] = ("mean",),
+    categ_operations: str | Iterable[str] = ("mode",),
+    suffix: str | None = None,
+) -> DataFrameLike:
+    """Aggregate a Polars dataframe or lazyframe.
+
+    This function uses the ``dataframe.group_by(key).agg`` method from Polars.
+
+    Parameters
+    ----------
+    table : pl.DataFrame or pl.LazyFrame,
+        The input dataframe to aggregate.
+
+    key : str or Iterable[str],
+        The columns used as keys to aggregate on.
+
+    cols_to_agg : str or Iterable[str],
+        The columns to aggregate.
+
+    num_operations : str or Iterable[str],
+        The reduction functions to apply on numerical columns
+        in ``cols_to_agg`` during the aggregation.
+
+    categ_operations : str or Iterable[str],
+        The reduction functions to apply on categorical columns
+        in ``cols_to_agg`` during the aggregation.
+
+    suffix : str,
+        The suffix appended to output columns.
+
+    Returns
+    -------
+    group : pl.DataFrame or pl.LazyFrame,
+        The aggregated output.
+    """
+    if not isinstance(table, (pl.DataFrame, pl.LazyFrame)):
+        raise TypeError(
+            f"'table' must be a polars dataframe or lazyframe, got {type(table)!r}."
+        )
+
+    key = atleast_1d_or_none(key)
+    cols_to_agg = atleast_1d_or_none(cols_to_agg)
+    num_operations = atleast_1d_or_none(num_operations)
+    categ_operations = atleast_1d_or_none(categ_operations)
+    suffix = "" if suffix is None else suffix
+
+    num_cols, categ_cols = split_num_categ_cols(table.select(cols_to_agg))
+
+    num_aggfuncs, num_mode_cols = get_aggfuncs(num_cols, num_operations)
+    categ_aggfuncs, categ_mode_cols = get_aggfuncs(categ_cols, categ_operations)
+
+    aggfuncs = [*num_aggfuncs, *categ_aggfuncs]
+    # If aggfuncs is empty, the output will be a series of index.
+    table = table.group_by(key).agg(aggfuncs)
+
+    # flattening post-processing of mode() cols
+    flatten_ops = []
+    for col in [*num_mode_cols, *categ_mode_cols]:
+        flatten_ops.append(pl.col(col).list[0].alias(col))
+    # add columns, no-op if 'flatten_ops' is empty.
+    table = table.with_columns(flatten_ops)
+
+    cols_renaming = {col: f"{col}{suffix}" for col in table.columns if col not in key}
+    table = table.rename(cols_renaming)
+    sorted_cols = sorted(table.columns)
+
+    return table.select(sorted_cols)
+
+
+def join(
+    left: DataFrameLike,
+    right: DataFrameLike,
+    left_on: str | Iterable[str],
+    right_on: str | Iterable[str],
+) -> DataFrameLike:
+    """Left join two Polars dataframes or lazyframes.
+
+    This function uses the ``dataframe.join`` method from Polars.
+
+    Note that the input dataframes type must agree: either both
+    Polars dataframes or both Polars lazyframes.
+
+    Mixing polars dataframe with lazyframe will raise an error.
+
+    Parameters
+    ----------
+    left : pl.DataFrame or pl.LazyFrame,
+        The left dataframe of the left-join.
+
+    right : pl.DataFrame or pl.LazyFrame,
+        The right dataframe of the left-join.
+
+    left_on : str or Iterable[str],
+        Left keys to merge on.
+
+    right_on : str or Iterable[str],
+        Right keys to merge on.
+
+    Returns
+    -------
+    merged : pl.DataFrame or pl.LazyFrame,
+        The merged output.
+    """
+    is_dataframe = isinstance(left, pl.DataFrame) and isinstance(right, pl.DataFrame)
+    is_lazyframe = isinstance(left, pl.LazyFrame) and isinstance(right, pl.LazyFrame)
+    if is_dataframe or is_lazyframe:
+        return left.join(
+            right,
+            how="left",
+            left_on=left_on,
+            right_on=right_on,
+        )
+    else:
+        raise TypeError(
+            "'left' and 'right' must be polars dataframes or lazyframes, "
+            f"got {type(left)!r} and {type(right)!r}."
+        )
+
+
+def get_aggfuncs(
+    cols: list[str],
+    operations: list[str],
+) -> tuple[list, list]:
+    """List Polars aggregation functions.
+
+    The list is used as input for the ``dataframe.group_by().agg()`` method from Polars.
+    The 'mode' operation needs a flattening post-processing.
+
+    Parameters
+    ----------
+    cols : list,
+        The columns to aggregate.
+
+    operations : list,
+        The reduce operations to perform.
+
+    Returns
+    -------
+    aggfuncs : list,
+        Named aggregation list.
+
+    mode_cols : list,
+        Output keys to post-process after 'mode' aggregation.
+    """
+    aggfuncs, mode_cols = [], []
+    for col, operation in product(cols, operations):
+        output_key = f"{col}_{operation}"
+        aggfunc = _polars_ops_mapping(col, operation, output_key)
+        aggfuncs.append(aggfunc)
+
+        if operation == "mode":
+            mode_cols.append(output_key)
+
+    return aggfuncs, mode_cols
+
+
+def _polars_ops_mapping(col, operation, output_key):
+    """Map an operation to its Polars expression.
+
+    Parameters
+    ----------
+    col : str,
+        Name of the column to aggregate.
+    operation : str,
+        Name of the reduce function.
+    output_key : str,
+        Name of the reduced column.
+
+    Returns
+    -------
+    aggfunc: polars.Expression,
+        The expression to apply.
+    """
+    polars_aggfuncs = {
+        "mean": pl.col(col).mean(),
+        "std": pl.col(col).std(),
+        "sum": pl.col(col).sum(),
+        "min": pl.col(col).min(),
+        "max": pl.col(col).max(),
+        "mode": pl.col(col).mode(),
+    }
+    aggfunc = polars_aggfuncs.get(operation, None)
+
+    if aggfunc is None:
+        raise ValueError(
+            f"Polars operation {operation!r} is not supported. Available:"
+            f" {list(polars_aggfuncs)}"
+        )
+
+    return aggfunc.alias(output_key)
+
+
+def split_num_categ_cols(table):
+    """Split a dataframe columns between numerical and categorical."""
+    num_cols = table.select(cs.numeric()).columns
+    categ_cols = table.select(cs.string()).columns
+
+    return num_cols, categ_cols

--- a/skrub/dataframe/_types.py
+++ b/skrub/dataframe/_types.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+try:
+    import polars as pl
+
+    POLARS_SETUP = True
+except ImportError:
+    POLARS_SETUP = False
+
+DataFrameLike = pd.DataFrame
+SeriesLike = pd.Series
+if POLARS_SETUP:
+    DataFrameLike |= pl.DataFrame | pl.LazyFrame
+    SeriesLike |= pl.Series

--- a/skrub/dataframe/tests/test_namespace.py
+++ b/skrub/dataframe/tests/test_namespace.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+import skrub.dataframe._pandas as skrub_pd
+import skrub.dataframe._polars as skrub_pl
+from skrub.dataframe import POLARS_SETUP, get_df_namespace
+
+main = pd.DataFrame(
+    {
+        "userId": [1, 1, 1, 2, 2, 2],
+        "movieId": [1, 3, 6, 318, 6, 1704],
+        "rating": [4.0, 4.0, 4.0, 3.0, 2.0, 4.0],
+        "genre": ["drama", "drama", "comedy", "sf", "comedy", "sf"],
+    }
+)
+
+
+def test_get_namespace_pandas():
+    skrub_px, _ = get_df_namespace(main, main)
+    assert skrub_px is skrub_pd
+
+    with pytest.raises(TypeError, match=r"(?=.*Pandas or Polars)(?=.*supported)"):
+        get_df_namespace(main, main.values)
+
+
+@pytest.mark.skipif(not POLARS_SETUP, reason="Polars is not available")
+def test_get_namespace_polars():
+    import polars as pl
+
+    skrub_px, _ = get_df_namespace(pl.DataFrame(main), pl.DataFrame(main))
+    assert skrub_px is skrub_pl
+
+    with pytest.raises(TypeError, match=r"(?=.*Pandas)(?=.*Polars)"):
+        get_df_namespace(main, pl.DataFrame(main))
+
+    with pytest.raises(TypeError, match=r"(?=.*lazyframes)(?=.*dataframes)"):
+        get_df_namespace(pl.DataFrame(main), pl.LazyFrame(main))

--- a/skrub/dataframe/tests/test_namespace.py
+++ b/skrub/dataframe/tests/test_namespace.py
@@ -16,10 +16,11 @@ main = pd.DataFrame(
 
 
 def test_get_namespace_pandas():
-    skrub_px, _ = get_df_namespace(main, main)
+    skrub_px, px = get_df_namespace(main, main)
     assert skrub_px is skrub_pd
+    assert px is pd
 
-    with pytest.raises(TypeError, match=r"(?=.*Pandas or Polars)(?=.*supported)"):
+    with pytest.raises(TypeError, match=r"(?=.*Only Pandas or Polars)(?=.*supported)"):
         get_df_namespace(main, main.values)
 
 
@@ -27,11 +28,14 @@ def test_get_namespace_pandas():
 def test_get_namespace_polars():
     import polars as pl
 
-    skrub_px, _ = get_df_namespace(pl.DataFrame(main), pl.DataFrame(main))
+    skrub_px, px = get_df_namespace(pl.DataFrame(main), pl.DataFrame(main))
     assert skrub_px is skrub_pl
+    assert px is pl
 
-    with pytest.raises(TypeError, match=r"(?=.*Pandas)(?=.*Polars)"):
+    with pytest.raises(TypeError, match=r"(?=.*Mixing Pandas)(?=.*Polars)"):
         get_df_namespace(main, pl.DataFrame(main))
 
-    with pytest.raises(TypeError, match=r"(?=.*lazyframes)(?=.*dataframes)"):
+    with pytest.raises(
+        TypeError, match=r"(?=.*Mixing)(?=.*lazyframes)(?=.*dataframes)"
+    ):
         get_df_namespace(pl.DataFrame(main), pl.LazyFrame(main))

--- a/skrub/dataframe/tests/test_pandas.py
+++ b/skrub/dataframe/tests/test_pandas.py
@@ -1,0 +1,97 @@
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+from skrub.dataframe._pandas import aggregate, join
+
+main = pd.DataFrame(
+    {
+        "userId": [1, 1, 1, 2, 2, 2],
+        "movieId": [1, 3, 6, 318, 6, 1704],
+        "rating": [4.0, 4.0, 4.0, 3.0, 2.0, 4.0],
+        "genre": ["drama", "drama", "comedy", "sf", "comedy", "sf"],
+    }
+)
+
+
+def test_join():
+    joined = join(left=main, right=main, left_on="movieId", right_on="movieId")
+    expected = main.merge(main, on="movieId", how="left")
+    assert_frame_equal(joined, expected)
+
+
+def test_simple_agg():
+    aggregated = aggregate(
+        table=main,
+        key="movieId",
+        cols_to_agg=["rating", "genre"],
+        num_operations="mean",
+        categ_operations="mode",
+    )
+    aggfunc = {
+        "genre_mode": ("genre", pd.Series.mode),
+        "rating_mean": ("rating", "mean"),
+    }
+    expected = main.groupby("movieId").agg(**aggfunc)
+    assert_frame_equal(aggregated, expected)
+
+
+def test_value_counts_agg():
+    aggregated = aggregate(
+        table=main,
+        key="userId",
+        cols_to_agg="rating",
+        num_operations="value_counts",
+        categ_operations=None,
+        suffix="_user",
+    )
+    expected = pd.DataFrame(
+        {
+            "rating_2.0_user": [0.0, 1.0],
+            "rating_3.0_user": [0.0, 1.0],
+            "rating_4.0_user": [3.0, 1.0],
+            "userId": [1, 2],
+        }
+    )
+    assert_frame_equal(aggregated, expected)
+
+    aggregated = aggregate(
+        table=main,
+        key="userId",
+        cols_to_agg="rating",
+        num_operations="hist(2)",
+        categ_operations=None,
+        suffix="_user",
+    )
+    expected = pd.DataFrame(
+        {
+            "rating_(1.999, 3.0]_user": [0, 2],
+            "rating_(3.0, 4.0]_user": [3, 1],
+            "userId": [1, 2],
+        }
+    )
+    assert_frame_equal(aggregated, expected)
+
+
+def test_incorrect_dataframe_inputs():
+    with pytest.raises(TypeError, match=r"(?=.*pandas dataframes)(?=.*array)"):
+        join(left=main.values, right=main, left_on="movieId", right_on="movieId")
+
+    with pytest.raises(TypeError, match=r"(?=.*pandas dataframe)(?=.*array)"):
+        aggregate(
+            table=main.values,
+            key="movieId",
+            cols_to_agg="rating",
+            num_operations="mean",
+        )
+
+
+def test_no_agg_operation():
+    with pytest.raises(ValueError, match=r"(?=.*No aggregation)"):
+        aggregate(
+            table=main,
+            key="movieId",
+            cols_to_agg="rating",
+            num_operations=None,
+            categ_operations=None,
+        )

--- a/skrub/dataframe/tests/test_polars.py
+++ b/skrub/dataframe/tests/test_polars.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import pytest
+
+from skrub.dataframe import POLARS_SETUP
+from skrub.dataframe._polars import aggregate, join
+
+if POLARS_SETUP:
+    import polars as pl
+    from polars.testing import assert_frame_equal
+
+    main = pl.DataFrame(
+        {
+            "userId": [1, 1, 1, 2, 2, 2],
+            "movieId": [1, 3, 6, 318, 6, 1704],
+            "rating": [4.0, 4.0, 4.0, 3.0, 2.0, 4.0],
+            "genre": ["drama", "drama", "comedy", "sf", "comedy", "sf"],
+        }
+    )
+
+POLARS_MISSING_MSG = "Polars is not available"
+
+
+@pytest.mark.skipif(not POLARS_SETUP, reason=POLARS_MISSING_MSG)
+def test_join():
+    joined = join(left=main, right=main, left_on="movieId", right_on="movieId")
+    expected = main.join(main, on="movieId", how="left")
+    assert_frame_equal(joined, expected)
+
+
+@pytest.mark.skipif(not POLARS_SETUP, reason=POLARS_MISSING_MSG)
+def test_simple_agg():
+    aggregated = aggregate(
+        table=main,
+        key="movieId",
+        cols_to_agg="rating",
+        num_operations="mean",
+    )
+    aggfunc = pl.col("rating").mean().alias("rating_mean")
+    expected = main.group_by("movieId").agg(aggfunc)
+    # As group_by parallizes threads, the row order of its output isn't
+    # deterministic. Hence, we need to set check_row_order to False.
+    assert_frame_equal(aggregated, expected, check_row_order=False)
+
+
+@pytest.mark.skipif(not POLARS_SETUP, reason=POLARS_MISSING_MSG)
+def test_mode_agg():
+    aggregated = aggregate(
+        table=main,
+        key="movieId",
+        cols_to_agg="genre",
+        categ_operations=["mode"],
+    )
+    expected = pl.DataFrame(
+        {
+            "genre_mode": ["drama", "drama", "sf", "sf", "comedy"],
+            "movieId": [3, 1, 318, 1704, 6],
+        }
+    )
+    assert_frame_equal(aggregated, expected, check_row_order=False)
+
+
+@pytest.mark.skipif(not POLARS_SETUP, reason=POLARS_MISSING_MSG)
+def test_incorrect_dataframe_inputs():
+    with pytest.raises(TypeError, match=r"(?=.*polars dataframes)(?=.*pandas)"):
+        join(left=pd.DataFrame(main), right=main, left_on="movieId", right_on="movieId")
+
+    with pytest.raises(TypeError, match=r"(?=.*polars dataframe)(?=.*pandas)"):
+        aggregate(
+            table=pd.DataFrame(main),
+            key="movieId",
+            cols_to_agg="rating",
+            num_operations="mean",
+        )


### PR DESCRIPTION
**References**
This PR aims at simplifying #600 by adding the `dataframe._pandas` and `dataframe._polars` namespaces prior to it.
It also enables solving issues like https://github.com/skrub-data/skrub/issues/730.

This PR takes into account the latest reviews made in #600.

**What does this PR implement?**
- Create a new submodule `skrub.dataframe` so that the `join` and `aggregate` functions for Pandas and Polars can be shared more easily across skrub.
- Add the `get_df_namespace` function and the `DataFrameLike`, `SeriesLike` types in separate files within `skrub.dataframe`.
- Add a specific documentation entry in the API section for the pandas and polars submodules.

**Additional comments**
This PR doesn't take into account the output of the discussion https://github.com/skrub-data/skrub/discussions/719 for now.