### PR TITLE
[FIX] Hotfix `to_datetime` for timezone

### DIFF
--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -5,6 +5,7 @@ from typing import Iterable
 import numpy as np
 import pandas as pd
 from pandas._libs.tslibs.parsing import guess_datetime_format
+from pandas.api.types import is_datetime64_any_dtype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.fixes import parse_version
@@ -314,7 +315,11 @@ def _get_datetime_column_indices(X_split, dayfirst=True):
     for col_idx, X_col in enumerate(X_split):
         X_col = X_col[pd.notnull(X_col)]  # X_col is a numpy array
 
-        if _is_column_datetime_parsable(X_col):
+        if is_datetime64_any_dtype(X_col):
+            indices.append(col_idx)
+            index_to_format[col_idx] = None
+
+        elif _is_column_datetime_parsable(X_col):
             indices.append(col_idx)
 
             # _guess_datetime_format only accept string columns.

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
+from pandas.api.types import is_datetime64_any_dtype
 from pandas.testing import assert_frame_equal
 
 from skrub._datetime_encoder import (
@@ -173,6 +174,23 @@ def test_fit(
     assert enc.index_to_format_ == expected_index_to_format
     assert enc.n_features_out_ == expected_n_features_out
     assert enc.get_feature_names_out() == expected_feature_names
+
+
+@pytest.mark.parametrize(
+    "get_data_func, expected_datetime_columns",
+    [
+        (get_date, [0, 1, 2]),
+        (get_datetime, [0, 1, 2]),
+        (get_tz_datetime, [0]),
+        (get_mixed_type_dataframe, ["a", "e"]),
+    ],
+)
+def test_to_datetime(get_data_func, expected_datetime_columns):
+    X = get_data_func()
+    X = to_datetime(X)
+    X = pd.DataFrame(X)
+    datetime_columns = [col for col in X.columns if is_datetime64_any_dtype(X[col])]
+    assert_array_equal(datetime_columns, expected_datetime_columns)
 
 
 def test_format_nan():


### PR DESCRIPTION
**Reference**

Fix a bug introduced in https://github.com/skrub-data/skrub/pull/828, which is currently [breaking the CI](https://app.circleci.com/pipelines/github/skrub-data/skrub/3132/workflows/821474d3-18dc-48d7-96d4-66392715d2b3/jobs/6139).

**What does this PR implement?**

- This PR suggests avoiding calling `_is_column_datetime_parsable` when the input is already of numeric or datetime data type, as initially proposed by Jérome https://github.com/skrub-data/skrub/pull/823#discussion_r1392726786.
- It also adds tests for `to_datetime`