### PR TITLE
MAINT avoid tie breaking in joiner examples

### DIFF
--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -131,14 +131,14 @@ def fuzzy_join(
     Examples
     --------
     >>> import pandas as pd
-    >>> left_table = pd.DataFrame({"Country": ["France", "Italia", "Spain"]})
+    >>> left_table = pd.DataFrame({"Country": ["France", "Italia", "Georgia"]})
     >>> right_table = pd.DataFrame( {"Country": ["Germany", "France", "Italy"],
     ...                            "Capital": ["Berlin", "Paris", "Rome"]} )
     >>> left_table
       Country
     0  France
     1  Italia
-    2   Spain
+    2  Georgia
     >>> right_table
        Country Capital
     0  Germany  Berlin
@@ -149,20 +149,20 @@ def fuzzy_join(
     ...     right_table,
     ...     on="Country",
     ...     suffix="_right",
-    ...     max_dist=1.0,
+    ...     max_dist=0.8,
     ...     add_match_info=False,
     ... )
       Country    Country_right    Capital_right
     0  France           France            Paris
     1  Italia            Italy             Rome
-    2   Spain              NaN              NaN
+    2   Georgia              NaN              NaN
     >>> fuzzy_join(
     ...     left_table,
     ...     right_table,
     ...     on="Country",
     ...     suffix="_right",
     ...     drop_unmatched=True,
-    ...     max_dist=1.0,
+    ...     max_dist=0.8,
     ...     add_match_info=False,
     ... )
       Country    Country_right    Capital_right
@@ -178,8 +178,8 @@ def fuzzy_join(
     ... )
       Country    Country_right    Capital_right
     0  France           France            Paris
-    1  Italia            Italy             Rome
-    2   Spain          Germany           Berlin
+    1  Italia           Italy             Rome
+    2  Georgia          Germany           Berlin
     """
     # duplicate the key checks performed by the Joiner so we can get better
     # names in error messages

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -184,14 +184,14 @@ class Joiner(TransformerMixin, BaseEstimator):
     Examples
     --------
     >>> import pandas as pd
-    >>> main_table = pd.DataFrame({"Country": ["France", "Italia", "Spain"]})
+    >>> main_table = pd.DataFrame({"Country": ["France", "Italia", "Georgia"]})
     >>> aux_table = pd.DataFrame( {"Country": ["Germany", "France", "Italy"],
     ...                            "Capital": ["Berlin", "Paris", "Rome"]} )
     >>> main_table
       Country
     0  France
     1  Italia
-    2   Spain
+    2   Georgia
     >>> aux_table
        Country Capital
     0  Germany  Berlin
@@ -201,14 +201,14 @@ class Joiner(TransformerMixin, BaseEstimator):
     ...     aux_table,
     ...     key="Country",
     ...     suffix="_aux",
-    ...     max_dist=0.9,
+    ...     max_dist=0.8,
     ...     add_match_info=False,
     ... )
     >>> joiner.fit_transform(main_table)
       Country      Country_aux      Capital_aux
     0  France           France            Paris
     1  Italia            Italy             Rome
-    2   Spain              NaN              NaN
+    2  Georgia              NaN              NaN
     """
 
     _match_info_keys = ["distance", "rescaled_distance", "match_accepted"]

--- a/skrub/tests/test_joiner.py
+++ b/skrub/tests/test_joiner.py
@@ -96,7 +96,7 @@ def test_multiple_keys(px, assert_frame_equal_):
 
 
 def test_pandas_aux_table_index():
-    main_table = pd.DataFrame({"Country": ["France", "Italia", "Spain"]})
+    main_table = pd.DataFrame({"Country": ["France", "Italia", "Georgia"]})
     aux_table = pd.DataFrame(
         {
             "Country": ["Germany", "France", "Italy"],


### PR DESCRIPTION
Locally, these tests and docstrings were flaky because the distances in the k-NN search where equals.

Find a new example without any tie.