### PR TITLE
temporarily skip ken embedding download tests

### DIFF
--- a/skrub/datasets/tests/test_ken_embeddings.py
+++ b/skrub/datasets/tests/test_ken_embeddings.py
@@ -33,6 +33,9 @@ def test_fetch_ken_types():
     assert types3.shape[0] == 2532
 
 
+# TODO: mock download in test & make download more robust & better error messages
+# See https://github.com/skrub-data/skrub/issues/900
+@pytest.mark.skip("Downloads large files and fails CI unpredictably")
 def test_small_ken_embeddings():
     """
     Test if small sized embeddings were fetched correctly
@@ -54,6 +57,9 @@ def test_small_ken_embeddings():
     assert emb2.shape[1] == 7
 
 
+# TODO: mock download in test & make download more robust & better error messages
+# See https://github.com/skrub-data/skrub/issues/900
+@pytest.mark.skip("Downloads large files and fails CI unpredictably")
 def test_big_ken_embeddings():
     """
     Test if bigger sized embeddings were fetched correctly


### PR DESCRIPTION
A quick fix for #900 (which should remain open until the downloads and test are actually improved and the skip is removed)