### PR TITLE
[DONT MERGE] add a package data file

### DIFF
--- a/build_tools/github/test.sh
+++ b/build_tools/github/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -x
 
-python -m pytest --pyargs skrub --cov=skrub -n auto
+pytest --pyargs skrub --cov=skrub -n auto

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -32,4 +32,16 @@ __all__ = [
     "TargetEncoder",
     "deduplicate",
     "compute_ngram_distance",
+    "load_package_data",
 ]
+
+
+def load_package_data() -> str:
+    """Dummy function that loads some package data.
+
+    Returns
+    -------
+    data: str
+        Some data.
+    """
+    return _Path(__file__).parent.joinpath("data_file.txt").read_text("utf-8")

--- a/skrub/data_file.txt
+++ b/skrub/data_file.txt
@@ -1,0 +1,1 @@
+some package data

--- a/skrub/tests/test_package_data.py
+++ b/skrub/tests/test_package_data.py
@@ -1,0 +1,5 @@
+import skrub
+
+
+def test_load_package_data():
+    skrub.load_package_data()


### PR DESCRIPTION
this is a dummy PR to run the CI

I have the impression that at the moment:

- the way we run tests in the CI invokes pytest from the repo root with `python -m pytest`, which adds the cwd to the PYTHONPATH, resulting in pytest importing skrub from the repo rather than the installed package
- we have no mechanism in place to copy package data to the installation directory, the VERSION.txt gets included as a special case

This is what I see locally: if I add a package data file without adding it to a MANIFEST.in or listing it in setup.py, and install skrub, `build_tools/test.sh` runs without errors even though the data file is not copied to the installation directory. However, if I edit `test.sh` to replace `python -m pytest` with `pytest`, the tests fail

I'm opening this dummy PR to see if the same thing happens in the CI. If it does, the tests would pass now, then fail when I push another commit with the modified pytest invokation