### PR TITLE
DOC Ignore unrecognized types in docstrings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -506,6 +506,7 @@ numpydoc_xref_aliases = {
     "DatasetAll": "skrub.datasets._fetching.DatasetAll",
     "_replace_false_missing": "skrub._table_vectorizer._replace_false_missing",
 }
+numpydoc_xref_ignore = "all"
 
 # -- sphinx.ext.autodoc configuration -----------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html


### PR DESCRIPTION
When building the doc, many terms are highlighted, even though they don't link to anything in particular. This happens in the parameters and returns type hinting of docstrings

For example below, you can see that "of", "or", and "optional" are in purple:
<img width="702" alt="doc_before" src="https://github.com/skrub-data/skrub/assets/57430673/36f7ca2a-35ff-499b-ad06-6f07c898f066">
I'm proposing to disable this like so:
<img width="695" alt="doc_after" src="https://github.com/skrub-data/skrub/assets/57430673/c6c48efb-925b-4db4-a27d-a4f15ae9bf45">

I've added a line in `doc/conf.py` that tells numpydoc to ignore all unrecognized terms. More info here: https://numpydoc.readthedocs.io/en/latest/install.html

---------

Another before/after example:
<img width="758" alt="doc_before_bis" src="https://github.com/skrub-data/skrub/assets/57430673/c3645d93-58ec-4248-a7de-97deb62259f5">
<img width="767" alt="doc_after_bis" src="https://github.com/skrub-data/skrub/assets/57430673/53d3c7dc-ae07-40f7-863e-038526f78b77">
