### PR TITLE
Fix the homepage example links

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -70,13 +70,13 @@ href="generated/skrub.TableVectorizer.html#skrub.TableVectorizer"
 title="skrub.TableVectorizer"><code class="xref py py-class docutils
 literal notranslate"><span class="pre">TableVectorizer</span></code></a>:
 <strong>turn a pandas dataframe into a numerical array</strong> for
-machine learning. <a class="reference internal" href="auto_examples/01_dirty_categories.html#example-table-vectorizer"><span class="std std-ref">Example</span></a></p>
+machine learning. <a class="reference internal" href="auto_examples/01_encodings.html#example-table-vectorizer"><span class="std std-ref">Example</span></a></p>
 <p><a class="reference internal"
 href="generated/skrub.GapEncoder.html#skrub.GapEncoder"
 title="skrub.GapEncoder"><code class="xref py py-class docutils literal
 notranslate"><span class="pre">GapEncoder</span></code></a>,
 OneHotEncoder but robust to typos or non-normalized categories. <a
-class="reference internal" href="auto_examples/02_investigating_dirty_categories.html#example-gap-encoder"><span class="std std-ref">Example</span></a></p>
+class="reference internal" href="auto_examples/02_feature_interpretation_with_gapencoder.html#example-gap-encoder"><span class="std std-ref">Example</span></a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The encoding and gap_encoder example links on the homepage are currently broken.