### PR TITLE
MAINT Remove `sklearn.utils.parse_version` from `skrub.utils`

### DIFF
--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -12,11 +12,11 @@ from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 from sklearn.preprocessing import OneHotEncoder
+from sklearn.utils import parse_version
 from sklearn.utils.fixes import _object_dtype_isnan
 from sklearn.utils.validation import check_is_fitted
 
 from ._string_distances import get_ngram_count, preprocess
-from ._utils import parse_version
 
 # Ignore lines too long, first docstring lines can't be cut
 # flake8: noqa: E501

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-from sklearn.utils import parse_version  # noqa
 from sklearn.utils import check_array
 
 

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -25,8 +25,9 @@ import pandas as pd
 from sklearn import __version__ as sklearn_version
 from sklearn.datasets import fetch_openml
 from sklearn.datasets._base import _sha256
+from sklearn.utils import parse_version
 
-from skrub._utils import import_optional_dependency, parse_version
+from skrub._utils import import_optional_dependency
 from skrub.datasets._utils import get_data_dir
 
 # Ignore lines too long, first docstring lines can't be cut

--- a/skrub/tests/test_sklearn.py
+++ b/skrub/tests/test_sklearn.py
@@ -2,10 +2,9 @@ import numpy as np
 import pytest
 import sklearn
 from sklearn.metrics.pairwise import linear_kernel, pairwise_distances
+from sklearn.utils import parse_version
 from sklearn.utils._tags import _safe_tags
 from sklearn.utils.estimator_checks import _is_pairwise_metric, parametrize_with_checks
-
-from skrub._utils import parse_version
 
 from skrub import (  # isort:skip
     DatetimeEncoder,


### PR DESCRIPTION
**Context**
For some reason, we import the `parse_version` function from `sklearn.utils` in `skrub.utils`, without using it. Then we import it from skrub instead of from scikit-learn across the project, which seems odd.

**What does this PR implement?**
- Replace the skrub import by the sklearn import across the project
- Remove the import from sklearn in `skrub.utils`

