### PR TITLE
MAINT Support Python 3.8+

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-            python-version: ["3.10", "3.11", "3.12"]
+            python-version: ["3.8", "3.11", "3.12"]
             # Install the min or latest dependencies for skrub
             # as defined in setup.cfg at [options.extra_require].
             #
@@ -51,13 +51,13 @@ jobs:
                 os-name: "Windows"
               - dependencies-version: "dev"
               - dependencies-version: "dev, pyarrow"
-                python-version: "3.11"
+                python-version: "3.8"
               - dependencies-version: "dev, polars"
                 python-version: "3.11"
               - dependencies-version: "dev, polars"
                 python-version: "3.12"
-              - dependencies-version: "dev, min-py310"
-                python-version: "3.10"
+              - dependencies-version: "dev, min-py38"
+                python-version: "3.8"
                 dependencies-version-type: "minimal"
     name: ${{ matrix.os-name }} with Python ${{ matrix.python-version }} and ${{ matrix.dependencies-version-type }} dependencies
     defaults:

--- a/benchmarks/bench_fuzzy_join_count_vs_hash.py
+++ b/benchmarks/bench_fuzzy_join_count_vs_hash.py
@@ -34,21 +34,21 @@ from utils.join import evaluate
 
 # Function kept for reference
 def fuzzy_join(
-    left: pd.DataFrame,
-    right: pd.DataFrame,
-    how: Literal["left", "right"] = "left",
-    left_on: Union[str, None] = None,
-    right_on: Union[str, None] = None,
-    on: Union[str, None] = None,
-    encoder: Literal["count", "hash"] = "count",
-    analyzer: Literal["word", "char", "char_wb"] = "char_wb",
-    ngram_range: Tuple[int, int] = (2, 4),
-    return_score: bool = False,
-    match_score: float = 0,
-    drop_unmatched: bool = False,
-    sort: bool = False,
-    suffixes: Tuple[str, str] = ("_x", "_y"),
-) -> pd.DataFrame:
+    left,
+    right,
+    how="left",
+    left_on=None,
+    right_on=None,
+    on=None,
+    encoder="count",
+    analyzer="char_wb",
+    ngram_range=(2, 4),
+    return_score=False,
+    match_score=0,
+    drop_unmatched=False,
+    sort=False,
+    suffixes=("_x", "_y"),
+):
     """
     Join two tables categorical string columns based on approximate
     matching and using morphological similarity.
@@ -317,10 +317,10 @@ benchmark_name = "bench_fuzzy_join_count_vs_hash"
     repeat=10,
 )
 def benchmark(
-    encoder: Literal["hash", "count"],
-    dataset_name: str,
-    analyzer: Literal["char_wb", "char", "word"],
-    ngram_range: tuple,
+    encoder,
+    dataset_name,
+    analyzer,
+    ngram_range,
 ):
     left_table, right_table, gt = load_data(dataset_name)
 
@@ -352,7 +352,7 @@ def benchmark(
     return res_dic
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.set_theme(style="ticks", palette="pastel")
 
     n_datasets = len(np.unique(df["dataset_name"]))

--- a/benchmarks/bench_fuzzy_join_count_vs_hash.py
+++ b/benchmarks/bench_fuzzy_join_count_vs_hash.py
@@ -14,7 +14,6 @@ Date: December 2022
 import math
 from argparse import ArgumentParser
 from time import perf_counter
-from typing import Literal, Tuple, Union
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -9,7 +9,6 @@ Date: June 2023
 """
 
 import math
-from pathlib import Path
 from utils import default_parser, find_result, monitor
 from utils.join import evaluate, fetch_big_data
 from argparse import ArgumentParser
@@ -17,7 +16,6 @@ import numbers
 import warnings
 from collections.abc import Iterable
 from time import perf_counter
-from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -35,11 +35,11 @@ from sklearn.preprocessing import StandardScaler
 
 
 def _numeric_encoding(
-    main: pd.DataFrame,
-    main_cols: list | str,
-    aux: pd.DataFrame,
-    aux_cols: list | str,
-) -> tuple:
+    main,
+    main_cols,
+    aux,
+    aux_cols,
+):
     """Encoding numerical columns.
 
     Parameters
@@ -71,15 +71,15 @@ def _numeric_encoding(
 
 
 def _string_encoding(
-    main: pd.DataFrame,
-    main_cols: list | str,
-    aux: pd.DataFrame,
-    aux_cols: list | str,
-    analyzer: Literal["word", "char", "char_wb"],
-    ngram_range: int | int,
-    encoder: _VectorizerMixin = None,
-    sparse: bool = True,
-) -> tuple:
+    main,
+    main_cols,
+    aux,
+    aux_cols,
+    analyzer,
+    ngram_range,
+    encoder=None,
+    sparse=True,
+):
     """Encoding string columns.
 
     Parameters
@@ -147,7 +147,7 @@ def _string_encoding(
         return main_enc_d, aux_enc_d
 
 
-def _nearest_matches(main_array, aux_array, sparse=True) -> np.ndarray | np.ndarray:
+def _nearest_matches(main_array, aux_array, sparse=True):
     """Find the closest matches using the nearest neighbors method.
 
     Parameters
@@ -182,23 +182,23 @@ def _nearest_matches(main_array, aux_array, sparse=True) -> np.ndarray | np.ndar
 
 
 def fuzzy_join(
-    left: pd.DataFrame,
-    right: pd.DataFrame,
-    how: Literal["left", "right"] = "left",
-    left_on: str | list[str] | list[int] | None = None,
-    right_on: str | list[str] | list[int] | None = None,
-    on: str | list[str] | list[int] | None = None,
-    numerical_match: Literal["string", "number"] = "number",
-    encoder: _VectorizerMixin = None,
-    analyzer: Literal["word", "char", "char_wb"] = "char_wb",
-    ngram_range: tuple[int, int] = (2, 4),
-    return_score: bool = False,
-    match_score: float = 0,
-    drop_unmatched: bool = False,
-    sort: bool = False,
-    suffixes: tuple[str, str] = ("_x", "_y"),
-    sparse: bool = True,
-) -> pd.DataFrame:
+    left,
+    right,
+    how="left",
+    left_on=None,
+    right_on=None,
+    on=None,
+    numerical_match="number",
+    encoder=None,
+    analyzer="char_wb",
+    ngram_range=(2, 4),
+    return_score=False,
+    match_score=0,
+    drop_unmatched=False,
+    sort=False,
+    suffixes=("_x", "_y"),
+    sparse=True,
+):
     """
     Join two tables categorical string columns based on approximate
     matching and using morphological similarity.
@@ -522,12 +522,12 @@ benchmark_name = "bench_fuzzy_join_sparse_vs_dense"
     save_as=benchmark_name,
 )
 def benchmark(
-    sparse: bool,
-    dataset_name: str,
-    analyzer: Literal["char_wb", "char", "word"],
-    ngram_range: tuple,
-    data_home: Path | str | None = None,
-    data_directory: str | None = "benchmarks_data",
+    sparse,
+    dataset_name,
+    analyzer,
+    ngram_range,
+    data_home=None,
+    data_directory="benchmarks_data",
 ):
     left_table, right_table, gt = fetch_big_data(
         dataset_name=dataset_name, data_home=data_home, data_directory=data_directory
@@ -574,7 +574,7 @@ def benchmark(
     return res_dic
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.set_theme(style="ticks", palette="pastel")
 
     n_datasets = len(np.unique(df["dataset_name"]))

--- a/benchmarks/bench_fuzzy_join_vs_others.py
+++ b/benchmarks/bench_fuzzy_join_vs_others.py
@@ -96,8 +96,8 @@ benchmark_name = "bench_fuzzy_join_vs_others"
     repeat=5,
 )
 def benchmark(
-    dataset_name: str,
-    join: str,
+    dataset_name,
+    join,
 ):
     left_table, right_table, gt = load_data(dataset_name)
 
@@ -151,7 +151,7 @@ def benchmark(
     return res_dic
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.set_theme(style="ticks", palette="pastel")
 
     n_datasets = len(np.unique(df["dataset_name"]))

--- a/benchmarks/bench_gap_divergence.py
+++ b/benchmarks/bench_gap_divergence.py
@@ -56,10 +56,10 @@ from utils import (
 
 
 class ModifiedGapEncoderColumn(GapEncoderColumn):
-    def __init__(self, *args, column_name: str = "MISSING COLUMN", **kwargs):
+    def __init__(self, *args, column_name="MISSING COLUMN", **kwargs):
         super().__init__(*args, **kwargs)
         self.column_name = column_name
-        self.benchmark_results_: list[dict[str, np.ndarray | float]] = []
+        self.benchmark_results_ = []
 
     def fit(self, X, y=None):
         # Copy parameter rho
@@ -124,9 +124,9 @@ class ModifiedGapEncoderColumn(GapEncoderColumn):
 
 
 class ModifiedGapEncoder(GapEncoder):
-    fitted_models_: list[ModifiedGapEncoderColumn]
+    # fitted_models_: list[ModifiedGapEncoderColumn]
 
-    def _create_column_gap_encoder(self, column_name: str):
+    def _create_column_gap_encoder(self, column_name):
         return ModifiedGapEncoderColumn(
             column_name=column_name,
             ngram_range=self.ngram_range,
@@ -187,7 +187,7 @@ benchmark_name = Path(__file__).stem
     },
     save_as=benchmark_name,
 )
-def benchmark(max_iter_e_step: int, dataset_name: str):
+def benchmark(max_iter_e_step, dataset_name):
     """
     Cross-validate a pipeline with a modified `GapEncoder` instance for the
     high cardinality column. The rest of the columns are passed to a
@@ -261,7 +261,7 @@ def benchmark(max_iter_e_step: int, dataset_name: str):
     return results
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     # Keep only the last outer iteration
     df = df[df["gap_iter"] == 5]
 

--- a/benchmarks/bench_gap_encoder_hp.py
+++ b/benchmarks/bench_gap_encoder_hp.py
@@ -47,12 +47,12 @@ benchmark_name = "gap_encoder_benchmark_hp"
     repeat=1,
 )
 def benchmark(
-    high_card_feature: str,
-    batch_size: int,
-    max_iter_e_step: int,
-    max_rows: int,
-    max_no_improvement: int,
-    random_state: int,
+    high_card_feature,
+    batch_size,
+    max_iter_e_step,
+    max_rows,
+    max_no_improvement,
+    random_state,
 ):
     X = np.array(ds.X[high_card_feature]).reshape(-1, 1).astype(str)
     y = ds.y
@@ -109,7 +109,7 @@ def benchmark(
     return res_dic
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     base_values = {"batch_size": 1024, "max_iter_e_step": 1, "max_no_improvement": 5}
     for variable in base_values.keys():
         df_to_plot = df

--- a/benchmarks/bench_gap_es_score.py
+++ b/benchmarks/bench_gap_es_score.py
@@ -81,7 +81,7 @@ class ModifiedGapEncoderColumn(GapEncoderColumn):
 
         return False
 
-    def fit(self, X, y=None) -> "GapEncoderColumn":
+    def fit(self, X, y=None):
         """
         Fit the GapEncoder on `X`.
 
@@ -163,7 +163,7 @@ class ModifiedGapEncoderColumn(GapEncoderColumn):
 
 
 class ModifiedGapEncoder(GapEncoder):
-    fitted_models_: list[ModifiedGapEncoderColumn]
+    # fitted_models_: list[ModifiedGapEncoderColumn]
 
     def _create_column_gap_encoder(self):
         return ModifiedGapEncoderColumn(
@@ -218,9 +218,9 @@ benchmark_name = "gap_encoder_benchmark_es_score"
     repeat=2,
 )
 def benchmark(
-    high_card_feature: str,
-    max_rows: int,
-    modif: bool,
+    high_card_feature,
+    max_rows,
+    modif,
 ):
     ds = fetch_traffic_violations()
     X = np.array(ds.X[high_card_feature]).reshape(-1, 1).astype(str)
@@ -276,7 +276,7 @@ def benchmark(
     return res_dic
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.lineplot(
         x="train_size", y="time_fit", data=df, hue="high_card_feature", style="modif"
     )

--- a/benchmarks/bench_minhash_batch_number.py
+++ b/benchmarks/bench_minhash_batch_number.py
@@ -108,20 +108,20 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
 
     """
 
-    hash_dict_: LRUDict
+    # hash_dict_: LRUDict
 
-    _capacity: int = 2**10
+    _capacity = 2**10
 
     def __init__(
         self,
-        n_components: int = 30,
-        ngram_range: tuple[int, int] = (2, 4),
-        hashing: Literal["fast", "murmur"] = "fast",
-        minmax_hash: bool = False,
-        handle_missing: Literal["error", "zero_impute"] = "zero_impute",
-        batch: bool = False,
-        batch_per_job: int = 1,
-        n_jobs: int = None,
+        n_components=30,
+        ngram_range=(2, 4),
+        hashing="fast",
+        minmax_hash=False,
+        handle_missing="zero_impute",
+        batch=False,
+        batch_per_job=1,
+        n_jobs=None,
     ):
         self.ngram_range = ngram_range
         self.n_components = n_components
@@ -132,13 +132,13 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
         self.batch_per_job = batch_per_job
         self.n_jobs = n_jobs
 
-    def _more_tags(self) -> dict[str, list[str]]:
+    def _more_tags(self):
         """
         Used internally by sklearn to ease the estimator checks.
         """
         return {"X_types": ["categorical"]}
 
-    def _get_murmur_hash(self, string: str) -> np.array:
+    def _get_murmur_hash(self, string):
         """
         Encode a string using murmur hashing function.
 
@@ -166,7 +166,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
             min_hashes = np.minimum(min_hashes, hash_array)
         return min_hashes / (2**32 - 1)
 
-    def _get_fast_hash(self, string: str) -> np.array:
+    def _get_fast_hash(self, string):
         """
         Encode a string with fast hashing function.
         fast hashing supports both min_hash and minmax_hash encoding.
@@ -196,9 +196,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
                 ]
             )
 
-    def _compute_hash(
-        self, string: str, hash_func: Callable[[str], np.ndarray]
-    ) -> np.ndarray:
+    def _compute_hash(self, string, hash_func):
         """Function called to compute the hash of a string.
 
         Check if the string is in the hash dictionary, if not, scompute the hash using
@@ -223,9 +221,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
                 self.hash_dict_[string] = hash_func(string)
         return self.hash_dict_[string]
 
-    def _compute_hash_batched(
-        self, batch: Collection[str], hash_func: Callable[[str], np.ndarray]
-    ):
+    def _compute_hash_batched(self, batch, hash_func):
         """Function called to compute the hashes of a batch of strings.
 
         Check if the string is in the hash dictionary, if not, compute the hash using
@@ -253,7 +249,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
             res[i] = self.hash_dict_[string]
         return res
 
-    def fit(self, X, y=None) -> "MinHashEncoder":
+    def fit(self, X, y=None):
         """
         Fit the MinHashEncoder to X. In practice, just initializes a dictionary
         to store encodings to speed up computation.
@@ -283,7 +279,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
         self.hash_dict_ = LRUDict(capacity=self._capacity)
         return self
 
-    def transform(self, X) -> np.array:
+    def transform(self, X):
         """
         Transform X using specified encoding scheme.
 
@@ -389,18 +385,18 @@ benchmark_name = "bench_minhash_batch_number"
     repeat=10,
 )
 def benchmark(
-    dataset_size: str,
-    batched: bool,
-    n_jobs: int,
-    batch_per_job: int,
-) -> None:
+    dataset_size,
+    batched,
+    n_jobs,
+    batch_per_job,
+):
     X = data[dataset_size]
     MinHashEncoder(batch=batched, n_jobs=n_jobs, batch_per_job=batch_per_job).fit(
         X
     ).transform(X)
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.set_theme(style="ticks", palette="pastel")
 
     # Create a new columns merging batched and batch_per_job

--- a/benchmarks/bench_minhash_batch_number.py
+++ b/benchmarks/bench_minhash_batch_number.py
@@ -9,9 +9,7 @@ Date: February 2023
 
 import pickle
 from argparse import ArgumentParser
-from collections.abc import Callable, Collection
 from pathlib import Path
-from typing import Literal
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/benchmarks/bench_tablevectorizer_tuning.py
+++ b/benchmarks/bench_tablevectorizer_tuning.py
@@ -53,9 +53,9 @@ benchmark_name = "bench_tablevectorizer_tuning"
     repeat=3,
 )
 def benchmark(
-    tv_cardinality_threshold: int,
-    minhash_n_components: int,
-    dataset_name: str,
+    tv_cardinality_threshold,
+    minhash_n_components,
+    dataset_name,
 ):
     tv = TableVectorizer(
         cardinality_threshold=tv_cardinality_threshold,
@@ -84,7 +84,7 @@ def benchmark(
     }
 
 
-def plot(df: pd.DataFrame):
+def plot(df):
     sns.set_theme(style="ticks", palette="pastel")
 
     n_datasets = len(np.unique(df["dataset_name"]))

--- a/benchmarks/run_on_openml_datasets.py
+++ b/benchmarks/run_on_openml_datasets.py
@@ -178,7 +178,7 @@ for type_id, problem, pipeline, metric in [
             errors[task_id] = str(e)
             continue
 
-logger.info(f"Finished! ")
+logger.info("Finished! ")
 logger.error(f"{len(errors)} tasks with errors: {set(errors.keys())}")
 # print all unique errors
 errors_counter = Counter(errors.values())

--- a/benchmarks/utils/_various.py
+++ b/benchmarks/utils/_various.py
@@ -14,11 +14,11 @@ from skrub.datasets import (
 from skrub.datasets import DatasetAll
 
 
-def find_result(bench_name: str) -> Path:
+def find_result(bench_name):
     return choose_file(find_results(bench_name))
 
 
-def find_results(bench_name: str) -> list[Path]:
+def find_results(bench_name):
     """
     Returns the list of results in the results' directory.
     """
@@ -30,7 +30,7 @@ def find_results(bench_name: str) -> list[Path]:
     ]
 
 
-def choose_file(results: list[Path]) -> Path:
+def choose_file(results):
     """
     Given a list of files, chooses one based on these rules:
     - If there are no files to choose from, exit the program
@@ -66,7 +66,7 @@ def choose_file(results: list[Path]) -> Path:
         return results[int(choice) - 1]
 
 
-def get_classification_datasets() -> dict[str, DatasetAll]:
+def get_classification_datasets():
     return {
         "open_payments": fetch_open_payments(),
         "drug_directory": fetch_drug_directory(),
@@ -76,7 +76,7 @@ def get_classification_datasets() -> dict[str, DatasetAll]:
     }
 
 
-def get_regression_datasets() -> dict[str, DatasetAll]:
+def get_regression_datasets():
     return {
         "medical_charge": fetch_medical_charge(),
         "employee_salaries": fetch_employee_salaries(),

--- a/benchmarks/utils/_various.py
+++ b/benchmarks/utils/_various.py
@@ -11,7 +11,6 @@ from skrub.datasets import (
     fetch_road_safety,
     fetch_traffic_violations,
 )
-from skrub.datasets import DatasetAll
 
 
 def find_result(bench_name):

--- a/benchmarks/utils/join.py
+++ b/benchmarks/utils/join.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from pathlib import Path
 
 from skrub.datasets._utils import get_data_dir
 

--- a/benchmarks/utils/join.py
+++ b/benchmarks/utils/join.py
@@ -5,9 +5,9 @@ from skrub.datasets._utils import get_data_dir
 
 
 def get_local_data(
-    dataset_name: str,
-    data_home: Path | str | None = None,
-    data_directory: str | None = None,
+    dataset_name,
+    data_home=None,
+    data_directory=None,
 ):
     """Get the path to the local datasets."""
     data_directory = get_data_dir(data_directory, data_home)
@@ -25,11 +25,11 @@ def get_local_data(
 
 
 def fetch_data(
-    dataset_name: str,
-    save: bool = True,
-    data_home: Path | str | None = None,
-    data_directory: str | None = None,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    dataset_name,
+    save=True,
+    data_home=None,
+    data_directory=None,
+):
     """Fetch datasets from https://github.com/Yeye-He/Auto-Join/tree/master/autojoin-Benchmark  # noqa
 
     Parameters
@@ -83,12 +83,12 @@ def fetch_data(
 
 
 def fetch_big_data(
-    dataset_name: str,
-    data_type: str = "Dirty",
-    save: bool = True,
-    data_home: Path | str | None = None,
-    data_directory: str | None = None,
-) -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    dataset_name,
+    data_type="Dirty",
+    save=True,
+    data_home=None,
+    data_directory=None,
+):
     """Fetch datasets from https://github.com/anhaidgroup/deepmatcher/blob/master/Datasets.md  # noqa
 
     Parameters

--- a/benchmarks/utils/monitor.py
+++ b/benchmarks/utils/monitor.py
@@ -2,14 +2,13 @@ import tracemalloc
 import os
 
 from collections import defaultdict
-from collections.abc import Callable, Collection, Mapping
+from collections.abc import Mapping
 from datetime import datetime
 from itertools import product
 from pathlib import Path
 from random import choice
 from string import ascii_letters, digits
 from time import perf_counter, time as get_time
-from typing import Any
 from warnings import warn
 
 import pandas as pd

--- a/benchmarks/utils/monitor.py
+++ b/benchmarks/utils/monitor.py
@@ -18,13 +18,13 @@ from tqdm import tqdm
 
 def monitor(
     *,
-    parametrize: Collection[Mapping[Any]] | Mapping[str, Collection[Any]] | None = None,
-    save_as: str | None = None,
-    memory: bool = True,
-    time: bool = True,
-    repeat: int = 1,
-    hot_load: str | None = None,
-) -> Callable[..., Callable[..., pd.DataFrame]]:
+    parametrize=None,
+    save_as=None,
+    memory=True,
+    time=True,
+    repeat=1,
+    hot_load=None,
+):
     """Decorator used to monitor the execution of a function.
 
     The decorated function should return either:
@@ -128,9 +128,7 @@ def monitor(
 
     reserved_column_names = {"iter", "time", "memory"}
 
-    def decorator(
-        func: Callable[..., Mapping[str, Any] | list[Mapping[str, Any]] | None]
-    ):
+    def decorator(func):
         """
         Catches the decorated function.
 
@@ -140,7 +138,7 @@ def monitor(
             The decorated function callable object.
         """
 
-        def wrapper(*call_args, **call_kwargs) -> pd.DataFrame:
+        def wrapper(*call_args, **call_kwargs):
             """
             Catches the decorated function's call arguments.
 
@@ -162,7 +160,7 @@ def monitor(
                     f"positional values: {call_args!r}"
                 )
 
-            def get_random_file_name() -> str:
+            def get_random_file_name():
                 """
                 Returns a random file name, used by hot-loading.
                 Format is ``{time}-{random_string}.parquet``.
@@ -171,7 +169,7 @@ def monitor(
                 time = int(get_time())
                 return f"{time}-{name}.parquet"
 
-            def load_intermediate_results(file_name: str) -> pd.DataFrame:
+            def load_intermediate_results(file_name):
                 """
                 Loads the results from the file passed.
                 If the file is not found, and to avoid unexpected behavior,
@@ -184,12 +182,12 @@ def monitor(
 
                 return pd.read_parquet(file_name)
 
-            def product_map(iterables: Mapping[str, Any]):
+            def product_map(iterables):
                 """``itertools.product`` with mapping support."""
                 for combination in product(*iterables.values()):
                     yield dict(zip(iterables.keys(), combination))
 
-            def exec_func(**kwargs) -> pd.DataFrame:
+            def exec_func(**kwargs):
                 """
                 Wraps the decorated function call with a single set of
                 parameters, and pre-process the returned values.
@@ -274,7 +272,7 @@ def monitor(
 
                 return df_results
 
-            parametrization: list[Mapping]
+            # parametrization: list[Mapping]
             if parametrize is None:
                 # Use the parameters passed by the call
                 parametrization = [call_kwargs]

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -69,7 +69,7 @@ Create a virtual environment, here for example, using `conda <https://docs.conda
 
 .. code:: console
 
-    $ conda create -n skrub python=3.10 # or any later python version
+    $ conda create -n skrub python=3.8 # or any later python version
     $ conda activate skrub
 
 Then, install the local package in editable mode,

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -178,7 +178,6 @@ cross_val_score(
 #
 # The mean squared error is not obvious to interpret, so we compare
 # visually the prediction of our model with the actual values.
-import numpy as np
 import matplotlib.pyplot as plt
 
 mask_train = X["date.utc"] < "2019-06-01"

--- a/examples/08_join_aggregation.py
+++ b/examples/08_join_aggregation.py
@@ -232,7 +232,7 @@ from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
 operations = ["mean", "hist(3)", "hist(5)", "hist(7)", "value_counts"]
 param_grid = [
     {
-        f"aggtarget-2__operation": [op],
+        "aggtarget-2__operation": [op],
     }
     for op in operations
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,8 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -32,7 +34,7 @@ install_requires =
     scipy>=1.9.3
     pandas>=1.5.3
     packaging>=23.1
-python_requires = >=3.10
+python_requires = >=3.8
 
 [options.packages.find]
 include = skrub*
@@ -80,7 +82,7 @@ benchmarks =
     loguru
 # Overwrite the previous install_requires for CI testing purposes
 # as defined in testing.yml.
-min-py310 =
+min-py38 =
     scikit-learn==1.2.1
     numpy==1.23.5
     scipy==1.9.3

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -22,7 +22,7 @@ CATEG_OPERATIONS = ["mode", "count", "value_counts"]
 ALL_OPS = NUM_OPERATIONS + CATEG_OPERATIONS
 
 
-def split_num_categ_operations(operations: list[str]) -> tuple[list[str], list[str]]:
+def split_num_categ_operations(operations):
     """Separate aggregagor operators input by their type.
 
     Parameters
@@ -434,9 +434,9 @@ class AggTarget(BaseEstimator, TransformerMixin):
 
     def __init__(
         self,
-        main_key: str | Iterable[str],
-        operation: str | Iterable[str] | None = None,
-        suffix: str | None = None,
+        main_key,
+        operation=None,
+        suffix=None,
     ):
         self.main_key = main_key
         self.operation = operation

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -6,7 +6,6 @@ Both classes aggregate the auxiliary tables first, then join these grouped
 tables with the base table.
 """
 from copy import deepcopy
-from typing import Iterable
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin

--- a/skrub/_deduplicate.py
+++ b/skrub/_deduplicate.py
@@ -15,10 +15,10 @@ from sklearn.metrics import silhouette_score
 
 
 def compute_ngram_distance(
-    unique_words: Sequence[str] | NDArray,
-    ngram_range: tuple[int, int] = (2, 4),
-    analyzer: str = "char_wb",
-) -> NDArray:
+    unique_words,
+    ngram_range=(2, 4),
+    analyzer="char_wb",
+):
     """Compute the condensed pair-wise n-gram distance between `unique_words`.
 
     Parameters
@@ -52,15 +52,13 @@ def compute_ngram_distance(
     return distance_mat
 
 
-def _get_silhouette_avg(Z: NDArray, n_clust: int, redundant_dist: NDArray) -> float:
+def _get_silhouette_avg(Z, n_clust, redundant_dist):
     labels = fcluster(Z, n_clust, criterion="maxclust")
     silhouette_avg = silhouette_score(redundant_dist, labels, metric="precomputed")
     return silhouette_avg
 
 
-def _guess_clusters(
-    Z: NDArray, distance_mat: NDArray, n_jobs: int | None = None
-) -> int:
+def _guess_clusters(Z, distance_mat, n_jobs=None):
     """Finds the number of clusters that maximize the silhouette score
     when clustering `distance_mat`.
 
@@ -88,10 +86,10 @@ def _guess_clusters(
 
 
 def _create_spelling_correction(
-    unique_words: Sequence[str] | NDArray[np.str_],
-    counts: Sequence[int] | NDArray[np.int_],
-    clusters: Sequence[int],
-) -> pd.Series:
+    unique_words,
+    counts,
+    clusters,
+):
     """
     Creates a pandas Series that map each cluster member to the most
     frequent cluster member. The assumption is that the most common spelling
@@ -115,8 +113,8 @@ def _create_spelling_correction(
         corrected spelling of each word as values.
     """
     count_series = pd.Series(counts, index=unique_words)
-    original_spelling: list[str] = []
-    corrected_spelling: list[str] = []
+    original_spelling = []
+    corrected_spelling = []
     for cluster in np.unique(clusters):
         sorted_spellings = (
             count_series.loc[clusters == cluster]

--- a/skrub/_deduplicate.py
+++ b/skrub/_deduplicate.py
@@ -2,12 +2,10 @@
 Implements deduplication based on clustering string distance matrices.
 """
 
-from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
-from numpy.typing import NDArray
 from scipy.cluster.hierarchy import fcluster, linkage
 from scipy.spatial.distance import pdist, squareform
 from sklearn.feature_extraction.text import TfidfVectorizer

--- a/skrub/_fast_hash.py
+++ b/skrub/_fast_hash.py
@@ -48,11 +48,11 @@ def gen_atom(atom_len, seed=0):
 
 
 def ngram_min_hash(
-    string: str,
-    ngram_range: tuple[int, int] = (2, 4),
-    seed: int = 0,
+    string,
+    ngram_range=(2, 4),
+    seed=0,
     return_minmax=False,
-) -> int | tuple[int, int]:
+):
     """
     Compute the min/max hash of the ngrams of the string.
 

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -37,29 +37,29 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         For more information.
     """
 
-    rho_: float
-    H_dict_: dict[NDArray, NDArray]
+    # rho_: float
+    # H_dict_: dict[NDArray, NDArray]
 
     def __init__(
         self,
-        n_components: int = 10,
-        batch_size: int = 1024,
-        gamma_shape_prior: float = 1.1,
-        gamma_scale_prior: float = 1.0,
-        rho: float = 0.95,
-        rescale_rho: bool = False,
-        hashing: bool = False,
-        hashing_n_features: int = 2**12,
-        init: Literal["k-means++", "random", "k-means"] = "k-means++",
-        max_iter: int = 5,
-        ngram_range: tuple[int, int] = (2, 4),
-        analyzer: Literal["word", "char", "char_wb"] = "char",
-        add_words: bool = False,
-        random_state: int | RandomState | None = None,
-        rescale_W: bool = True,
-        max_iter_e_step: int = 1,
-        max_no_improvement: int = 5,
-        verbose: int = 0,
+        n_components=10,
+        batch_size=1024,
+        gamma_shape_prior=1.1,
+        gamma_scale_prior=1.0,
+        rho=0.95,
+        rescale_rho=False,
+        hashing=False,
+        hashing_n_features=2**12,
+        init="k-means++",
+        max_iter=5,
+        ngram_range=(2, 4),
+        analyzer="char",
+        add_words=False,
+        random_state=None,
+        rescale_W=True,
+        max_iter_e_step=1,
+        max_no_improvement=5,
+        verbose=0,
     ):
         self.ngram_range = ngram_range
         self.n_components = n_components
@@ -80,7 +80,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.max_no_improvement = max_no_improvement
         self.verbose = verbose
 
-    def _init_vars(self, X) -> tuple[NDArray, NDArray, NDArray]:
+    def _init_vars(self, X):
         """
         Build the bag-of-n-grams representation `V` of `X` and initialize
         the topics `W`.
@@ -135,7 +135,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             self.rho_ = self.rho ** (self.batch_size / len(X))
         return unq_X, unq_V, lookup
 
-    def _get_H(self, X: NDArray) -> NDArray:
+    def _get_H(self, X):
         """
         Return the bag-of-n-grams representation of `X`.
         """
@@ -144,7 +144,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             h_out[:] = self.H_dict_[x]
         return H_out
 
-    def _init_w(self, V: NDArray, X) -> tuple[NDArray, NDArray, NDArray]:
+    def _init_w(self, V, X):
         """
         Initialize the topics `W`.
         If `self.init='k-means++'`, we use the init method of
@@ -200,11 +200,11 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
 
     def _minibatch_convergence(
         self,
-        batch_size: int,
-        batch_cost: float,
-        n_samples: int,
-        step: int,
-        n_steps: int,
+        batch_size,
+        batch_cost,
+        n_samples,
+        step,
+        n_steps,
     ):
         """
         Helper function to encapsulate the early stopping logic.
@@ -276,7 +276,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
 
         return False
 
-    def fit(self, X: ArrayLike, y=None) -> "GapEncoderColumn":
+    def fit(self, X, y=None):
         """
         Fit the GapEncoder on `X`.
 
@@ -357,9 +357,9 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
 
     def get_feature_names_out(
         self,
-        n_labels: int = 3,
-        prefix: str = "",
-    ) -> list[str]:
+        n_labels=3,
+        prefix="",
+    ):
         """
         Returns the labels that best summarize the learned components/topics.
         For each topic, labels with the highest activations are selected.
@@ -402,7 +402,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             topic_labels.append(label)
         return topic_labels
 
-    def score(self, X: ArrayLike) -> float:
+    def score(self, X):
         """Score this instance of `X`.
 
         Returns the Kullback-Leibler divergence between the n-grams counts
@@ -446,7 +446,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         )
         return kl_divergence
 
-    def partial_fit(self, X: ArrayLike, y=None) -> "GapEncoderColumn":
+    def partial_fit(self, X, y=None):
         """Partial fit this instance on `X`.
 
         To be used in an online learning procedure where batches of data are
@@ -524,7 +524,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
         self.H_dict_.update(zip(unq_X, unq_H))
         return self
 
-    def _add_unseen_keys_to_H_dict(self, X) -> None:
+    def _add_unseen_keys_to_H_dict(self, X):
         """
         Add activations of unseen string categories from `X` to `H_dict`.
         """
@@ -540,7 +540,7 @@ class GapEncoderColumn(BaseEstimator, TransformerMixin):
             )
             self.H_dict_.update(zip(unseen_X, unseen_H))
 
-    def transform(self, X: ArrayLike) -> NDArray:
+    def transform(self, X):
         """Return the encoded vectors (activations) `H` of input strings in `X`.
 
         Parameters
@@ -750,33 +750,33 @@ class GapEncoder(TransformerMixin, BaseEstimator):
     The higher the value, the bigger the correspondence with the topic.
     """
 
-    rho_: float
-    fitted_models_: list[GapEncoderColumn]
-    column_names_: list[str]
+    # rho_: float
+    # fitted_models_: list[GapEncoderColumn]
+    # column_names_: list[str]
 
     def __init__(
         self,
         *,
-        n_components: int = 10,
-        batch_size: int = 1024,
-        gamma_shape_prior: float = 1.1,
-        gamma_scale_prior: float = 1.0,
-        rho: float = 0.95,
-        rescale_rho: bool = False,
-        hashing: bool = False,
-        hashing_n_features: int = 2**12,
-        init: Literal["k-means++", "random", "k-means"] = "k-means++",
-        max_iter: int = 5,
-        ngram_range: tuple[int, int] = (2, 4),
-        analyzer: Literal["word", "char", "char_wb"] = "char",
-        add_words: bool = False,
-        random_state: int | RandomState | None = None,
-        rescale_W: bool = True,
-        max_iter_e_step: int = 1,
-        max_no_improvement: int = 5,
-        handle_missing: Literal["error", "empty_impute"] = "zero_impute",
-        n_jobs: int | None = None,
-        verbose: int = 0,
+        n_components=10,
+        batch_size=1024,
+        gamma_shape_prior=1.1,
+        gamma_scale_prior=1.0,
+        rho=0.95,
+        rescale_rho=False,
+        hashing=False,
+        hashing_n_features=2**12,
+        init="k-means++",
+        max_iter=5,
+        ngram_range=(2, 4),
+        analyzer="char",
+        add_words=False,
+        random_state=None,
+        rescale_W=True,
+        max_iter_e_step=1,
+        max_no_improvement=5,
+        handle_missing="zero_impute",
+        n_jobs=None,
+        verbose=0,
     ):
         self.ngram_range = ngram_range
         self.n_components = n_components
@@ -799,7 +799,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
         self.n_jobs = n_jobs
         self.verbose = verbose
 
-    def _create_column_gap_encoder(self) -> GapEncoderColumn:
+    def _create_column_gap_encoder(self):
         """Helper method for creating a GapEncoderColumn from
         the parameters of this instance."""
         return GapEncoderColumn(
@@ -844,7 +844,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
 
         return X
 
-    def fit(self, X: ArrayLike, y=None) -> "GapEncoder":
+    def fit(self, X, y=None):
         """Fit the instance on X.
 
         Parameters
@@ -881,7 +881,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
         )
         return self
 
-    def transform(self, X: ArrayLike) -> NDArray:
+    def transform(self, X):
         """Return the encoded vectors (activations) `H` of input strings in `X`.
 
         Given the learnt topics `W`, the activations `H` are tuned to fit
@@ -913,7 +913,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
         X_enc = np.hstack(X_enc)
         return X_enc
 
-    def partial_fit(self, X: ArrayLike, y=None) -> "GapEncoder":
+    def partial_fit(self, X, y=None):
         """Partial fit this instance on X.
 
         To be used in an online learning procedure where batches of data are
@@ -950,8 +950,8 @@ class GapEncoder(TransformerMixin, BaseEstimator):
 
     def get_feature_names_out(
         self,
-        col_names: Literal["auto"] | list[str] | None = None,
-        n_labels: int = 3,
+        col_names=None,
+        n_labels=3,
         input_features=None,
     ):
         """Return the labels that best summarize the learned components/topics.
@@ -1000,7 +1000,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
             labels.extend(col_labels)
         return np.asarray(labels, dtype=object)
 
-    def score(self, X: ArrayLike, y=None) -> float:
+    def score(self, X, y=None):
         """Score this instance on `X`.
 
         Returns the sum over the columns of `X` of the Kullback-Leibler
@@ -1047,7 +1047,7 @@ class GapEncoder(TransformerMixin, BaseEstimator):
         }
 
 
-def _rescale_W(W: NDArray, A: NDArray) -> None:
+def _rescale_W(W, A):
     """
     Rescale the topics `W` to have a L1-norm equal to 1.
     Note that they are modified in-place.
@@ -1081,14 +1081,14 @@ def _special_sparse_dot(H, W, X):
 
 
 def _multiplicative_update_w(
-    Vt: NDArray,
-    W: NDArray,
-    A: NDArray,
-    B: NDArray,
-    Ht: NDArray,
-    rescale_W: bool,
-    rho: float,
-) -> tuple[NDArray, NDArray, NDArray]:
+    Vt,
+    W,
+    A,
+    B,
+    Ht,
+    rescale_W,
+    rho,
+):
     """
     Multiplicative update step for the topics `W`.
     """
@@ -1107,7 +1107,7 @@ def _multiplicative_update_w(
     return W, A, B
 
 
-def _rescale_h(V: NDArray, H: NDArray) -> NDArray:
+def _rescale_h(V, H):
     """
     Rescale the activations `H`.
     """
@@ -1118,14 +1118,14 @@ def _rescale_h(V: NDArray, H: NDArray) -> NDArray:
 
 
 def _multiplicative_update_h(
-    Vt: NDArray,
-    W: NDArray,
-    Ht: NDArray,
-    epsilon: float = 1e-3,
-    max_iter: int = 10,
-    rescale_W: bool = False,
-    gamma_shape_prior: float = 1.1,
-    gamma_scale_prior: float = 1.0,
+    Vt,
+    W,
+    Ht,
+    epsilon=1e-3,
+    max_iter=10,
+    rescale_W=False,
+    gamma_shape_prior=1.1,
+    gamma_scale_prior=1.0,
 ):
     """
     Multiplicative update step for the activations `H`.
@@ -1155,9 +1155,9 @@ def _multiplicative_update_h(
 
 
 def batch_lookup(
-    lookup: NDArray,
-    n: int = 1,
-) -> Generator[tuple[NDArray, NDArray], None, None]:
+    lookup,
+    n=1,
+):
     """
     Make batches of the lookup array.
     """
@@ -1169,15 +1169,15 @@ def batch_lookup(
 
 
 def get_kmeans_prototypes(
-    X: ArrayLike,
-    n_prototypes: int,
-    analyzer: Literal["word", "char", "char_wb"] = "char",
-    hashing_dim: int = 128,
-    ngram_range: tuple[int, int] = (2, 4),
-    sparse: bool = False,
+    X,
+    n_prototypes,
+    analyzer="char",
+    hashing_dim=128,
+    ngram_range=(2, 4),
+    sparse=False,
     sample_weight=None,
-    random_state: int | RandomState | None = None,
-) -> NDArray:
+    random_state=None,
+):
     """
     Computes prototypes based on:
       - dimensionality reduction (via hashing n-grams)

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -3,16 +3,12 @@ Implements the GapEncoder: a probabilistic encoder for categorical variables.
 """
 from __future__ import annotations
 
-from collections.abc import Generator
 from copy import deepcopy
-from typing import Literal
 
 import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 from joblib import Parallel, delayed
-from numpy.random import RandomState
-from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.cluster import KMeans, kmeans_plusplus

--- a/skrub/_minhash_encoder.py
+++ b/skrub/_minhash_encoder.py
@@ -115,19 +115,19 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
             -1.45918266e+09, -1.58098831e+09]])
     """
 
-    hash_dict_: LRUDict
+    # hash_dict_: LRUDict
 
-    _capacity: int = 2**10
+    _capacity = 2**10
 
     def __init__(
         self,
         *,
-        n_components: int = 30,
-        ngram_range: tuple[int, int] = (2, 4),
-        hashing: Literal["fast", "murmur"] = "fast",
-        minmax_hash: bool = False,
-        handle_missing: Literal["error", "zero_impute"] = "zero_impute",
-        n_jobs: int = None,
+        n_components=30,
+        ngram_range=(2, 4),
+        hashing="fast",
+        minmax_hash=False,
+        handle_missing="zero_impute",
+        n_jobs=None,
     ):
         self.ngram_range = ngram_range
         self.n_components = n_components
@@ -136,7 +136,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
         self.handle_missing = handle_missing
         self.n_jobs = n_jobs
 
-    def _get_murmur_hash(self, string: str) -> NDArray:
+    def _get_murmur_hash(self, string):
         """
         Encode a string using murmur hashing function.
 
@@ -164,7 +164,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
             min_hashes = np.minimum(min_hashes, hash_array)
         return min_hashes / (2**32 - 1)
 
-    def _get_fast_hash(self, string: str) -> NDArray:
+    def _get_fast_hash(self, string):
         """Encode a string with fast hashing function.
 
         Fast hashing supports both min_hash and minmax_hash encoding.
@@ -194,9 +194,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
                 ]
             )
 
-    def _compute_hash_batched(
-        self, batch: Collection[str], hash_func: Callable[[str], NDArray]
-    ) -> NDArray:
+    def _compute_hash_batched(self, batch, hash_func):
         """Function called to compute the hashes of a batch of strings.
 
         Check if the string is in the hash dictionary, if not, compute the hash
@@ -224,7 +222,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
             res[i] = self.hash_dict_[string]
         return res
 
-    def fit(self, X: ArrayLike, y=None) -> "MinHashEncoder":
+    def fit(self, X, y=None):
         """Fit the MinHashEncoder to `X`.
 
         In practice, just initializes a dictionary
@@ -259,7 +257,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
         self.hash_dict_ = LRUDict(capacity=self._capacity)
         return self
 
-    def transform(self, X: ArrayLike) -> NDArray:
+    def transform(self, X):
         """
         Transform `X` using specified encoding scheme.
 
@@ -342,9 +340,7 @@ class MinHashEncoder(TransformerMixin, BaseEstimator):
 
         return X_out.astype(np.float64)  # The output is an int32 before conversion
 
-    def get_feature_names_out(
-        self, input_features: ArrayLike | str | None = None
-    ) -> NDArray[np.str_]:
+    def get_feature_names_out(self, input_features=None):
         """Get output feature names for transformation.
 
         The output feature names look like:

--- a/skrub/_minhash_encoder.py
+++ b/skrub/_minhash_encoder.py
@@ -4,12 +4,8 @@ applying the MinHash method to n-gram decompositions of strings.
 """
 from __future__ import annotations
 
-from collections.abc import Callable, Collection
-from typing import Literal
-
 import numpy as np
 from joblib import Parallel, delayed, effective_n_jobs
-from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import gen_even_slices, murmurhash3_32
 from sklearn.utils.validation import _check_feature_names_in, check_is_fitted

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -3,13 +3,11 @@ Implements the SimilarityEncoder, a generalization of the OneHotEncoder,
 which encodes similarity instead of equality of values.
 """
 
-from typing import Literal
 
 import numpy as np
 import pandas as pd
 import sklearn
 from joblib import Parallel, delayed
-from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 from sklearn.preprocessing import OneHotEncoder

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -23,15 +23,15 @@ from ._string_distances import get_ngram_count, preprocess
 
 
 def _ngram_similarity_one_sample_inplace(
-    x_count_vector: NDArray,
-    vocabulary_count_matrix: NDArray,
-    str_x: str,
-    vocabulary_ngram_counts: NDArray,
-    se_dict: dict,
-    unq_X: NDArray,
-    i: int,
-    ngram_range: tuple[int, int],
-) -> None:
+    x_count_vector,
+    vocabulary_count_matrix,
+    str_x,
+    vocabulary_ngram_counts,
+    se_dict,
+    unq_X,
+    i,
+    ngram_range,
+):
     """
     Update inplace a dict of similarities between a string and a vocabulary
 
@@ -74,12 +74,12 @@ def _ngram_similarity_one_sample_inplace(
 
 def ngram_similarity_matrix(
     X,
-    cats: list[str],
-    ngram_range: tuple[int, int],
-    analyzer: Literal["word", "char", "char_wb"],
-    hashing_dim: int,
-    dtype: type = np.float64,
-) -> NDArray:
+    cats,
+    ngram_range,
+    analyzer,
+    hashing_dim,
+    dtype=np.float64,
+):
     """
     Similarity encoding for dirty categorical variables:
     Given two arrays of strings, returns the similarity encoding matrix
@@ -261,25 +261,25 @@ class SimilarityEncoder(OneHotEncoder):
           dtype=object)
     """
 
-    categories_: list[NDArray]
-    n_features_in_: int
-    drop_idx_: NDArray
-    vectorizers_: list[CountVectorizer]
-    vocabulary_count_matrices_: list[NDArray]
-    vocabulary_ngram_counts_: list[list[int]]
-    _infrequent_enabled: bool
+    # categories_: list[NDArray]
+    # n_features_in_: int
+    # drop_idx_: NDArray
+    # vectorizers_: list[CountVectorizer]
+    # vocabulary_count_matrices_: list[NDArray]
+    # vocabulary_ngram_counts_: list[list[int]]
+    # _infrequent_enabled: bool
 
     def __init__(
         self,
         *,
-        ngram_range: tuple[int, int] = (2, 4),
-        analyzer: Literal["word", "char", "char_wb"] = "char",
-        categories: Literal["auto"] | list[list[str]] = "auto",
-        dtype: type = np.float64,
-        handle_unknown: Literal["error", "ignore"] = "ignore",
-        handle_missing: Literal["error", ""] = "",
-        hashing_dim: int | None = None,
-        n_jobs: int | None = None,
+        ngram_range=(2, 4),
+        analyzer="char",
+        categories="auto",
+        dtype=np.float64,
+        handle_unknown="ignore",
+        handle_missing="",
+        hashing_dim=None,
+        n_jobs=None,
     ):
         super().__init__()
         self.categories = categories
@@ -298,7 +298,7 @@ class SimilarityEncoder(OneHotEncoder):
                     "'auto' or a list of prototypes. "
                 )
 
-    def fit(self, X: ArrayLike, y=None) -> "SimilarityEncoder":
+    def fit(self, X, y=None):
         """Fit the instance to `X`.
 
         Parameters
@@ -422,7 +422,7 @@ class SimilarityEncoder(OneHotEncoder):
         self._n_features_outs = list(map(len, self.categories_))
         return self
 
-    def transform(self, X: ArrayLike, fast: bool = True) -> NDArray:
+    def transform(self, X, fast=True):
         """Transform `X` using specified encoding scheme.
 
         Parameters
@@ -498,9 +498,9 @@ class SimilarityEncoder(OneHotEncoder):
 
     def _ngram_similarity_fast(
         self,
-        X: list | NDArray,
-        col_idx: int,
-    ) -> NDArray:
+        X,
+        col_idx,
+    ):
         """
         Fast computation of ngram similarity.
 

--- a/skrub/_string_distances.py
+++ b/skrub/_string_distances.py
@@ -8,7 +8,7 @@ from collections import Counter
 # TODO vectorize these functions (accept arrays)
 
 
-def get_ngram_count(string: str, ngram_range: tuple[int, int]) -> int:
+def get_ngram_count(string, ngram_range):
     """
     Compute the number of ngrams in a string.
 
@@ -30,7 +30,7 @@ def get_ngram_count(string: str, ngram_range: tuple[int, int]) -> int:
     return ngram_count
 
 
-def preprocess(x: str) -> str:
+def preprocess(x):
     """
     Combine preprocessing done by CountVectorizer and the SimilarityEncoder.
 
@@ -56,7 +56,7 @@ def preprocess(x: str) -> str:
     return _white_spaces.sub(" ", x)
 
 
-def get_unique_ngrams(string: str, ngram_range: tuple[int, int]):
+def get_unique_ngrams(string, ngram_range):
     """
     Return the set of unique n-grams of a string.
 
@@ -83,7 +83,7 @@ def get_unique_ngrams(string: str, ngram_range: tuple[int, int]):
     return ngram_set
 
 
-def get_ngrams(string: str, n: int) -> list[tuple]:
+def get_ngrams(string, n):
     """Return the set of different n-grams in a string"""
     # Pure Python implementation: no numpy
     spaces = " "  # * (n // 2 + n % 2)

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -20,7 +20,6 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.compose import ColumnTransformer
 from sklearn.compose._column_transformer import _get_transformer_list
 from sklearn.preprocessing import OneHotEncoder
-from sklearn.utils import Bunch
 from sklearn.utils.validation import check_is_fitted
 
 from skrub import DatetimeEncoder, GapEncoder, to_datetime

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -782,7 +782,7 @@ sparse_output=False), \
         return transformers
 
     @property
-    def named_transformers_(self) -> Bunch:
+    def named_transformers_(self):
         """Map transformer names to transformer objects.
 
         Read-only attribute to access any transformer by given name.
@@ -792,7 +792,7 @@ sparse_output=False), \
         return self._column_transformer.named_transformers_
 
     @property
-    def sparse_output_(self) -> bool:
+    def sparse_output_(self):
         """Whether the output of ``transform`` is sparse or dense.
 
         Boolean flag indicating whether the output of ``transform`` is a
@@ -802,7 +802,7 @@ sparse_output=False), \
         return self._column_transformer.sparse_output_
 
     @property
-    def output_indices_(self) -> dict[str, slice]:
+    def output_indices_(self):
         """Map the transformer names to their input indices.
 
         A dictionary from each transformer name to a slice, where the slice
@@ -812,7 +812,7 @@ sparse_output=False), \
         """
         return self._column_transformer.output_indices_
 
-    def _more_tags(self) -> dict:
+    def _more_tags(self):
         """
         Used internally by sklearn to ease the estimator checks.
         """

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -15,11 +15,11 @@ class LRUDict:
 
     Using LRU eviction avoids memorizing a full dataset"""
 
-    def __init__(self, capacity: int):
+    def __init__(self, capacity):
         self.capacity = capacity
         self.cache = collections.OrderedDict()
 
-    def __getitem__(self, key: Hashable):
+    def __getitem__(self, key):
         try:
             value = self.cache.pop(key)
             self.cache[key] = value
@@ -27,7 +27,7 @@ class LRUDict:
         except KeyError:
             return -1
 
-    def __setitem__(self, key: Hashable, value: Any):
+    def __setitem__(self, key, value):
         try:
             self.cache.pop(key)
         except KeyError:
@@ -35,11 +35,11 @@ class LRUDict:
                 self.cache.popitem(last=False)
         self.cache[key] = value
 
-    def __contains__(self, key: Hashable):
+    def __contains__(self, key):
         return key in self.cache
 
 
-def check_input(X) -> NDArray:
+def check_input(X):
     """
     Check input with sklearn standards.
     Also converts X to a numpy array if not already.
@@ -66,7 +66,7 @@ def check_input(X) -> NDArray:
     return X_
 
 
-def import_optional_dependency(name: str, extra: str = ""):
+def import_optional_dependency(name, extra=""):
     """Import an optional dependency.
 
     By default, if a dependency is missing an ImportError with a nice

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -1,11 +1,9 @@
 import collections
 import importlib
 import re
-from collections.abc import Hashable
-from typing import Any, Iterable
+from typing import Iterable
 
 import numpy as np
-from numpy.typing import NDArray
 from sklearn.base import clone
 from sklearn.utils import check_array
 

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -17,7 +17,7 @@ import warnings
 from dataclasses import dataclass
 from itertools import chain
 from pathlib import Path
-from typing import Any, Literal, TextIO
+from typing import Any
 from urllib.error import URLError
 from zipfile import BadZipFile, ZipFile
 
@@ -41,24 +41,24 @@ from skrub.datasets._utils import get_data_dir
 # ``Experimental`` so the structure might change in future releases.
 # This path will be concatenated to the skrub data directory,
 # available via the function ``get_data_dir()``.
-DETAILS_DIRECTORY      = "openml/openml.org/api/v1/json/data/"
+DETAILS_DIRECTORY = "openml/openml.org/api/v1/json/data/"
 
 # Same as above; for the datasets features location.
-FEATURES_DIRECTORY      = "openml/openml.org/api/v1/json/data/features/"
+FEATURES_DIRECTORY = "openml/openml.org/api/v1/json/data/features/"
 
 # Same as above; for the datasets data location.
-DATA_DIRECTORY      = "openml/openml.org/data/v1/download/"
+DATA_DIRECTORY = "openml/openml.org/data/v1/download/"
 
 # The IDs of the datasets, from OpenML.
 # For each dataset, its URL is constructed as follows:
-openml_url      = "https://www.openml.org/d/{ID}"
-ROAD_SAFETY_ID      = 42803
-OPEN_PAYMENTS_ID      = 42738
-MIDWEST_SURVEY_ID      = 42805
-MEDICAL_CHARGE_ID      = 42720
-EMPLOYEE_SALARIES_ID      = 42125
-TRAFFIC_VIOLATIONS_ID      = 42132
-DRUG_DIRECTORY_ID      = 43044
+openml_url = "https://www.openml.org/d/{ID}"
+ROAD_SAFETY_ID = 42803
+OPEN_PAYMENTS_ID = 42738
+MIDWEST_SURVEY_ID = 42805
+MEDICAL_CHARGE_ID = 42720
+EMPLOYEE_SALARIES_ID = 42125
+TRAFFIC_VIOLATIONS_ID = 42132
+DRUG_DIRECTORY_ID = 43044
 
 MOVIELENS_URL = "https://files.grouplens.org/datasets/movielens/{zip_directory}.zip"
 
@@ -112,7 +112,7 @@ class DatasetAll:
     path: Path
     read_csv_kwargs: dict[str, Any]
 
-    def __eq__(self, other            )        :
+    def __eq__(self, other):
         """
         Implemented for the tests to work without bloating the code.
         The main reason for which it's needed is that equality between
@@ -152,9 +152,9 @@ class DatasetInfoOnly:
 
 
 def _fetch_openml_dataset(
-    dataset_id     ,
-    data_directory              = None,
-)                  :
+    dataset_id,
+    data_directory=None,
+):
     """
     Gets a dataset from OpenML (https://www.openml.org).
 
@@ -228,9 +228,9 @@ def _fetch_openml_dataset(
 
 
 def _fetch_world_bank_data(
-    indicator_id     ,
-    data_directory              = None,
-)                  :
+    indicator_id,
+    data_directory=None,
+):
     """Gets a dataset from World Bank open data platform (https://data.worldbank.org/).
 
     Parameters
@@ -311,9 +311,9 @@ def _fetch_world_bank_data(
 
 
 def _fetch_figshare(
-    figshare_id     ,
-    data_directory              = None,
-)                  :
+    figshare_id,
+    data_directory=None,
+):
     """Fetch a dataset from figshare using the download ID number.
 
     Parameters
@@ -424,7 +424,7 @@ def _fetch_figshare(
             raise URLError("No internet connection or the website is down.")
 
 
-def _fetch_movielens(dataset_id     , data_directory              = None)             :
+def _fetch_movielens(dataset_id, data_directory=None):
     """Downloads a subset of the Movielens dataset.
 
     Parameters
@@ -488,7 +488,7 @@ def _download_and_write_movielens_dataset(dataset_id, data_directory, zip_direct
         raise
 
 
-def _download_and_write_openml_dataset(dataset_id     , data_directory      )        :
+def _download_and_write_openml_dataset(dataset_id, data_directory):
     """Downloads a dataset from OpenML, taking care of creating the directories.
 
     Parameters
@@ -532,7 +532,7 @@ def _download_and_write_openml_dataset(dataset_id     , data_directory      )   
     )
 
 
-def _read_json_from_gz(compressed_dir_path      )        :
+def _read_json_from_gz(compressed_dir_path):
     """Opens a gzip file, reads its content (JSON expected), and returns a dictionary.
 
     Parameters
@@ -557,7 +557,7 @@ def _read_json_from_gz(compressed_dir_path      )        :
     return details_json
 
 
-def _get_details(compressed_dir_path      )           :
+def _get_details(compressed_dir_path):
     """Gets useful details from the details file.
 
     Parameters
@@ -581,7 +581,7 @@ def _get_details(compressed_dir_path      )           :
     )
 
 
-def _get_features(compressed_dir_path      )            :
+def _get_features(compressed_dir_path):
     """Gets features that can be inserted in the CSV file.
 
     The most important feature are the column names.
@@ -603,9 +603,7 @@ def _get_features(compressed_dir_path      )            :
     return Features(names=[column["name"] for column in raw_features["feature"]])
 
 
-def _export_gz_data_to_csv(
-    compressed_dir_path      , destination_file      , features          
-)        :
+def _export_gz_data_to_csv(compressed_dir_path, destination_file, features):
     """Reads a gzip file containing ARFF data, and writes it to a CSV file.
 
     Parameters
@@ -620,7 +618,7 @@ def _export_gz_data_to_csv(
     atdata_found = False
     with destination_file.open(mode="w", encoding="utf8") as csv:
         with gzip.open(compressed_dir_path, mode="rt", encoding="utf8") as gz:
-            #gz: TextIO  # Clarify for IDEs
+            # gz: TextIO  # Clarify for IDEs
             csv.write(_features_to_csv_format(features))
             csv.write("\n")
             # We will look at each line of the file until we find
@@ -633,19 +631,19 @@ def _export_gz_data_to_csv(
                     csv.write(line)
 
 
-def _features_to_csv_format(features          )       :
+def _features_to_csv_format(features):
     return ",".join(features.names)
 
 
 def _fetch_dataset_as_dataclass(
-    source                                             ,
-    dataset_name     ,
-    dataset_id           ,
-    target            ,
-    load_dataframe      ,
-    data_directory                    = None,
-    read_csv_kwargs              = None,
-)                                :
+    source,
+    dataset_name,
+    dataset_id,
+    target,
+    load_dataframe,
+    data_directory=None,
+    read_csv_kwargs=None,
+):
     """Fetches a dataset from a source, and returns it as a dataclass.
 
     Takes a dataset identifier, a target column name (if applicable),
@@ -725,12 +723,12 @@ def _fetch_dataset_as_dataclass(
 
 def fetch_employee_salaries(
     *,
-    load_dataframe       = True,
-    drop_linked       = True,
-    drop_irrelevant       = True,
-    overload_job_titles       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    drop_linked=True,
+    drop_irrelevant=True,
+    overload_job_titles=True,
+    data_directory=None,
+):
     """Fetches the employee salaries dataset (regression), available at https://openml.org/d/42125
 
     Description of the dataset:
@@ -797,9 +795,9 @@ def fetch_employee_salaries(
 
 def fetch_road_safety(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the road safety dataset (classification), available at https://openml.org/d/42803
 
     Description of the dataset:
@@ -831,9 +829,9 @@ def fetch_road_safety(
 
 def fetch_medical_charge(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the medical charge dataset (regression), available at https://openml.org/d/42720
 
     Description of the dataset:
@@ -870,9 +868,9 @@ def fetch_medical_charge(
 
 def fetch_midwest_survey(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the midwest survey dataset (classification), available at https://openml.org/d/42805
 
     Description of the dataset:
@@ -902,9 +900,9 @@ def fetch_midwest_survey(
 
 def fetch_open_payments(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the open payments dataset (classification), available at https://openml.org/d/42738
 
     Description of the dataset:
@@ -936,9 +934,9 @@ def fetch_open_payments(
 
 def fetch_traffic_violations(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the traffic violations dataset (classification), available at https://openml.org/d/42132
 
     Description of the dataset:
@@ -972,9 +970,9 @@ def fetch_traffic_violations(
 
 def fetch_drug_directory(
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches the drug directory dataset (classification), available at https://openml.org/d/43044
 
     Description of the dataset:
@@ -1004,11 +1002,11 @@ def fetch_drug_directory(
 
 
 def fetch_world_bank_indicator(
-    indicator_id     ,
+    indicator_id,
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches a dataset of an indicator from the World Bank open data platform.
 
     Description of the dataset:
@@ -1035,11 +1033,11 @@ def fetch_world_bank_indicator(
 
 
 def fetch_figshare(
-    figshare_id     ,
+    figshare_id,
     *,
-    load_dataframe       = True,
-    data_directory                    = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches a table of from figshare.
 
     Returns
@@ -1061,11 +1059,11 @@ def fetch_figshare(
 
 
 def fetch_movielens(
-    dataset_id      = "ratings",
+    dataset_id="ratings",
     *,
-    load_dataframe       = True,
-    data_directory              = None,
-)                                :
+    load_dataframe=True,
+    data_directory=None,
+):
     """Fetches a dataset from Movielens.
 
     Parameters

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -41,24 +41,24 @@ from skrub.datasets._utils import get_data_dir
 # ``Experimental`` so the structure might change in future releases.
 # This path will be concatenated to the skrub data directory,
 # available via the function ``get_data_dir()``.
-DETAILS_DIRECTORY: str = "openml/openml.org/api/v1/json/data/"
+DETAILS_DIRECTORY      = "openml/openml.org/api/v1/json/data/"
 
 # Same as above; for the datasets features location.
-FEATURES_DIRECTORY: str = "openml/openml.org/api/v1/json/data/features/"
+FEATURES_DIRECTORY      = "openml/openml.org/api/v1/json/data/features/"
 
 # Same as above; for the datasets data location.
-DATA_DIRECTORY: str = "openml/openml.org/data/v1/download/"
+DATA_DIRECTORY      = "openml/openml.org/data/v1/download/"
 
 # The IDs of the datasets, from OpenML.
 # For each dataset, its URL is constructed as follows:
-openml_url: str = "https://www.openml.org/d/{ID}"
-ROAD_SAFETY_ID: int = 42803
-OPEN_PAYMENTS_ID: int = 42738
-MIDWEST_SURVEY_ID: int = 42805
-MEDICAL_CHARGE_ID: int = 42720
-EMPLOYEE_SALARIES_ID: int = 42125
-TRAFFIC_VIOLATIONS_ID: int = 42132
-DRUG_DIRECTORY_ID: int = 43044
+openml_url      = "https://www.openml.org/d/{ID}"
+ROAD_SAFETY_ID      = 42803
+OPEN_PAYMENTS_ID      = 42738
+MIDWEST_SURVEY_ID      = 42805
+MEDICAL_CHARGE_ID      = 42720
+EMPLOYEE_SALARIES_ID      = 42125
+TRAFFIC_VIOLATIONS_ID      = 42132
+DRUG_DIRECTORY_ID      = 43044
 
 MOVIELENS_URL = "https://files.grouplens.org/datasets/movielens/{zip_directory}.zip"
 
@@ -112,7 +112,7 @@ class DatasetAll:
     path: Path
     read_csv_kwargs: dict[str, Any]
 
-    def __eq__(self, other: DatasetAll) -> bool:
+    def __eq__(self, other            )        :
         """
         Implemented for the tests to work without bloating the code.
         The main reason for which it's needed is that equality between
@@ -152,9 +152,9 @@ class DatasetInfoOnly:
 
 
 def _fetch_openml_dataset(
-    dataset_id: int,
-    data_directory: Path | None = None,
-) -> dict[str, Any]:
+    dataset_id     ,
+    data_directory              = None,
+)                  :
     """
     Gets a dataset from OpenML (https://www.openml.org).
 
@@ -228,9 +228,9 @@ def _fetch_openml_dataset(
 
 
 def _fetch_world_bank_data(
-    indicator_id: str,
-    data_directory: Path | None = None,
-) -> dict[str, Any]:
+    indicator_id     ,
+    data_directory              = None,
+)                  :
     """Gets a dataset from World Bank open data platform (https://data.worldbank.org/).
 
     Parameters
@@ -311,9 +311,9 @@ def _fetch_world_bank_data(
 
 
 def _fetch_figshare(
-    figshare_id: str,
-    data_directory: Path | None = None,
-) -> dict[str, Any]:
+    figshare_id     ,
+    data_directory              = None,
+)                  :
     """Fetch a dataset from figshare using the download ID number.
 
     Parameters
@@ -424,7 +424,7 @@ def _fetch_figshare(
             raise URLError("No internet connection or the website is down.")
 
 
-def _fetch_movielens(dataset_id: str, data_directory: Path | None = None) -> dict[str]:
+def _fetch_movielens(dataset_id     , data_directory              = None)             :
     """Downloads a subset of the Movielens dataset.
 
     Parameters
@@ -488,7 +488,7 @@ def _download_and_write_movielens_dataset(dataset_id, data_directory, zip_direct
         raise
 
 
-def _download_and_write_openml_dataset(dataset_id: int, data_directory: Path) -> None:
+def _download_and_write_openml_dataset(dataset_id     , data_directory      )        :
     """Downloads a dataset from OpenML, taking care of creating the directories.
 
     Parameters
@@ -532,7 +532,7 @@ def _download_and_write_openml_dataset(dataset_id: int, data_directory: Path) ->
     )
 
 
-def _read_json_from_gz(compressed_dir_path: Path) -> dict:
+def _read_json_from_gz(compressed_dir_path      )        :
     """Opens a gzip file, reads its content (JSON expected), and returns a dictionary.
 
     Parameters
@@ -557,7 +557,7 @@ def _read_json_from_gz(compressed_dir_path: Path) -> dict:
     return details_json
 
 
-def _get_details(compressed_dir_path: Path) -> Details:
+def _get_details(compressed_dir_path      )           :
     """Gets useful details from the details file.
 
     Parameters
@@ -581,7 +581,7 @@ def _get_details(compressed_dir_path: Path) -> Details:
     )
 
 
-def _get_features(compressed_dir_path: Path) -> Features:
+def _get_features(compressed_dir_path      )            :
     """Gets features that can be inserted in the CSV file.
 
     The most important feature are the column names.
@@ -604,8 +604,8 @@ def _get_features(compressed_dir_path: Path) -> Features:
 
 
 def _export_gz_data_to_csv(
-    compressed_dir_path: Path, destination_file: Path, features: Features
-) -> None:
+    compressed_dir_path      , destination_file      , features          
+)        :
     """Reads a gzip file containing ARFF data, and writes it to a CSV file.
 
     Parameters
@@ -620,7 +620,7 @@ def _export_gz_data_to_csv(
     atdata_found = False
     with destination_file.open(mode="w", encoding="utf8") as csv:
         with gzip.open(compressed_dir_path, mode="rt", encoding="utf8") as gz:
-            gz: TextIO  # Clarify for IDEs
+            #gz: TextIO  # Clarify for IDEs
             csv.write(_features_to_csv_format(features))
             csv.write("\n")
             # We will look at each line of the file until we find
@@ -633,19 +633,19 @@ def _export_gz_data_to_csv(
                     csv.write(line)
 
 
-def _features_to_csv_format(features: Features) -> str:
+def _features_to_csv_format(features          )       :
     return ",".join(features.names)
 
 
 def _fetch_dataset_as_dataclass(
-    source: Literal["openml", "world_bank", "figshare"],
-    dataset_name: str,
-    dataset_id: int | str,
-    target: str | None,
-    load_dataframe: bool,
-    data_directory: Path | str | None = None,
-    read_csv_kwargs: dict | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    source                                             ,
+    dataset_name     ,
+    dataset_id           ,
+    target            ,
+    load_dataframe      ,
+    data_directory                    = None,
+    read_csv_kwargs              = None,
+)                                :
     """Fetches a dataset from a source, and returns it as a dataclass.
 
     Takes a dataset identifier, a target column name (if applicable),
@@ -725,12 +725,12 @@ def _fetch_dataset_as_dataclass(
 
 def fetch_employee_salaries(
     *,
-    load_dataframe: bool = True,
-    drop_linked: bool = True,
-    drop_irrelevant: bool = True,
-    overload_job_titles: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    drop_linked       = True,
+    drop_irrelevant       = True,
+    overload_job_titles       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the employee salaries dataset (regression), available at https://openml.org/d/42125
 
     Description of the dataset:
@@ -797,9 +797,9 @@ def fetch_employee_salaries(
 
 def fetch_road_safety(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the road safety dataset (classification), available at https://openml.org/d/42803
 
     Description of the dataset:
@@ -831,9 +831,9 @@ def fetch_road_safety(
 
 def fetch_medical_charge(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the medical charge dataset (regression), available at https://openml.org/d/42720
 
     Description of the dataset:
@@ -870,9 +870,9 @@ def fetch_medical_charge(
 
 def fetch_midwest_survey(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the midwest survey dataset (classification), available at https://openml.org/d/42805
 
     Description of the dataset:
@@ -902,9 +902,9 @@ def fetch_midwest_survey(
 
 def fetch_open_payments(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the open payments dataset (classification), available at https://openml.org/d/42738
 
     Description of the dataset:
@@ -936,9 +936,9 @@ def fetch_open_payments(
 
 def fetch_traffic_violations(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the traffic violations dataset (classification), available at https://openml.org/d/42132
 
     Description of the dataset:
@@ -972,9 +972,9 @@ def fetch_traffic_violations(
 
 def fetch_drug_directory(
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches the drug directory dataset (classification), available at https://openml.org/d/43044
 
     Description of the dataset:
@@ -1004,11 +1004,11 @@ def fetch_drug_directory(
 
 
 def fetch_world_bank_indicator(
-    indicator_id: str,
+    indicator_id     ,
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches a dataset of an indicator from the World Bank open data platform.
 
     Description of the dataset:
@@ -1035,11 +1035,11 @@ def fetch_world_bank_indicator(
 
 
 def fetch_figshare(
-    figshare_id: str,
+    figshare_id     ,
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | str | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory                    = None,
+)                                :
     """Fetches a table of from figshare.
 
     Returns
@@ -1061,11 +1061,11 @@ def fetch_figshare(
 
 
 def fetch_movielens(
-    dataset_id: str = "ratings",
+    dataset_id      = "ratings",
     *,
-    load_dataframe: bool = True,
-    data_directory: Path | None = None,
-) -> DatasetAll | DatasetInfoOnly:
+    load_dataframe       = True,
+    data_directory              = None,
+)                                :
     """Fetches a dataset from Movielens.
 
     Parameters

--- a/skrub/datasets/_generating.py
+++ b/skrub/datasets/_generating.py
@@ -11,11 +11,11 @@ from sklearn.utils import check_random_state
 
 
 def make_deduplication_data(
-    examples: list[str],
-    entries_per_example: list[int],
-    prob_mistake_per_letter: float = 0.2,
-    random_state: int | np.random.RandomState | None = None,
-) -> list[str]:
+    examples,
+    entries_per_example,
+    prob_mistake_per_letter=0.2,
+    random_state=None,
+):
     """Duplicates examples with spelling mistakes.
 
     Characters are misspelled with probability `prob_mistake_per_letter`.

--- a/skrub/datasets/_ken_embeddings.py
+++ b/skrub/datasets/_ken_embeddings.py
@@ -17,7 +17,7 @@ _correspondence_table_url = (
 )
 
 
-def fetch_ken_table_aliases() -> set[str]:
+def fetch_ken_table_aliases():
     """Get the supported aliases of embedded KEN entities tables.
 
     These aliases can be using in subsequent functions (see section *See Also*).
@@ -50,11 +50,11 @@ def fetch_ken_table_aliases() -> set[str]:
 
 
 def fetch_ken_types(
-    search: str = None,
+    search=None,
     *,
-    exclude: str | None = None,
-    embedding_table_id: str = "all_entities",
-) -> pd.DataFrame:
+    exclude=None,
+    embedding_table_id="all_entities",
+):
     """Helper function to search for KEN entity types.
 
     The result can then be used with fetch_ken_embeddings.
@@ -136,14 +136,14 @@ def fetch_ken_types(
 
 
 def fetch_ken_embeddings(
-    search_types: str | None = None,
+    search_types=None,
     *,
-    exclude: str | None = None,
-    embedding_table_id: str = "all_entities",
-    embedding_type_id: str | None = None,
-    pca_components: int | None = None,
-    suffix: str = "",
-) -> pd.DataFrame:
+    exclude=None,
+    embedding_table_id="all_entities",
+    embedding_type_id=None,
+    pca_components=None,
+    suffix="",
+):
     """Download Wikipedia embeddings by type.
 
     More details on the embeddings can be found on

--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 
-def get_data_home(data_home: Path | str | None = None) -> Path:
+def get_data_home(data_home=None):
     """Returns the path of the skrub data directory.
 
     This folder is used by some large dataset loaders to avoid downloading the
@@ -35,7 +35,7 @@ def get_data_home(data_home: Path | str | None = None) -> Path:
     return data_home
 
 
-def get_data_dir(name: str | None = None, data_home: Path | str | None = None) -> Path:
+def get_data_dir(name=None, data_home=None):
     """
     Returns the directory in which skrub looks for data.
 

--- a/skrub/datasets/tests/test_fetching.py
+++ b/skrub/datasets/tests/test_fetching.py
@@ -9,7 +9,7 @@ import pytest
 from skrub.datasets import _fetching
 
 
-def _has_data_id(call, data_id: int) -> bool:
+def _has_data_id(call, data_id):
     # Unpacking copied from `mock._Call.__eq__`
     if len(call) == 2:
         args, kwargs = call
@@ -22,7 +22,7 @@ def _has_data_id(call, data_id: int) -> bool:
     "skrub.datasets._fetching.fetch_openml",
     side_effect=_fetching.fetch_openml,
 )
-def test_openml_fetching(fetch_openml_mock: mock.Mock):
+def test_openml_fetching(fetch_openml_mock):
     """
     Downloads a small dataset (midwest survey) and performs a bunch of tests
     that asserts the fetching function works correctly.
@@ -79,7 +79,7 @@ def test_openml_datasets_exist():
 
 
 @mock.patch("skrub.datasets._fetching.fetch_openml")
-def test_openml_datasets_calls(fetch_openml_mock: mock.Mock):
+def test_openml_datasets_calls(fetch_openml_mock):
     """
     Checks that calling the fetching functions actually calls
     `sklearn.datasets.fetch_openml`.

--- a/skrub/tests/test_deduplicate.py
+++ b/skrub/tests/test_deduplicate.py
@@ -1,5 +1,3 @@
-from functools import cache
-
 import joblib
 import numpy as np
 import pandas as pd
@@ -101,7 +99,6 @@ def test__create_spelling_correction(seed=123):
         ).all()
 
 
-@cache
 def default_deduplicate(n=500, random_state=0):
     """
     Create a default deduplication dataset.

--- a/skrub/tests/test_deduplicate.py
+++ b/skrub/tests/test_deduplicate.py
@@ -22,9 +22,9 @@ from skrub.datasets import make_deduplication_data
     [([500, 100, 1500], 0.05), ([100, 100], 0.02), ([200, 50, 30, 200, 800], 0.01)],
 )
 def test_deduplicate(
-    entries_per_category: list[int],
-    prob_mistake_per_letter: float,
-    seed: int = 123,
+    entries_per_category,
+    prob_mistake_per_letter,
+    seed=123,
 ):
     rng = np.random.RandomState(seed)
 
@@ -78,7 +78,7 @@ def test__guess_clusters():
     assert n_clusters == len(np.unique(words))
 
 
-def test__create_spelling_correction(seed: int = 123):
+def test__create_spelling_correction(seed=123):
     rng = np.random.RandomState(seed)
     n_clusters = 3
     samples_per_cluster = 10
@@ -102,7 +102,7 @@ def test__create_spelling_correction(seed: int = 123):
 
 
 @cache
-def default_deduplicate(n: int = 500, random_state=0):
+def default_deduplicate(n=500, random_state=0):
     """
     Create a default deduplication dataset.
     """

--- a/skrub/tests/test_docstrings.py
+++ b/skrub/tests/test_docstrings.py
@@ -10,7 +10,6 @@ should also remove their corresponding references from the list.
 
 import inspect
 import re
-from collections.abc import Callable
 from importlib import import_module
 
 import pytest

--- a/skrub/tests/test_docstrings.py
+++ b/skrub/tests/test_docstrings.py
@@ -68,10 +68,10 @@ def get_functions_to_validate():
 
 
 def repr_errors(
-    res: dict,
-    estimator: type | None = None,
-    method: str | None = None,
-) -> str:
+    res,
+    estimator=None,
+    method=None,
+):
     """
     Pretty print original docstring and the obtained errors
 
@@ -126,7 +126,7 @@ def repr_errors(
     return msg
 
 
-def filter_errors(errors, method: Callable, estimator_cls: type | None = None):
+def filter_errors(errors, method, estimator_cls=None):
     """
     Ignore some errors based on the method type.
     """
@@ -163,7 +163,7 @@ def filter_errors(errors, method: Callable, estimator_cls: type | None = None):
     ["estimator_cls", "method"],
     get_methods_to_validate(),
 )
-def test_estimator_docstrings(estimator_cls: type, method: str, request):
+def test_estimator_docstrings(estimator_cls, method, request):
     base_import_path = estimator_cls.__module__
     import_path = [base_import_path, estimator_cls.__name__]
     if method is not None:
@@ -190,7 +190,7 @@ def test_estimator_docstrings(estimator_cls: type, method: str, request):
     ["func", "name"],
     get_functions_to_validate(),
 )
-def test_function_docstrings(func: Callable, name: str, request):
+def test_function_docstrings(func, name, request):
     import_path = ".".join([func.__module__, name])
     print(import_path)
 

--- a/skrub/tests/test_fast_hash.py
+++ b/skrub/tests/test_fast_hash.py
@@ -2,7 +2,7 @@ from skrub._fast_hash import ngram_min_hash
 from skrub.tests.utils import generate_data
 
 
-def test_fast_hash() -> None:
+def test_fast_hash():
     data = generate_data(100, as_list=True)
     a = data[0]
 

--- a/skrub/tests/test_fuzzy_join.py
+++ b/skrub/tests/test_fuzzy_join.py
@@ -28,7 +28,7 @@ if POLARS_SETUP:
     "analyzer",
     ["char", "char_wb", "word"],
 )
-def test_fuzzy_join(px, analyzer: Literal["char", "char_wb", "word"]):
+def test_fuzzy_join(px, analyzer):
     """
     Testing if fuzzy_join results are as expected.
     """

--- a/skrub/tests/test_fuzzy_join.py
+++ b/skrub/tests/test_fuzzy_join.py
@@ -1,5 +1,4 @@
 import warnings
-from typing import Literal
 
 import numpy as np
 import pandas as pd

--- a/skrub/tests/test_gap_encoder.py
+++ b/skrub/tests/test_gap_encoder.py
@@ -28,12 +28,12 @@ if POLARS_SETUP:
     ],
 )
 def test_analyzer(
-    hashing: bool,
-    init: str,
-    rescale_W: bool,
-    add_words: bool,
-    rescale_rho: bool,
-    n_samples: int = 70,
+    hashing,
+    init,
+    rescale_W,
+    add_words,
+    rescale_rho,
+    n_samples=70,
 ):
     """
     Test if the output is different when the analyzer is 'word' or 'char'.
@@ -85,12 +85,12 @@ def test_analyzer(
     ],
 )
 def test_gap_encoder(
-    hashing: bool,
-    init: str,
-    analyzer: str,
-    add_words: bool,
-    verbose: bool,
-    n_samples: int = 70,
+    hashing,
+    init,
+    analyzer,
+    add_words,
+    verbose,
+    n_samples=70,
 ):
     X = generate_data(n_samples, random_state=0)
     n_components = 10
@@ -158,7 +158,7 @@ def test_input_type(px):
     "add_words",
     [True, False],
 )
-def test_partial_fit(px, add_words: bool, n_samples: int = 70):
+def test_partial_fit(px, add_words, n_samples=70):
     X = generate_data(n_samples, random_state=0)
     X2 = px.DataFrame(generate_data(n_samples - 10, random_state=1))
     X3 = generate_data(n_samples - 10, random_state=2)
@@ -244,7 +244,7 @@ def test_overflow_error():
     enc.fit(X)
 
 
-def test_score(n_samples: int = 70):
+def test_score(n_samples=70):
     X1 = generate_data(n_samples, random_state=0)
     X2 = np.hstack([X1, X1])
     enc = GapEncoder(random_state=42)
@@ -261,7 +261,7 @@ def test_score(n_samples: int = 70):
     "missing",
     ["zero_impute", "error", "aaa"],
 )
-def test_missing_values(px, missing: str):
+def test_missing_values(px, missing):
     """Test what happens when missing values are in the data"""
     if is_module_polars(px):
         pytest.xfail(

--- a/skrub/tests/test_minhash_encoder.py
+++ b/skrub/tests/test_minhash_encoder.py
@@ -113,7 +113,7 @@ def test_encoder_params(hashing, minmax_hash):
 @pytest.mark.parametrize("input_type", INPUT_TYPE)
 @pytest.mark.parametrize("missing", ["error", "zero_impute", "aaa"])
 @pytest.mark.parametrize("hashing", ["fast", "murmur", "aaa"])
-def test_missing_values(input_type: str, missing: str, hashing: str):
+def test_missing_values(input_type, missing, hashing):
     X = ["Red", np.nan, "green", "blue", "green", "green", "blue", float("nan")]
     n = 3
     z = np.zeros(n)

--- a/skrub/tests/test_similarity_encoder.py
+++ b/skrub/tests/test_similarity_encoder.py
@@ -79,7 +79,7 @@ def test_parameters():
         sim.transform(X2)
 
 
-def _test_missing_values(input_type: str, missing: str):
+def _test_missing_values(input_type, missing):
     observations = [["a", "b"], ["b", "a"], ["b", None], ["a", "c"], [np.nan, "a"]]
     encoded = np.array(
         [
@@ -111,7 +111,7 @@ def _test_missing_values(input_type: str, missing: str):
         return
 
 
-def _test_missing_values_transform(input_type: str, missing: str):
+def _test_missing_values_transform(input_type, missing):
     observations = [["a", "b"], ["b", "a"], ["b", "b"], ["a", "c"], ["c", "a"]]
     test_observations = [
         ["a", "b"],
@@ -149,9 +149,9 @@ def _test_missing_values_transform(input_type: str, missing: str):
 
 
 def _test_similarity(
-    similarity_f: Callable,
-    hashing_dim: int | None = None,
-    categories: str = "auto",
+    similarity_f,
+    hashing_dim=None,
+    categories="auto",
 ):
     X = np.array(["aa", "aaa", "aaab"]).reshape(-1, 1)
     X_test = np.array([["Aa", "aAa", "aaa", "aaab", " aaa  c"]]).reshape(-1, 1)

--- a/skrub/tests/test_similarity_encoder.py
+++ b/skrub/tests/test_similarity_encoder.py
@@ -1,5 +1,3 @@
-from collections.abc import Callable
-
 import numpy as np
 import numpy.testing
 import pandas as pd

--- a/skrub/tests/test_string_distances.py
+++ b/skrub/tests/test_string_distances.py
@@ -3,7 +3,7 @@ import numpy as np
 from skrub import _string_distances
 
 
-def test_get_unique_ngrams() -> None:
+def test_get_unique_ngrams():
     string = "test"
     true_ngrams = {
         (" ", "t"),
@@ -24,7 +24,7 @@ def test_get_unique_ngrams() -> None:
     assert ngrams == true_ngrams
 
 
-def _random_string_pairs(n_pairs=50, seed=1) -> list[tuple[str, str]]:
+def _random_string_pairs(n_pairs=50, seed=1):
     rng = np.random.RandomState(seed)
     characters = list(map(chr, range(10000)))
     pairs = []
@@ -37,12 +37,12 @@ def _random_string_pairs(n_pairs=50, seed=1) -> list[tuple[str, str]]:
     return pairs
 
 
-def _check_symmetry(dist_func, *args, **kwargs) -> None:
+def _check_symmetry(dist_func, *args, **kwargs):
     for a, b in _random_string_pairs():
         assert dist_func(a, b, *args, **kwargs) == dist_func(b, a, *args, **kwargs)
 
 
-def test_ngram_similarity() -> None:
+def test_ngram_similarity():
     # TODO
     # assert ...
     for n in range(1, 4):

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -610,7 +610,7 @@ def test_changing_types(X_train, X_test, expected_X_out):
     assert_array_equal(X_out[mask_nan], expected_X_out[mask_nan])
 
 
-def test_changing_types_int_float() -> None:
+def test_changing_types_int_float():
     """
     The TableVectorizer shouldn't cast floats to ints
     even if only ints were seen during fit

--- a/skrub/tests/utils.py
+++ b/skrub/tests/utils.py
@@ -1,7 +1,6 @@
 import random
 
 import numpy as np
-from numpy.typing import NDArray
 
 
 def generate_data(

--- a/skrub/tests/utils.py
+++ b/skrub/tests/utils.py
@@ -5,11 +5,11 @@ from numpy.typing import NDArray
 
 
 def generate_data(
-    n_samples: int,
-    as_list: bool = False,
-    random_state: int | float | str | bytes | bytearray | None = None,
-    sample_length: int = 100,
-) -> NDArray:
+    n_samples,
+    as_list=False,
+    random_state=None,
+    sample_length=100,
+):
     if random_state is not None:
         random.seed(random_state)
     MAX_LIMIT = 255  # extended ASCII Character set


### PR DESCRIPTION
closes #815 

apparently the only thing that prevents support for python3.8 and python3.9 is the use of operators on built-in types (like `list[str]`, `list | dict` ) for type annotations.

the type annotations as they are are not usable anyway: (i) many functions don't have them and more importantly (ii) a large part of those that exist are incorrect; `mypy ./skrub` yields over a hundred errors.
So for users I think supporting all python version (3.8 EOL is Oct 2024 and 3.9 is Oct 2025) is more important.

This is what we agreed on in the skrub IRL meeting