### PR TITLE
ensure test.sh exits with status 0 if tests fail

### DIFF
--- a/build_tools/github/test.sh
+++ b/build_tools/github/test.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -x
 
-pytest --pyargs skrub --cov=skrub -n auto --doctest-modules
-coverage xml
+pytest --pyargs skrub --cov=skrub -n auto --doctest-modules --cov-report xml


### PR DESCRIPTION
the problem was introduced in #797  because the added line `coverage xml` exits with code 0