### PR TITLE
MAIN Improve the error message for Pandas sparse arrays in TableVectorizer

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -679,6 +679,16 @@ class TableVectorizer(ColumnTransformer):
                 "X.toarray() to convert to a dense numpy array."
             )
 
+        # Check Pandas sparse arrays
+        is_sparse_col = [hasattr(X[col], "sparse") for col in X.columns]
+        if any(is_sparse_col):
+            sparse_cols = X.columns[is_sparse_col]
+            raise TypeError(
+                f"Columns {sparse_cols!r} are sparse Pandas series, but dense "
+                "data is required. Use df[col].sparse.to_dense() to convert "
+                "a series from sparse to dense."
+            )
+
         if not isinstance(X, pd.DataFrame):
             # check the dimension of X before to create a dataframe that always
             # `ndim == 2`

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -679,16 +679,6 @@ class TableVectorizer(ColumnTransformer):
                 "X.toarray() to convert to a dense numpy array."
             )
 
-        # Check Pandas sparse arrays
-        is_sparse_col = [hasattr(X[col], "sparse") for col in X.columns]
-        if any(is_sparse_col):
-            sparse_cols = X.columns[is_sparse_col]
-            raise TypeError(
-                f"Columns {sparse_cols!r} are sparse Pandas series, but dense "
-                "data is required. Use df[col].sparse.to_dense() to convert "
-                "a series from sparse to dense."
-            )
-
         if not isinstance(X, pd.DataFrame):
             # check the dimension of X before to create a dataframe that always
             # `ndim == 2`
@@ -713,6 +703,16 @@ class TableVectorizer(ColumnTransformer):
         else:
             # Create a copy to avoid altering the original data.
             X = X.copy()
+
+        # Check Pandas sparse arrays
+        is_sparse_col = [hasattr(X[col], "sparse") for col in X.columns]
+        if any(is_sparse_col):
+            sparse_cols = X.columns[is_sparse_col]
+            raise TypeError(
+                f"Columns {sparse_cols!r} are sparse Pandas series, but dense "
+                "data is required. Use df[col].sparse.to_dense() to convert "
+                "a series from sparse to dense."
+            )
 
         if X.shape[0] < 1:
             raise ValueError(

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -864,3 +864,23 @@ def test_table_vectorizer_remainder_cloning():
     assert table_vectorizer.high_card_cat_transformer_ is not remainder
     assert table_vectorizer.numerical_transformer_ is not remainder
     assert table_vectorizer.datetime_transformer_ is not remainder
+
+
+def test_pandas_sparse_array():
+    df = pd.DataFrame(
+        dict(
+            a=[1, 2, 3, 4, 5],
+            b=[1, 0, 0, 0, 2],
+        )
+    )
+    df["b"] = pd.arrays.SparseArray(df["b"])
+
+    match = r"(?=.*sparse Pandas series)(?=.*'b')"
+    with pytest.raises(TypeError, match=match):
+        TableVectorizer().fit(df)
+
+    df = df.astype(pd.SparseDtype())
+
+    match = r"(?=.*sparse Pandas series)(?=.*'a', 'b')"
+    with pytest.raises(TypeError, match=match):
+        TableVectorizer().fit(df)


### PR DESCRIPTION
**References**
Addresses https://github.com/skrub-data/skrub/issues/679

**What does this PR implement?** 
`TableVectorizer` currently doesn't support sparse matrices. Until then, we should also prevent users from using Pandas sparse arrays.

This PR suggests that, during the `_check_input` call, we iterate on dataframe columns to look for the "sparse" accessor. We raise an error when at least one column is sparse.

**Alternative solution**
AFAIK, there is no way to identify a sparse column within a Pandas dataframe without iterating on the columns.

cc @LeoGrin 