### PR TITLE
DatetimeEncoder fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,8 +137,9 @@ Minor changes
   which provides some more information about the job title.
   :pr:`581` by :user:`Lilian Boulard <LilianBoulard>`
 
-* Fix bug which was triggered when `extract_until` was smaller than `seconds`
-  in :class:`DatetimeEncoder`. :pr:`743` by :user:`Leo Grinsztajn <LeoGrin>`
+* Fix bugs which was triggered when `extract_until` was "year", "month", "microseconds"
+  or "nanoseconds", and add the option to set it to `None` to only extract `total_time`,
+  the time from epoch. :class:`DatetimeEncoder`. :pr:`743` by :user:`Leo Grinsztajn <LeoGrin>`
 
 Before skrub: dirty_cat
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,7 +138,7 @@ Minor changes
   :pr:`581` by :user:`Lilian Boulard <LilianBoulard>`
 
 * Fix bug which was triggered when `extract_until` was smaller than `seconds`
-  in :class:`DatetimeEncoder`. :pr:`1526` by :user:`Leo Grinsztajn <LeoGrin>`
+  in :class:`DatetimeEncoder`. :pr:`743` by :user:`Leo Grinsztajn <LeoGrin>`
 
 Before skrub: dirty_cat
 ========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -137,6 +137,9 @@ Minor changes
   which provides some more information about the job title.
   :pr:`581` by :user:`Lilian Boulard <LilianBoulard>`
 
+* Fix bug which was triggered when `extract_until` was smaller than `seconds`
+  in :class:`DatetimeEncoder`. :pr:`1526` by :user:`Leo Grinsztajn <LeoGrin>`
+
 Before skrub: dirty_cat
 ========================
 

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -19,7 +19,6 @@ WORD_TO_ALIAS: dict[str, str] = {
     "hour": "H",
     "minute": "min",
     "second": "S",
-    "millisecond": "ms",
     "microsecond": "us",
     "nanosecond": "N",
 }
@@ -31,7 +30,6 @@ AcceptedTimeValues = Literal[
     "hour",
     "minute",
     "second",
-    "millisecond",
     "microsecond",
     "nanosecond",
 ]
@@ -47,7 +45,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
 
     Parameters
     ----------
-    extract_until : {'year', 'month', 'day', 'hour', 'minute', 'second', 'millisecond', 'microsecond', 'nanosecond'}, default='hour'
+    extract_until : {'year', 'month', 'day', 'hour', 'minute', 'second', 'microsecond', 'nanosecond'}, default='hour'
         Extract up to this granularity.
         If all features have not been extracted, add the 'total_time' feature,
         which contains the time to epoch (in seconds).
@@ -145,8 +143,6 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
             return pd.DatetimeIndex(date_series).minute.to_numpy()
         elif feature == "second":
             return pd.DatetimeIndex(date_series).second.to_numpy()
-        elif feature == "millisecond":
-            return pd.DatetimeIndex(date_series).millisecond.to_numpy()
         elif feature == "microsecond":
             return pd.DatetimeIndex(date_series).microsecond.to_numpy()
         elif feature == "nanosecond":
@@ -263,7 +259,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
         Feature names are formatted like: "<column_name>_<new_feature>"
         if the original data has column names, otherwise with format
         "<column_index>_<new_feature>" where `<new_feature>` is one of
-        {"year", "month", "day", "hour", "minute", "second", "millisecond",
+        {"year", "month", "day", "hour", "minute", "second",
         "microsecond", "nanosecond", "dayofweek"}.
 
         Parameters

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -124,7 +124,7 @@ class DatetimeEncoder(BaseEstimator, TransformerMixin):
         }
 
     def _validate_keywords(self):
-        if self.extract_until not in TIME_LEVELS and not self.extract_until is None:
+        if self.extract_until not in TIME_LEVELS and self.extract_until is not None:
             raise ValueError(
                 f'"extract_until" should be one of {TIME_LEVELS}, '
                 f"got {self.extract_until}. "

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -32,16 +32,40 @@ def get_datetime_array() -> np.array:
     return np.array(
         [
             pd.to_datetime(
-                ["2020-01-01 10:12:01", "2020-01-02 10:23:00", "2020-01-03 10:00:00"]
+                [
+                    "2020-01-01 10:12:01",
+                    "2020-01-02 10:23:00",
+                    "2020-01-03 10:00:00",
+                    "2020-08-24 15:55:30.123456789",
+                ],
+                format="mixed",
             ),
             pd.to_datetime(
-                ["2021-02-03 12:45:23", "2020-02-04 22:12:00", "2021-02-05 12:00:00"]
+                [
+                    "2021-02-03 12:45:23",
+                    "2020-02-04 22:12:00",
+                    "2021-02-05 12:00:00",
+                    "2021-07-20 14:56:31.987654321",
+                ],
+                format="mixed",
             ),
             pd.to_datetime(
-                ["2022-01-01 23:23:43", "2020-12-25 11:12:00", "2022-01-03 11:00:00"]
+                [
+                    "2022-01-01 23:23:43",
+                    "2020-12-25 11:12:00",
+                    "2022-01-03 11:00:00",
+                    "2023-09-20 14:57:32.123987654",
+                ],
+                format="mixed",
             ),
             pd.to_datetime(
-                ["2023-02-03 11:12:12", "2020-02-04 08:32:00", "2023-02-05 23:00:00"]
+                [
+                    "2023-02-03 11:12:12",
+                    "2020-02-04 08:32:00",
+                    "2023-02-05 23:00:00",
+                    "2023-09-20 14:58:33.987123456",
+                ],
+                format="mixed",
             ),
         ]
     )
@@ -126,11 +150,15 @@ def test_fit() -> None:
         0: ["year", "month", "day", "hour", "dayofweek", "total_time"],
         1: ["month", "day", "hour", "dayofweek", "total_time"],
         2: ["year", "month", "day", "hour", "dayofweek"],
+        3: ["year", "month", "day", "hour", "dayofweek", "total_time"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
+    # we check that the features are extracted until `extract_until`
+    # that constant feature are not extracted
+    # and that the total_time feature is extracted if needed
     X = get_datetime_array()
     enc = DatetimeEncoder(extract_until="minute")
     expected_to_extract = ["year", "month", "day", "hour", "minute"]
@@ -138,6 +166,46 @@ def test_fit() -> None:
         0: ["year", "month", "day", "hour", "minute", "total_time"],
         1: ["month", "day", "hour", "minute"],
         2: ["year", "month", "day", "hour"],
+        3: ["year", "month", "day", "hour", "minute", "total_time"],
+    }
+    enc.fit(X)
+    assert enc._to_extract == expected_to_extract
+    assert enc.features_per_column_ == expected_features_per_column_
+
+    # extract_until="nanosecond"
+    X = get_datetime_array()
+    enc = DatetimeEncoder(extract_until="nanosecond")
+    expected_to_extract = [
+        "year",
+        "month",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "microsecond",
+        "nanosecond",
+    ]
+    expected_features_per_column_ = {
+        0: [
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+        ],
+        1: ["month", "day", "hour", "minute"],
+        2: ["year", "month", "day", "hour"],
+        3: [
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "microsecond",
+            "nanosecond",
+        ],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
@@ -186,6 +254,12 @@ def test_fit() -> None:
         "2_day",
         "2_hour",
         "2_dayofweek",
+        "3_year",
+        "3_month",
+        "3_day",
+        "3_hour",
+        "3_dayofweek",
+        "3_total_time",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names
@@ -193,7 +267,7 @@ def test_fit() -> None:
     # With column names
     X = get_datetime_array()
     X = pd.DataFrame(X)
-    X.columns = ["col1", "col2", "col3"]
+    X.columns = ["col1", "col2", "col3", "col4"]
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_feature_names = [
         "col1_year",
@@ -212,6 +286,12 @@ def test_fit() -> None:
         "col3_day",
         "col3_hour",
         "col3_dayofweek",
+        "col4_year",
+        "col4_month",
+        "col4_day",
+        "col4_hour",
+        "col4_dayofweek",
+        "col4_total_time",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -145,39 +145,33 @@ def test_fit() -> None:
     # Dates
     X = get_date_array()
     enc = DatetimeEncoder()
-    expected_to_extract = ["year", "month", "day", "hour"]
     expected_features_per_column_ = {
         0: ["year", "month", "day"],
         1: ["month", "day"],
         2: ["year", "month", "day"],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     X = get_date_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_to_extract = ["year", "month", "day", "hour", "dayofweek"]
     expected_features_per_column_ = {
         0: ["year", "month", "day", "dayofweek"],
         1: ["month", "day", "dayofweek"],
         2: ["year", "month", "day", "dayofweek"],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # Datetimes
     X = get_datetime_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
-    expected_to_extract = ["year", "month", "day", "hour", "dayofweek"]
     expected_features_per_column_ = {
-        0: ["year", "month", "day", "hour", "dayofweek", "total_time"],
-        1: ["month", "day", "hour", "dayofweek", "total_time"],
+        0: ["year", "month", "day", "hour", "total_time", "dayofweek"],
+        1: ["month", "day", "hour", "total_time", "dayofweek"],
         2: ["year", "month", "day", "hour", "dayofweek"],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # we check that the features are extracted until `extract_until`
@@ -185,29 +179,17 @@ def test_fit() -> None:
     # and that the total_time feature is extracted if needed
     X = get_datetime_array()
     enc = DatetimeEncoder(extract_until="minute")
-    expected_to_extract = ["year", "month", "day", "hour", "minute"]
     expected_features_per_column_ = {
         0: ["year", "month", "day", "hour", "minute", "total_time"],
         1: ["month", "day", "hour", "minute"],
         2: ["year", "month", "day", "hour"],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # extract_until="nanosecond"
     X = get_datetime_array_nanoseconds()
     enc = DatetimeEncoder(extract_until="nanosecond")
-    expected_to_extract = [
-        "year",
-        "month",
-        "day",
-        "hour",
-        "minute",
-        "second",
-        "microsecond",
-        "nanosecond",
-    ]
     expected_features_per_column_ = {
         # constant year and month
         # for first feature
@@ -231,29 +213,24 @@ def test_fit() -> None:
         ],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # Dirty Datetimes
     X = get_dirty_datetime_array()
     enc = DatetimeEncoder()
-    expected_to_extract = ["year", "month", "day", "hour"]
     expected_features_per_column_ = {
         0: ["year", "month", "day", "hour", "total_time"],
         1: ["month", "day", "hour", "total_time"],
         2: ["year", "month", "day", "hour"],
     }
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # Datetimes with TZ
     X = get_datetime_with_TZ_array()
     enc = DatetimeEncoder()
-    expected_to_extract = ["year", "month", "day", "hour"]
     expected_features_per_column_ = {0: ["year", "month", "day", "hour", "total_time"]}
     enc.fit(X)
-    assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # Feature names
@@ -265,13 +242,13 @@ def test_fit() -> None:
         "0_month",
         "0_day",
         "0_hour",
-        "0_dayofweek",
         "0_total_time",
+        "0_dayofweek",
         "1_month",
         "1_day",
         "1_hour",
-        "1_dayofweek",
         "1_total_time",
+        "1_dayofweek",
         "2_year",
         "2_month",
         "2_day",
@@ -291,13 +268,13 @@ def test_fit() -> None:
         "col1_month",
         "col1_day",
         "col1_hour",
-        "col1_dayofweek",
         "col1_total_time",
+        "col1_dayofweek",
         "col2_month",
         "col2_day",
         "col2_hour",
-        "col2_dayofweek",
         "col2_total_time",
+        "col2_dayofweek",
         "col3_year",
         "col3_month",
         "col3_day",
@@ -353,14 +330,14 @@ def test_transform() -> None:
     # Check that the "total_time" feature is working
     expected_result = np.array(
         [
-            [2020, 1, 1, 10, 2, 0],
-            [2021, 2, 3, 12, 2, 0],
-            [2022, 1, 1, 23, 5, 0],
-            [2023, 2, 3, 11, 4, 0],
+            [2020, 1, 1, 10, 0, 2],
+            [2021, 2, 3, 12, 0, 2],
+            [2022, 1, 1, 23, 0, 5],
+            [2023, 2, 3, 11, 0, 4],
         ]
     ).astype(np.float64)
     # Time from epochs in seconds
-    expected_result[:, 5] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
+    expected_result[:, 4] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
 
     enc.fit(X)
     X_trans = enc.transform(X)
@@ -369,7 +346,7 @@ def test_transform() -> None:
     # Check if we find back the date from the time to epoch
     assert (
         (
-            pd.to_datetime(X_trans[:, 5], unit="s") - pd.to_datetime(X.reshape(-1))
+            pd.to_datetime(X_trans[:, 4], unit="s") - pd.to_datetime(X.reshape(-1))
         ).total_seconds()
         == 0
     ).all()
@@ -379,15 +356,15 @@ def test_transform() -> None:
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_result = np.array(
         [
-            [2020, 1, 1, 10, 2, 0],
+            [2020, 1, 1, 10, 0, 2],
             [np.nan] * 6,
-            [2022, 1, 1, 23, 5, 0],
-            [2023, 2, 3, 11, 4, 0],
+            [2022, 1, 1, 23, 0, 5],
+            [2023, 2, 3, 11, 0, 4],
         ]
     )
     # Time from epochs in seconds
-    expected_result[:, 5] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
-    expected_result[1, 5] = np.nan
+    expected_result[:, 4] = (X.astype("int64") // 1e9).astype(np.float64).reshape(-1)
+    expected_result[1, 4] = np.nan
     enc.fit(X)
     X_trans = enc.transform(X)
     assert np.allclose(X_trans, expected_result, equal_nan=True)
@@ -401,14 +378,14 @@ def test_transform() -> None:
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_result = np.array(
         [
-            [2020, 1, 1, 10, 2, 0],
-            [2021, 2, 3, 12, 2, 0],
-            [2022, 1, 1, 23, 5, 0],
-            [2023, 2, 3, 11, 4, 0],
+            [2020, 1, 1, 10, 0, 2],
+            [2021, 2, 3, 12, 0, 2],
+            [2022, 1, 1, 23, 0, 5],
+            [2023, 2, 3, 11, 0, 4],
         ]
     ).astype(np.float64)
     # Time from epochs in seconds
-    expected_result[:, 5] = (
+    expected_result[:, 4] = (
         (X.iloc[:, 0].view(dtype="int64") // 1e9)
         .astype(np.float64)
         .to_numpy()
@@ -421,7 +398,7 @@ def test_transform() -> None:
     # Check if we find back the date from the time to epoch
     assert (
         (
-            pd.to_datetime(X_trans[:, 5], unit="s")
+            pd.to_datetime(X_trans[:, 4], unit="s")
             .tz_localize("utc")
             .tz_convert(X.iloc[:, 0][0].tz)
             - pd.DatetimeIndex(X.iloc[:, 0])
@@ -433,6 +410,49 @@ def test_transform() -> None:
     X = get_constant_date_array()
     enc = DatetimeEncoder(add_day_of_the_week=True)
     assert enc.fit_transform(X).shape[1] == 0
+
+
+@pytest.mark.parametrize(
+    "extract_until",
+    ["year", "month", "day", "hour", "minute", "second", "microsecond", "nanosecond"],
+)
+def test_extract_until(extract_until) -> None:
+    time_levels = [
+        "year",
+        "month",
+        "day",
+        "hour",
+        "minute",
+        "second",
+        "microsecond",
+        "nanosecond",
+    ]
+    X = get_datetime_array()
+    enc = DatetimeEncoder(extract_until=extract_until)
+    expected_features_per_column_ = {
+        # all features after seconds are constant
+        # we want total_time if we have not extracted all non-constant features
+        0: time_levels[
+            : min(time_levels.index(extract_until), time_levels.index("second")) + 1
+        ]
+        + (
+            ["total_time"]
+            if extract_until in ["year", "month", "day", "hour", "minute"]
+            else []
+        ),
+        # constant after minute + year constant
+        1: time_levels[
+            1 : min(time_levels.index(extract_until), time_levels.index("minute")) + 1
+        ]
+        + (["total_time"] if extract_until in ["year", "month", "day", "hour"] else []),
+        # constant after hour
+        2: time_levels[
+            : min(time_levels.index(extract_until), time_levels.index("hour")) + 1
+        ]
+        + (["total_time"] if extract_until in ["year", "month", "day"] else []),
+    }
+    enc.fit(X)
+    assert enc.features_per_column_ == expected_features_per_column_
 
 
 def test_check_fitted_datetime_encoder() -> None:

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -455,6 +455,33 @@ def test_extract_until(extract_until) -> None:
     assert enc.features_per_column_ == expected_features_per_column_
 
 
+def test_extract_until_none() -> None:
+    X = get_dirty_datetime_array()
+    enc = DatetimeEncoder(extract_until=None)
+    expected_features_per_column_ = {
+        # all features after seconds are constant
+        # we want total_time if we have not extracted all non-constant features
+        0: ["total_time"],
+        1: ["total_time"],
+        2: ["total_time"],
+    }
+    enc.fit(X)
+    assert enc.features_per_column_ == expected_features_per_column_
+
+    # check get_names_out
+    expected_feature_names = [
+        "0_total_time",
+        "1_total_time",
+        "2_total_time",
+    ]
+    assert enc.get_feature_names_out() == expected_feature_names
+
+    # check with constant datetimes
+    X = get_constant_date_array()
+    enc = DatetimeEncoder(extract_until=None)
+    assert enc.fit_transform(X).shape[1] == 0
+
+
 def test_check_fitted_datetime_encoder() -> None:
     """Test that calling transform before fit raises an error"""
     X = get_datetime_array()[:, 0].reshape(-1, 1)

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -36,36 +36,61 @@ def get_datetime_array() -> np.array:
                     "2020-01-01 10:12:01",
                     "2020-01-02 10:23:00",
                     "2020-01-03 10:00:00",
-                    "2020-08-24 15:55:30.123456789",
                 ],
-                format="mixed",
             ),
             pd.to_datetime(
                 [
                     "2021-02-03 12:45:23",
                     "2020-02-04 22:12:00",
                     "2021-02-05 12:00:00",
-                    "2021-07-20 14:56:31.987654321",
                 ],
-                format="mixed",
             ),
             pd.to_datetime(
                 [
                     "2022-01-01 23:23:43",
                     "2020-12-25 11:12:00",
                     "2022-01-03 11:00:00",
-                    "2023-09-20 14:57:32.123987654",
                 ],
-                format="mixed",
             ),
             pd.to_datetime(
                 [
                     "2023-02-03 11:12:12",
                     "2020-02-04 08:32:00",
                     "2023-02-05 23:00:00",
+                ],
+            ),
+        ]
+    )
+
+
+def get_datetime_array_nanoseconds() -> np.array:
+    return np.array(
+        [
+            pd.to_datetime(
+                [
+                    # constant year and month
+                    # for the first feature
+                    "2020-08-24 15:55:30.123456789",
+                    "2020-08-24 15:55:30.123456789",
+                ],
+            ),
+            pd.to_datetime(
+                [
+                    "2020-08-20 14:56:31.987654321",
+                    "2021-07-20 14:56:31.987654321",
+                ],
+            ),
+            pd.to_datetime(
+                [
+                    "2020-08-20 14:57:32.123987654",
+                    "2023-09-20 14:57:32.123987654",
+                ],
+            ),
+            pd.to_datetime(
+                [
+                    "2020-08-20 14:58:33.987123456",
                     "2023-09-20 14:58:33.987123456",
                 ],
-                format="mixed",
             ),
         ]
     )
@@ -150,7 +175,6 @@ def test_fit() -> None:
         0: ["year", "month", "day", "hour", "dayofweek", "total_time"],
         1: ["month", "day", "hour", "dayofweek", "total_time"],
         2: ["year", "month", "day", "hour", "dayofweek"],
-        3: ["year", "month", "day", "hour", "dayofweek", "total_time"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
@@ -166,14 +190,13 @@ def test_fit() -> None:
         0: ["year", "month", "day", "hour", "minute", "total_time"],
         1: ["month", "day", "hour", "minute"],
         2: ["year", "month", "day", "hour"],
-        3: ["year", "month", "day", "hour", "minute", "total_time"],
     }
     enc.fit(X)
     assert enc._to_extract == expected_to_extract
     assert enc.features_per_column_ == expected_features_per_column_
 
     # extract_until="nanosecond"
-    X = get_datetime_array()
+    X = get_datetime_array_nanoseconds()
     enc = DatetimeEncoder(extract_until="nanosecond")
     expected_to_extract = [
         "year",
@@ -186,17 +209,17 @@ def test_fit() -> None:
         "nanosecond",
     ]
     expected_features_per_column_ = {
+        # constant year and month
+        # for first feature
         0: [
-            "year",
-            "month",
             "day",
             "hour",
             "minute",
             "second",
+            "microsecond",
+            "nanosecond",
         ],
-        1: ["month", "day", "hour", "minute"],
-        2: ["year", "month", "day", "hour"],
-        3: [
+        1: [
             "year",
             "month",
             "day",
@@ -254,12 +277,6 @@ def test_fit() -> None:
         "2_day",
         "2_hour",
         "2_dayofweek",
-        "3_year",
-        "3_month",
-        "3_day",
-        "3_hour",
-        "3_dayofweek",
-        "3_total_time",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names
@@ -267,7 +284,7 @@ def test_fit() -> None:
     # With column names
     X = get_datetime_array()
     X = pd.DataFrame(X)
-    X.columns = ["col1", "col2", "col3", "col4"]
+    X.columns = ["col1", "col2", "col3"]
     enc = DatetimeEncoder(add_day_of_the_week=True)
     expected_feature_names = [
         "col1_year",
@@ -286,12 +303,6 @@ def test_fit() -> None:
         "col3_day",
         "col3_hour",
         "col3_dayofweek",
-        "col4_year",
-        "col4_month",
-        "col4_day",
-        "col4_hour",
-        "col4_dayofweek",
-        "col4_total_time",
     ]
     enc.fit(X)
     assert enc.get_feature_names_out() == expected_feature_names


### PR DESCRIPTION
- Fix #741 Remove millisecond extraction in DatetimeEncoder (Turns out you pandas' `DatetimeIndex` don't have a `millisecond` attribute.)
- Fix #745 Stop using the `floor` function and simplify the logic to check if we need `total_time`
- Close #744 Adds a `None` option for `extract_until` to only extract `total_time`.

@jeromedockes 