### PR TITLE
PR - issue766 - Fixed the ignore warnings for example 04_fuzzy_joining

### DIFF
--- a/examples/04_fuzzy_joining.py
+++ b/examples/04_fuzzy_joining.py
@@ -110,11 +110,6 @@ gdppc.sort_values(by="Country Name").tail(7)
 # we have extracted.
 #
 
-# We will ignore the warnings:
-import warnings
-
-warnings.filterwarnings("ignore")
-
 ###############################################################################
 # .. _example_fuzzy_join:
 #
@@ -253,8 +248,8 @@ fig = sns.regplot(
     y="Happiness score",
     lowess=True,
 )
-fig.set_ylabel("Happiness index")
-fig.set_title("Is a higher life expectancy linked to happiness?")
+fig.set_ylabel("Happiness Index")
+fig.set_title("Effect of Life Expectancy on Happiness")
 plt.tight_layout()
 plt.show()
 
@@ -289,8 +284,8 @@ fig = sns.regplot(
     y="Happiness score",
     lowess=True,
 )
-fig.set_ylabel("Happiness index")
-fig.set_title("Does a country's legal rights strength lead to happiness?")
+fig.set_ylabel("Happiness Index")
+fig.set_title("Effect of a Country's Strength of Legal Rights on Happiness")
 plt.tight_layout()
 plt.show()
 

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -354,8 +354,6 @@ def fuzzy_join(
     As expected, the category "nana" has no exact match (`match_score=1`).
     """
 
-    warnings.warn("This feature is still experimental.")
-
     if analyzer not in ["char", "word", "char_wb"]:
         raise ValueError(
             f"analyzer should be either 'char', 'word' or 'char_wb', got {analyzer!r}",


### PR DESCRIPTION
Working towards issue #766 

I have removed the warning thrown everytime fuzzy_join() is called. I have also got rid of the warnings.filterwarnings("ignore") in example 4. 

I have also changed a few of the titles and capitalisation in example 4 that I noticed. Happy to remove them and resubmit the pull request if you guys don't like them.

Let me know your thoughts - this is my first PR. Thanks guys