### PR TITLE
DOC - set the browser tab icon 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -237,6 +237,8 @@ html_js_files = []
 # Project logo, to place at the top of the sidebar.
 html_logo = "_static/skrub.svg"
 
+# Icon to put in the browser tab.
+html_favicon = "_static/skrub.svg"
 
 # Modify the title to get good social-media links
 html_title = "skrub"


### PR DESCRIPTION
This PR sets the icon of the browser tab.

- Current:

![Screenshot from 2023-10-18 16-49-24](https://github.com/skrub-data/skrub/assets/65614794/246904d0-5c34-4009-ae40-a72fddc0dd5c)

- New: 

![Screenshot from 2023-10-18 16-48-15](https://github.com/skrub-data/skrub/assets/65614794/e7e633fa-ab9b-4e33-ba87-c49442011430)

