### PR TITLE
parametrize with keys so we get more informative test names

### DIFF
--- a/skrub/conftest.py
+++ b/skrub/conftest.py
@@ -98,7 +98,7 @@ def all_dataframe_modules():
     return _DATAFAME_MODULES_INFO
 
 
-@pytest.fixture(params=list(_DATAFAME_MODULES_INFO.values()))
+@pytest.fixture(params=list(_DATAFAME_MODULES_INFO.keys()))
 def df_module(request):
     """Return information about a dataframe module (either polars or pandas).
 
@@ -144,7 +144,7 @@ def df_module(request):
         A mapping from dtype names to types, keys are:
         ['float32', 'float64', 'int32', 'int64'].
     """
-    return request.param
+    return _DATAFAME_MODULES_INFO[request.param]
 
 
 @pytest.fixture


### PR DESCRIPTION
when using pytest -v with this change the tests that use this fixture will look like

```
skrub/_dataframe/tests/test_common.py::test_unique[pandas] PASSED                                                                                                                                  
skrub/_dataframe/tests/test_common.py::test_unique[polars] PASSED 
```

instead of 

```
skrub/_dataframe/tests/test_common.py::test_unique[df_module0] PASSED                                                                                                                                  
skrub/_dataframe/tests/test_common.py::test_unique[df_module1] PASSED 
```