### PR TITLE
FIX make sure to have Mixin on the left of BaseEstimator

### DIFF
--- a/benchmarks/bench_gap_divergence.py
+++ b/benchmarks/bench_gap_divergence.py
@@ -47,7 +47,6 @@ from utils import (
 from skrub import TableVectorizer
 from skrub._gap_encoder import (
     GapEncoder,
-    GapEncoder,
     _multiplicative_update_h,
     _multiplicative_update_w,
     batch_lookup,

--- a/benchmarks/bench_gap_es_score.py
+++ b/benchmarks/bench_gap_es_score.py
@@ -15,7 +15,6 @@ from utils import default_parser, find_result, monitor
 
 from skrub import GapEncoder
 from skrub._gap_encoder import (
-    GapEncoder,
     _beta_divergence,
     _multiplicative_update_h,
     _multiplicative_update_w,

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -26,7 +26,7 @@ from . import _dataframe as sbd
 from ._on_each_column import RejectColumn, SingleColumnTransformer
 
 
-class GapEncoder(SingleColumnTransformer, TransformerMixin):
+class GapEncoder(TransformerMixin, SingleColumnTransformer):
     """Constructs latent topics with continuous encoding.
 
     This encoder can be understood as a continuous encoding on a set of latent


### PR DESCRIPTION
From the top of the head, we should always have the mixins on the left of `BaseEstimator` for the MRO to work properly (e.g. for tags inheritance).

Quick fix to solve issues that I let pass in a previous PR.