### PR TITLE
[MAIN] Preserve extension dtypes and categorical dtypes in `to_datetime`

### DIFF
--- a/skrub/_dataframe/_pandas.py
+++ b/skrub/_dataframe/_pandas.py
@@ -35,6 +35,8 @@ def make_dataframe(X, index=None, dtypes=None):
     """
     df = pd.DataFrame(X, index=index)
     if dtypes is not None:
+        # 'df.astype(None)' might raise a ValueError because
+        # it tries to cast all columns to floats.
         df = df.astype(dtypes)
     return df
 

--- a/skrub/_dataframe/_pandas.py
+++ b/skrub/_dataframe/_pandas.py
@@ -10,7 +10,7 @@ import pandas as pd
 from skrub._utils import atleast_1d_or_none
 
 
-def make_dataframe(X, index=None):
+def make_dataframe(X, index=None, dtypes=None):
     """Convert an dictionary of columns into a Pandas dataframe.
 
     Parameters
@@ -21,15 +21,25 @@ def make_dataframe(X, index=None):
     index : 1d array-like, default=None
         The index of the dataframe.
 
+    dtypes : str, data type, Series or Mapping of column name -> data type, default=None
+        Use a str, numpy.dtype, pandas.ExtensionDtype or Python type to
+        cast entire pandas object to the same type. Alternatively, use a
+        mapping, e.g. {col: dtype, ...}, where col is a column label and dtype is
+        a numpy.dtype or Python type to cast one or more of the DataFrame's
+        columns to column-specific types
+
     Returns
     -------
     X : Pandas dataframe
         Converted output.
     """
-    return pd.DataFrame(X, index=index)
+    df = pd.DataFrame(X, index=index)
+    if dtypes is not None:
+        df = df.astype(dtypes)
+    return df
 
 
-def make_series(X, index=None, name=None):
+def make_series(X, index=None, name=None, dtype=None):
     """Convert an 1d array into a Pandas series.
 
     Parameters
@@ -43,12 +53,16 @@ def make_series(X, index=None, name=None):
     name : str, default=None
         The name of the series.
 
+    dtype : str, numpy.dtype, or ExtensionDtype, default=None
+        Data type for the output Series.
+
     Returns
     -------
     X : Pandas series
         Converted output.
     """
-    return pd.Series(X, index=index, name=name)
+    series = pd.Series(X, index=index, name=name, dtype=dtype)
+    return series
 
 
 def aggregate(

--- a/skrub/_dataframe/_polars.py
+++ b/skrub/_dataframe/_polars.py
@@ -14,7 +14,7 @@ from itertools import product
 from skrub._utils import atleast_1d_or_none
 
 
-def make_dataframe(X, index=None):
+def make_dataframe(X, index=None, dtypes=None):
     """Convert an dictionary of columns into a Polars dataframe.
 
     Parameters
@@ -26,6 +26,10 @@ def make_dataframe(X, index=None):
         Unused since polars doesn't use index.
         Only here for compatibility with Pandas.
 
+    dtypes : DataType or mapping of column names to DataType, default=None
+        Mapping of column names (or selector) to dtypes, or a single dtype
+        to which all columns will be cast.
+
     Returns
     -------
     X : Polars dataframe
@@ -36,10 +40,13 @@ def make_dataframe(X, index=None):
             "Polars dataframes don't have an index, but "
             f"the Polars dataframe maker was called with {index=!r}."
         )
-    return pl.DataFrame(X)
+    df = pl.DataFrame(X)
+    if dtypes is not None:
+        df = df.cast(dtypes)
+    return df
 
 
-def make_series(X, index=None, name=None):
+def make_series(X, index=None, name=None, dtype=None):
     """Convert an 1d array into a Polars series.
 
     Parameters
@@ -54,6 +61,9 @@ def make_series(X, index=None, name=None):
     name : str, default=None
         The name of the series.
 
+    dtype : DataType, default=None
+        Polars dtype of the Series data.
+
     Returns
     -------
     X : Polars series
@@ -64,7 +74,8 @@ def make_series(X, index=None, name=None):
             "Polars series don't have an index, but "
             f"the Polars series maker was called with {index=!r}."
         )
-    return pl.Series(values=X, name=name)
+    series = pl.Series(values=X, name=name, dtype=dtype)
+    return series
 
 
 def aggregate(

--- a/skrub/_dataframe/tests/test_pandas.py
+++ b/skrub/_dataframe/tests/test_pandas.py
@@ -97,13 +97,21 @@ def test_no_agg_operation():
         )
 
 
-def test_make_dataframe():
+@pytest.mark.parametrize("dtypes", [None, {"a": "int64", "b": "category"}])
+def test_make_dataframe(dtypes):
     X = dict(a=[1, 2], b=["z", "e"])
+
     expected_df = pd.DataFrame(dict(a=[1, 2], b=["z", "e"]))
-    assert_frame_equal(make_dataframe(X, index=[0, 1]), expected_df)
+    if dtypes is not None:
+        expected_df = expected_df.astype(dtypes)
+
+    df = make_dataframe(X, index=[0, 1], dtypes=dtypes)
+    assert_frame_equal(df, expected_df)
 
 
-def test_make_series():
-    X = [1, 2, 3]
-    expected_series = pd.Series(X)
-    assert_series_equal(make_series(X, index=[0, 1, 2]), expected_series)
+@pytest.mark.parametrize("dtype", [None, "category"])
+def test_make_series(dtype):
+    X = ["1", "2", "3"]
+    expected_series = pd.Series(X, dtype=dtype)
+    series = make_series(X, index=[0, 1, 2], dtype=dtype)
+    assert_series_equal(series, expected_series)

--- a/skrub/_dataframe/tests/test_polars.py
+++ b/skrub/_dataframe/tests/test_polars.py
@@ -75,19 +75,27 @@ def test_incorrect_dataframe_inputs():
         )
 
 
-def test_make_dataframe():
+@pytest.mark.parametrize("dtypes", [None, {"a": pl.Int64, "b": pl.Utf8}])
+def test_make_dataframe(dtypes):
     X = dict(a=[1, 2], b=["z", "e"])
+
     expected_df = pl.DataFrame(dict(a=[1, 2], b=["z", "e"]))
-    assert_frame_equal(make_dataframe(X), expected_df)
+    if dtypes is not None:
+        expected_df = expected_df.cast(dtypes)
+
+    df = make_dataframe(X, dtypes=dtypes)
+    assert_frame_equal(df, expected_df)
 
     with pytest.raises(ValueError, match=r"(?=.*Polars dataframe)(?=.*index)"):
         make_dataframe(X, index=[0, 1])
 
 
-def test_make_series():
+@pytest.mark.parametrize("dtype", [None, pl.Int64])
+def test_make_series(dtype):
     X = [1, 2, 3]
-    expected_series = pl.Series(X)
-    assert_series_equal(make_series(X, index=None), expected_series)
+    expected_series = pl.Series(X, dtype=dtype)
+    series = make_series(X, index=None, dtype=dtype)
+    assert_series_equal(series, expected_series)
 
     with pytest.raises(ValueError, match=r"(?=.*Polars series)(?=.*index)"):
         make_series(X, index=[0, 1])

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -464,3 +464,12 @@ def test_monthfirst_only():
     out = to_datetime(X_col)
     expected_out = np.array(["2021-02-02", "2021-01-15"], dtype="datetime64[ns]")
     assert_array_equal(out, expected_out)
+
+
+def test_preserve_dtypes():
+    X = get_mixed_type_dataframe()
+    X["b"] = X["b"].astype("category")
+    non_datetime_columns = ["b", "c", "f"]
+
+    X_trans = to_datetime(X)
+    assert_frame_equal(X_trans[non_datetime_columns], X[non_datetime_columns])


### PR DESCRIPTION
**What does this PR address?**

`to_datetime` converts every dataframe's column into a list of vectors using `to_numpy()` for every column. This results in the loss of extension dtypes (e.g.,`pd.Int64Dtype`) and categorical dtypes since we recreate the original dataframe from this mapping of numpy 1d arrays.

- This PR suggests a simple **temporary** workaround that casts back to their original types all columns that are not parsed as datetime. In the future, we need to stop converting series with `to_numpy()` and specialize the datetime parsing logic for Pandas and Polars. We will remove this workaround then.
- It also extends the `make_series` and `make_dataframe` methods to accept dtypes argument.

Before
```python
import pandas as pd
from skrub import to_datetime

to_datetime(pd.Series(["1", "2", "3"], dtype="category"))
# 0    1
# 1    2
# 2    3
# dtype: object
```

After
```python
import pandas as pd
from skrub import to_datetime

to_datetime(pd.Series(["1", "2", "3"], dtype="category"))
# 0    1
# 1    2
# 2    3
# dtype: category
# Categories (3, object): ['1', '2', '3']
```