### PR TITLE
Add JupyterCon talk link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,8 @@ Additional resources
 --------------------
 
 * `Introductory video (YouTube) <https://youtu.be/_GNaaeEI2tg>`_
-* `Overview poster for EuroSciPy 2023 (Dropbox) <https://www.dropbox.com/scl/fi/89tapbshxtw0kh5uzx8dc/Poster-Euroscipy-2023.pdf?rlkey=u4ycpiyftk7rzttrjll9qlrkx&dl=0>`_
+* `JupyterCon 2023 talk (YouTube) <https://youtu.be/lvDN0wgTpeI>`_
+* `EuroSciPy 2023 poster (Dropbox) <https://www.dropbox.com/scl/fi/89tapbshxtw0kh5uzx8dc/Poster-Euroscipy-2023.pdf?rlkey=u4ycpiyftk7rzttrjll9qlrkx&dl=0>`_
 
 References
 ----------


### PR DESCRIPTION
Hi, small change to add a link to the JupyterCon 2023 talk to the README, it fits with the other resources we link to :)