### PR TITLE
[ENH] make `to_datetime` more robust to bad inputs

### DIFF
--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -377,6 +377,8 @@ def test_datetime_encoder_invalid_params():
         [1, 2],
         np.array([1, 2]),
         pd.Timestamp(2020, 1, 1),
+        np.array([pd.Timestamp(2020, 1, 1), "hello"]),
+        np.array(["2020-01-01", {"hello"}]),
         np.array(["2020-01-01", "hello", "2020-01-02"]),
     ],
 )


### PR DESCRIPTION
**Reference**
Follows-up on https://github.com/skrub-data/skrub/pull/784

**What does this PR implement?**

- Heterogeneous arrays containing arbitrary objects like sets raise TypeErrors. This PR fixes these by catching TypeError, which allows returning the input.
- Heterogeneous arrays containing datetimes objects like `pd.Timestamp` and `datetime.datetime` also raise errors, because Pandas' `guess_datetime_format` only accepts string values. We now skip the call to `guess_datetime_format`  by ensuring the input array is invariant under `astype(str)` transformation.

Before:
```python
import pandas as pd
from skrub import to_datetime

to_datetime([pd.Timestamp("2019-01-01"), "yo"])
# TypeError: float() argument must be a string or a real number, not 'Timestamp'

to_datetime([pd.Timestamp("2019-01-01"), "2020-01-01"])
# TypeError: float() argument must be a string or a real number, not 'Timestamp'

to_datetime(['2020-01-01', {'hello'}])
# TypeError: <class 'set'> is not convertible to datetime, at position 1

```

After:
```python
import pandas as pd
from skrub import to_datetime

to_datetime([pd.Timestamp("2019-01-01"), "yo"])
# no-op
#  array([Timestamp('2019-01-01 00:00:00'), 'yo'], dtype=object)

to_datetime([pd.Timestamp("2019-01-01"), "2020-01-01"])
# parsing
# array(['2019-01-01T00:00:00.000000000', '2020-01-01T00:00:00.000000000'],
#      dtype='datetime64[ns]')

to_datetime(['2020-01-01', {'hello'}])
# no-op
# array(['2020-01-01', {'hello'}], dtype=object)
```
