### PR TITLE
DOC - fix layout of search results page 

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -17,7 +17,6 @@
 .bd-main .bd-content {
     display: flex;
     height: 100%;
-    justify-content: flex-end;
     gap: 60px;
     /* margin: 0 20px; */
 }
@@ -155,7 +154,7 @@ div.sk-landing-bg-more-info {
     font-size: 3.2rem;
     margin-bottom: 5px;
 }
-  
+
 .sk-landing-subheader {
     letter-spacing: 0.17rem;
     margin-top: 5px;
@@ -175,7 +174,8 @@ div.sk-landing-footer {
  * affine formula to have a continuous function during the switch */
 @media (min-width: 1200px) {
     .bd-page-width, div.sk-landing-container, div.sk-landing-footer div.row {
-	width: calc(min(100vw, 90vw + 120px));
+    width: calc(min(100vw, 90vw + 120px));
+    }
 }
 
 @media (min-width: 1200px) {
@@ -201,5 +201,3 @@ div.sk-landing-footer {
 	max-width: 60rem;
     }
 }
-
-


### PR DESCRIPTION
## Context of the PR

The search result page is currently justified on the right as shown in the figure below.
Reproduce that by typing in text on the search bar.

- Before
![Screenshot from 2023-11-01 18-33-54](https://github.com/skrub-data/skrub/assets/65614794/5f0b2cc7-ea4b-449a-bbb6-cfbf780a81ad)

- After
![Screenshot from 2023-11-01 18-39-51](https://github.com/skrub-data/skrub/assets/65614794/7f96e81b-c677-44ba-abab-9e635bb8822f)


## Contributions of the PR

- remove justify-content property (checked it has no side-effects)
- fix the format and syntax of ``custom.css``