### PR TITLE
Use dispatch and module fixture in tests

### DIFF
--- a/skrub/_dataframe/_test_utils.py
+++ b/skrub/_dataframe/_test_utils.py
@@ -1,6 +1,33 @@
+import pandas as pd
+import pandas.testing
+
+try:
+    import polars as pl
+    import polars.testing
+except ImportError:
+    pass
+
+from .._dispatch import dispatch
+
+
 def is_module_pandas(px):
     return px.__name__ == "pandas"
 
 
 def is_module_polars(px):
     return px.__name__ == "polars"
+
+
+@dispatch
+def assert_frame_equal(left, right):
+    raise NotImplementedError()
+
+
+@assert_frame_equal.specialize("pandas")
+def _assert_frame_equal_pandas(left, right):
+    return pd.testing.assert_frame_equal(left, right)
+
+
+@assert_frame_equal.specialize("polars")
+def assert_frame_equal_polars(left, right):
+    return pl.testing.assert_frame_equal(left, right)

--- a/skrub/tests/test_joiner.py
+++ b/skrub/tests/test_joiner.py
@@ -2,25 +2,15 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
-from pandas.testing import assert_frame_equal
 
 from skrub import Joiner
-from skrub._dataframe._polars import POLARS_SETUP
-
-MODULES = [pd]
-ASSERT_TUPLES = [(pd, assert_frame_equal)]
-
-if POLARS_SETUP:
-    import polars as pl
-    from polars.testing import assert_frame_equal as assert_frame_equal_pl
-
-    MODULES.append(pl)
-    ASSERT_TUPLES.append((pl, assert_frame_equal_pl))
+from skrub._dataframe import _common as ns
+from skrub._dataframe._test_utils import assert_frame_equal
 
 
-@pytest.mark.parametrize("px", MODULES)
-def test_joiner(px):
-    main_table = px.DataFrame(
+# TODO: change this name
+def test_joiner(df_module):
+    main_table = df_module.make_dataframe(
         {
             "Country": [
                 "France",
@@ -30,7 +20,7 @@ def test_joiner(px):
         }
     )
 
-    aux_table = px.DataFrame(
+    aux_table = df_module.make_dataframe(
         {
             "country": ["Germany", "French Republic", "Italia"],
             "Population": [84_000_000, 68_000_000, 59_000_000],
@@ -67,12 +57,11 @@ def test_joiner(px):
         false_joiner2.fit(main_table)
 
 
-@pytest.mark.parametrize("px, assert_frame_equal_", ASSERT_TUPLES)
-def test_multiple_keys(px, assert_frame_equal_):
-    df = px.DataFrame(
+def test_multiple_keys(df_module):
+    df = df_module.make_dataframe(
         {"Co": ["France", "Italia", "Deutchland"], "Ca": ["Paris", "Roma", "Berlin"]}
     )
-    df2 = px.DataFrame(
+    df2 = df_module.make_dataframe(
         {"CO": ["France", "Italy", "Germany"], "CA": ["Paris", "Rome", "Berlin"]}
     )
     joiner_list = Joiner(
@@ -82,17 +71,15 @@ def test_multiple_keys(px, assert_frame_equal_):
         add_match_info=False,
     )
     result = joiner_list.fit_transform(df)
-    try:
-        expected = px.concat([df, df2], axis=1)
-    except TypeError:
-        expected = px.concat([df, df2], how="horizontal")
-    assert_frame_equal_(result, expected)
+
+    expected = ns.concat_horizontal(df, df2)
+    df_module.assert_frame_equal(result, expected)
 
     joiner_list = Joiner(
         aux_table=df2, aux_key="CA", main_key="Ca", add_match_info=False
     )
     result = joiner_list.fit_transform(df)
-    assert_frame_equal_(result, expected)
+    assert_frame_equal(result, expected)
 
 
 def test_pandas_aux_table_index():

--- a/skrub/tests/test_joiner.py
+++ b/skrub/tests/test_joiner.py
@@ -35,10 +35,10 @@ def test_joiner(df_module):
 
     joiner.fit(main_table)
     big_table = joiner.transform(main_table)
-    assert big_table.shape == (main_table.shape[0], 3)
+    assert ns.shape(big_table) == (ns.shape(main_table)[0], 3)
     assert_array_equal(
-        big_table["Population"].to_numpy(),
-        aux_table["Population"].to_numpy()[[1, 0, 2]],
+        ns.to_numpy(ns.col(big_table, "Population")),
+        ns.to_numpy(ns.col(aux_table, "Population"))[[1, 0, 2]],
     )
 
     false_joiner = Joiner(aux_table=aux_table, main_key="Countryy", aux_key="country")
@@ -73,7 +73,7 @@ def test_multiple_keys(df_module):
     result = joiner_list.fit_transform(df)
 
     expected = ns.concat_horizontal(df, df2)
-    df_module.assert_frame_equal(result, expected)
+    assert_frame_equal(result, expected)
 
     joiner_list = Joiner(
         aux_table=df2, aux_key="CA", main_key="Ca", add_match_info=False
@@ -98,6 +98,8 @@ def test_pandas_aux_table_index():
         suffix="_capitals",
     )
     join = joiner.fit_transform(main_table)
+    # TODO: change into ``ns.to_list(ns.col(join, "Country_capitals"))``
+    # after selectors PR
     assert join["Country_capitals"].tolist() == ["France", "Italy", "Germany"]
 
 

--- a/skrub/tests/test_joiner.py
+++ b/skrub/tests/test_joiner.py
@@ -9,6 +9,7 @@ from skrub._dataframe._test_utils import assert_frame_equal
 
 
 # TODO: change this name
+# see https://github.com/skrub-data/skrub/pull/896#discussion_r1538167538
 def test_joiner(df_module):
     main_table = df_module.make_dataframe(
         {


### PR DESCRIPTION
The goal of this PR is to uniformize how we write tests: 
- to take advantage of `dispatch` for comparing dataframes with a custom implementation of `assert_frame_equal`,
- to avoid the boilerplate 
    ```
    import pandas as pd

    MODULES = [pd]
    ASSERT_TUPLES = [(pd, assert_frame_equal)]
    
    if POLARS_SETUP:
        import polars as pl
        from polars.testing import assert_frame_equal as assert_frame_equal_pl
    
        MODULES.append(pl)
        ASSERT_TUPLES.append((pl, assert_frame_equal_pl))
    ```
    in each test module, by using the `df_module` fixture in `conftest` instead.

I propose to use `df_module` to parametrize tests and create the dataframes (when we wouldn't have access to a dataframe to feed as a first parameter of a dispatched function), and to use functions in `_dataframe._common` and `_test_utils` for all other backend-specific functions.

Here's an example of this implementation on `test_joiner`, let me know what you think. I can apply the changes to all other test modules once we settle on the method.

cc @jeromedockes 