### PR TITLE
MNT import parse_version from sklearn.utils.fixes

### DIFF
--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import pandas.api.types
-from sklearn.utils import parse_version
+from sklearn.utils.fixes import parse_version
 
 try:
     import polars as pl

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -13,7 +13,7 @@ from numpy.typing import ArrayLike, NDArray
 from scipy import sparse
 from sklearn.feature_extraction.text import CountVectorizer, HashingVectorizer
 from sklearn.preprocessing import OneHotEncoder
-from sklearn.utils import parse_version
+from sklearn.utils.fixes import parse_version
 from sklearn.utils.validation import check_is_fitted
 
 from ._string_distances import get_ngram_count, preprocess

--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -25,7 +25,7 @@ import pandas as pd
 from sklearn import __version__ as sklearn_version
 from sklearn.datasets import fetch_openml
 from sklearn.datasets._base import _sha256
-from sklearn.utils import parse_version
+from sklearn.utils.fixes import parse_version
 
 from skrub._utils import import_optional_dependency
 from skrub.datasets._utils import get_data_dir


### PR DESCRIPTION
in the scikit-learn main branch `parse_version` is not in `utils` anymore but can still be imported from `utils.fixes`