### PR TITLE
DOC Remove `filterwarnings` from `03_datetime_encoder.py`

### DIFF
--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -100,13 +100,11 @@ print(encoder.get_feature_names_out())
 # As mentioned earlier, the |TableVectorizer| makes use of the
 # |DatetimeEncoder| by default.
 
-from pprint import pprint
-
 from skrub import TableVectorizer
 
 table_vec = TableVectorizer()
 table_vec.fit_transform(X)
-pprint(table_vec.get_feature_names_out())
+print(*table_vec.get_feature_names_out(), sep="\n")
 
 ###############################################################################
 # If we want to customize the |DatetimeEncoder| inside the |TableVectorizer|,
@@ -118,7 +116,7 @@ table_vec = TableVectorizer(
     datetime_transformer=DatetimeEncoder(add_day_of_the_week=True),
 )
 table_vec.fit_transform(X)
-table_vec.get_feature_names_out()
+print(*table_vec.get_feature_names_out(), sep="\n")
 
 ###############################################################################
 # .. note:
@@ -127,7 +125,7 @@ table_vec.get_feature_names_out()
 #
 # Inspecting the |TableVectorizer| further, we can check that the
 # |DatetimeEncoder| is used on the correct column(s).
-pprint(table_vec.transformers_)
+print(*table_vec.transformers_, sep="\n")
 
 ###############################################################################
 # Prediction with datetime features

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -45,6 +45,8 @@ It is used by default in the |TableVectorizer|.
 # In this setting, we want to predict the NO2 air concentration, based
 # on the location, date and time of measurement.
 
+from pprint import pprint
+
 import pandas as pd
 
 data = pd.read_csv(
@@ -83,7 +85,7 @@ encoder = make_column_transformer(
 )
 
 X_enc = encoder.fit_transform(X)
-print(encoder.get_feature_names_out())
+pprint(encoder.get_feature_names_out())
 
 ###############################################################################
 # We see that the encoder is working as expected: the "date.utc" column has
@@ -104,7 +106,7 @@ from skrub import TableVectorizer
 
 table_vec = TableVectorizer()
 table_vec.fit_transform(X)
-print(*table_vec.get_feature_names_out(), sep="\n")
+pprint(table_vec.get_feature_names_out())
 
 ###############################################################################
 # If we want to customize the |DatetimeEncoder| inside the |TableVectorizer|,
@@ -116,7 +118,7 @@ table_vec = TableVectorizer(
     datetime_transformer=DatetimeEncoder(add_day_of_the_week=True),
 )
 table_vec.fit_transform(X)
-print(*table_vec.get_feature_names_out(), sep="\n")
+pprint(table_vec.get_feature_names_out())
 
 ###############################################################################
 # .. note:
@@ -125,7 +127,7 @@ print(*table_vec.get_feature_names_out(), sep="\n")
 #
 # Inspecting the |TableVectorizer| further, we can check that the
 # |DatetimeEncoder| is used on the correct column(s).
-print(*table_vec.transformers_, sep="\n")
+pprint(table_vec.transformers_)
 
 ###############################################################################
 # Prediction with datetime features

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -36,9 +36,6 @@ It is used by default in the |TableVectorizer|.
     :class:`~sklearn.ensemble.HistGradientBoostingRegressor`
 """
 
-import warnings
-
-warnings.filterwarnings("ignore")
 
 ###############################################################################
 # A problem with relevant datetime features
@@ -86,7 +83,7 @@ encoder = make_column_transformer(
 )
 
 X_enc = encoder.fit_transform(X)
-encoder.get_feature_names_out()
+print(encoder.get_feature_names_out())
 
 ###############################################################################
 # We see that the encoder is working as expected: the "date.utc" column has
@@ -103,7 +100,6 @@ encoder.get_feature_names_out()
 # As mentioned earlier, the |TableVectorizer| makes use of the
 # |DatetimeEncoder| by default.
 
-from skrub import TableVectorizer
 from pprint import pprint
 
 from skrub import TableVectorizer
@@ -169,7 +165,6 @@ pipeline = make_pipeline(table_vec, HistGradientBoostingRegressor())
 # Instead, we can use the |TimeSeriesSplit|,
 # which ensures that the test set is always in the future.
 
-X["date.utc"] = pd.to_datetime(X["date.utc"])
 sorted_indices = np.argsort(X["date.utc"])
 X = X.iloc[sorted_indices]
 y = y.iloc[sorted_indices]
@@ -228,8 +223,8 @@ plt.show()
 ###############################################################################
 # Let's zoom on a few days:
 
-X_zoomed = X[X["date.utc"] <= "2019-06-04"][X["date.utc"] >= "2019-06-01"]
-y_zoomed = y[X["date.utc"] <= "2019-06-04"][X["date.utc"] >= "2019-06-01"]
+X_zoomed = X[(X["date.utc"] <= "2019-06-04") & (X["date.utc"] >= "2019-06-01")]
+y_zoomed = y[(X["date.utc"] <= "2019-06-04") & (X["date.utc"] >= "2019-06-01")]
 
 X_train_zoomed = X_zoomed[X_zoomed["date.utc"] < "2019-06-03"]
 X_test_zoomed = X_zoomed[X_zoomed["date.utc"] >= "2019-06-03"]


### PR DESCRIPTION
Towards #766

Also there is generated file `doc/sg_execution_times.rst` which isn't in .gitignore, if that makes sense to add it there I can do it here or in separate PR.