### PR TITLE
[MAIN] Accelerate guess datetime format

### DIFF
--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -9,7 +9,7 @@ from pandas.api.types import is_datetime64_any_dtype, is_numeric_dtype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.fixes import parse_version
-from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.validation import check_is_fitted, check_random_state
 
 from ._dataframe._namespace import get_df_namespace
 
@@ -38,6 +38,7 @@ MIXED_FORMAT = "mixed" if _is_pandas_format_mixed_available() else None
 def to_datetime(
     X,
     errors="coerce",
+    random_state=None,
     **kwargs,
 ):
     """Convert the columns of a dataframe or 2d array into a datetime representation.
@@ -75,6 +76,10 @@ def to_datetime(
         match this format to ``NaT``.
 
         Note that the ``'ignore'`` option is not used and will raise an error.
+
+    random_state : int, RandomState instance or None, default=None
+        Determines random number generation for the subsampling during
+        datetime guessing. Use an int to make the randomness deterministic.
 
     **kwargs : key, value mappings
         Other keyword arguments are passed down to :func:`pandas.to_datetime`.
@@ -117,6 +122,7 @@ def to_datetime(
     if errors not in errors_options:
         raise ValueError(f"errors options are {errors_options!r}, got {errors!r}.")
     kwargs["errors"] = errors
+    kwargs["random_state"] = random_state
 
     if "unit" in kwargs:
         raise ValueError(
@@ -242,6 +248,7 @@ def _to_datetime_2d(
     indices=None,
     index_to_format=None,
     format=None,
+    random_state=None,
     **kwargs,
 ):
     """Convert datetime parsable columns from a 2d array or dataframe \
@@ -271,6 +278,10 @@ def _to_datetime_2d(
         If format is not None, all values of ``indices_to_format`` are set
         to format.
 
+    random_state : int, RandomState instance or None, default=None
+        Determines random number generation for the subsampling during
+        datetime guessing. Use an int to make the randomness deterministic.
+
     format : str, default=None
         When format is not None, it overwrites the values in indices_to_format.
 
@@ -279,7 +290,7 @@ def _to_datetime_2d(
     X_split : list of 1d array of length n_features
     """
     if indices is None:
-        indices, index_to_format = _get_datetime_column_indices(X_split)
+        indices, index_to_format = _get_datetime_column_indices(X_split, random_state)
 
     # format overwrite indices_to_format
     if format is not None:
@@ -293,7 +304,7 @@ def _to_datetime_2d(
     return X_split
 
 
-def _get_datetime_column_indices(X_split, dayfirst=True):
+def _get_datetime_column_indices(X_split, random_state=None):
     """Select the datetime parsable columns by their indices \
     and return their datetime format.
 
@@ -330,7 +341,7 @@ def _get_datetime_column_indices(X_split, dayfirst=True):
             # contains e.g., datetime.datetime or pd.Timestamp.
             X_col_str = X_col.astype(str)
             if np.array_equal(X_col, X_col_str):
-                datetime_format = _guess_datetime_format(X_col)
+                datetime_format = _guess_datetime_format(X_col, random_state)
             else:
                 # We don't need to specify a parsing format
                 # for columns that are already of type datetime64.
@@ -376,7 +387,7 @@ def _is_column_datetime_parsable(X_col):
         return False
 
 
-def _guess_datetime_format(X_col):
+def _guess_datetime_format(X_col, random_state=None):
     """Infer the format of a 1d array.
 
     This functions uses Pandas ``guess_datetime_format`` routine for both
@@ -403,6 +414,12 @@ def _guess_datetime_format(X_col):
     # raises a TypeError.
     # We have to convert these to the object dtype first.
     X_col = X_col.astype("object")
+
+    # Subsample samples for fast format estimation
+    size = min(X_col.shape[0], 10)
+    rng = check_random_state(random_state)
+    X_col = rng.choice(X_col, size=size, replace=False)
+
     vfunc = np.vectorize(guess_datetime_format)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=UserWarning)

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -312,6 +312,10 @@ def _get_datetime_column_indices(X_split, random_state=None):
     ----------
     X_split : list of 1d array of length n_features
 
+    random_state : int, RandomState instance or None, default=None
+        Determines random number generation for the subsampling during
+        datetime guessing. Use an int to make the randomness deterministic.
+
     Returns
     -------
     datetime_indices : list of int
@@ -405,6 +409,10 @@ def _guess_datetime_format(X_col, random_state=None):
     ----------
     X_col : ndarray of shape ``(n_samples,)``
         X_col must only contains string objects without any missing value.
+
+    random_state : int, RandomState instance or None, default=None
+        Determines random number generation for the subsampling during
+        datetime guessing. Use an int to make the randomness deterministic.
 
     Returns
     -------

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -401,9 +401,12 @@ def _guess_datetime_format(X_col, random_state=None):
     When both dayfirst and monthfirst format are possible, we select
     monthfirst by default.
 
-    You can overwrite this behaviour by setting a format of the caller function.
+    You can overwrite this behaviour by setting a format in the caller function.
     Setting a format always take precedence over infering it using
     ``_guess_datetime_format``.
+
+    For computational effiency, we only subsample ``n_samples`` rows of ``X_col``.
+    ``n_samples`` is currently set to 30.
 
     Parameters
     ----------
@@ -424,7 +427,8 @@ def _guess_datetime_format(X_col, random_state=None):
     X_col = X_col.astype("object")
 
     # Subsample samples for fast format estimation
-    size = min(X_col.shape[0], 10)
+    n_samples = 30
+    size = min(X_col.shape[0], n_samples)
     rng = check_random_state(random_state)
     X_col = rng.choice(X_col, size=size, replace=False)
 

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -185,9 +185,10 @@ def test_fit(
         (get_mixed_type_dataframe, ["a", "e"]),
     ],
 )
-def test_to_datetime(get_data_func, expected_datetime_columns):
+@pytest.mark.parametrize("random_state", np.arange(20))
+def test_to_datetime(get_data_func, expected_datetime_columns, random_state):
     X = get_data_func()
-    X = to_datetime(X)
+    X = to_datetime(X, random_state=random_state)
     X = pd.DataFrame(X)
     datetime_columns = [col for col in X.columns if is_datetime64_any_dtype(X[col])]
     assert_array_equal(datetime_columns, expected_datetime_columns)


### PR DESCRIPTION
**Reference**

This PR addresses https://github.com/skrub-data/skrub/issues/835

**What does this PR implement?**
- Sample 10 rows to infer the datetime format instead of using the whole array, yielding a 500x speed up on a 1d array of size 100k.
- Add some tests using 20 different `random_state`