### PR TITLE
Remove pandas and polars specific code

### DIFF
--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -16,7 +16,6 @@ __all__ = [
     #
     # Inspecting containers' type and module
     #
-    "skrub_namespace",
     "dataframe_module_name",
     "is_pandas",
     "is_polars",
@@ -89,34 +88,6 @@ __all__ = [
 # Inspecting containers' type and module
 # ======================================
 #
-
-
-# TODO: skrub_namespace is temporary; all code in those modules should be moved
-# here or in the corresponding skrub modules and use the dispatch mechanism.
-
-
-@dispatch
-def skrub_namespace(obj):
-    """Return the skrub private module for a dataframe library.
-
-    Returns either ``skrub._dataframe._pandas`` or ``skrub._dataframe._polars``.
-    This is temporary until functions in those modules have moved elsewhere.
-    """
-    raise NotImplementedError()
-
-
-@skrub_namespace.specialize("pandas")
-def _skrub_namespace_pandas(obj):
-    from . import _pandas
-
-    return _pandas
-
-
-@skrub_namespace.specialize("polars")
-def _skrub_namespace_polars(obj):
-    from . import _polars
-
-    return _polars
 
 
 @dispatch

--- a/skrub/_dataframe/_namespace.py
+++ b/skrub/_dataframe/_namespace.py
@@ -5,6 +5,9 @@ import pandas as pd
 import skrub._dataframe._pandas as skrub_pd
 import skrub._dataframe._polars as skrub_pl
 
+# TODO: _dataframe._namespace is temporary; all code in this module should be moved
+# elsewhere and use the dispatch mechanism.
+
 
 def is_pandas(dataframe):
     """Check whether the input is a Pandas dataframe.

--- a/skrub/_dataframe/_pandas.py
+++ b/skrub/_dataframe/_pandas.py
@@ -9,64 +9,8 @@ import pandas as pd
 
 from skrub._utils import atleast_1d_or_none
 
-DATAFRAME_MODULE_NAME = "pandas"
-
-
-def make_dataframe(X, index=None, dtypes=None):
-    """Convert an dictionary of columns into a Pandas dataframe.
-
-    Parameters
-    ----------
-    X : mapping from column name to 1d iterable
-        Input data to convert.
-
-    index : 1d array-like, default=None
-        The index of the dataframe.
-
-    dtypes : str, data type, Series or Mapping of column name -> data type, default=None
-        Use a str, numpy.dtype, pandas.ExtensionDtype or Python type to
-        cast entire pandas object to the same type. Alternatively, use a
-        mapping, e.g. {col: dtype, ...}, where col is a column label and dtype is
-        a numpy.dtype or Python type to cast one or more of the DataFrame's
-        columns to column-specific types.
-
-    Returns
-    -------
-    X : pd.DataFrame
-        Converted output.
-    """
-    df = pd.DataFrame(X, index=index)
-    if dtypes is not None:
-        # 'df.astype(None)' might raise a ValueError because
-        # it tries to cast all columns to floats.
-        df = df.astype(dtypes)
-    return df
-
-
-def make_series(X, index=None, name=None, dtype=None):
-    """Convert a 1d array into a Pandas series.
-
-    Parameters
-    ----------
-    X : 1d iterable
-        Input data to convert.
-
-    index : 1d array-like, default=None
-        The index of the series.
-
-    name : str, default=None
-        The name of the series.
-
-    dtype : str, numpy.dtype, or ExtensionDtype, default=None
-        Data type for the output Series.
-
-    Returns
-    -------
-    X : Pandas series
-        Converted output.
-    """
-    series = pd.Series(X, index=index, name=name, dtype=dtype)
-    return series
+# TODO: _dataframe._pandas is temporary; all code in this module should be moved
+# elsewhere and use the dispatch mechanism.
 
 
 def aggregate(

--- a/skrub/_dataframe/_polars.py
+++ b/skrub/_dataframe/_polars.py
@@ -7,79 +7,15 @@ try:
     import polars as pl
     import polars.selectors as cs
 
-    POLARS_SETUP = True
 except ImportError:
-    POLARS_SETUP = False
+    pass
 
 from itertools import product
 
 from skrub._utils import atleast_1d_or_none
 
-DATAFRAME_MODULE_NAME = "polars"
-
-
-def make_dataframe(X, index=None, dtypes=None):
-    """Convert an dictionary of columns into a Polars dataframe.
-
-    Parameters
-    ----------
-    X : mapping from column name to 1d iterable
-        Input data to convert.
-
-    index : 1d array-like, default=None
-        Unused since polars doesn't use index.
-        Only here for compatibility with Pandas.
-
-    dtypes : DataType or mapping of column names to DataType, default=None
-        Mapping of column names (or selector) to dtypes, or a single dtype
-        to which all columns will be cast.
-
-    Returns
-    -------
-    X : pl.DataFrame
-        Converted output.
-    """
-    if index is not None:
-        raise ValueError(
-            "Polars dataframes don't have an index, but "
-            f"the Polars dataframe maker was called with {index=!r}."
-        )
-    df = pl.DataFrame(X)
-    if dtypes is not None:
-        df = df.cast(dtypes)
-    return df
-
-
-def make_series(X, index=None, name=None, dtype=None):
-    """Convert an 1d array into a Polars series.
-
-    Parameters
-    ----------
-    X : 1d iterable
-        Input data to convert.
-
-    index : 1d array-like, default=None
-        Unused since polars doesn't use index.
-        Only here for compatibility with Pandas.
-
-    name : str, default=None
-        The name of the series.
-
-    dtype : DataType, default=None
-        Polars dtype of the Series data.
-
-    Returns
-    -------
-    X : pl.Series
-        Converted output.
-    """
-    if index is not None:
-        raise ValueError(
-            "Polars series don't have an index, but "
-            f"the Polars series maker was called with {index=!r}."
-        )
-    series = pl.Series(values=X, name=name, dtype=dtype)
-    return series
+# TODO: _dataframe._polars is temporary; all code in this module should be moved
+# elsewhere and use the dispatch mechanism.
 
 
 def aggregate(

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -44,11 +44,6 @@ def test_not_implemented():
 #
 
 
-def test_skrub_namespace(df_module):
-    skrub_ns = ns.skrub_namespace(df_module.empty_dataframe)
-    assert skrub_ns.DATAFRAME_MODULE_NAME == df_module.name
-
-
 def test_dataframe_module_name(df_module):
     assert ns.dataframe_module_name(df_module.empty_dataframe) == df_module.name
     assert getattr(ns, f"is_{df_module.name}")(df_module.empty_dataframe)

--- a/skrub/_dataframe/tests/test_namespace.py
+++ b/skrub/_dataframe/tests/test_namespace.py
@@ -4,7 +4,7 @@ import pytest
 import skrub._dataframe._pandas as skrub_pd
 import skrub._dataframe._polars as skrub_pl
 from skrub._dataframe._namespace import get_df_namespace
-from skrub._dataframe._polars import POLARS_SETUP
+from skrub.conftest import _POLARS_INSTALLED
 
 main = pd.DataFrame(
     {
@@ -25,7 +25,7 @@ def test_get_namespace_pandas():
         get_df_namespace(main, main.values)
 
 
-@pytest.mark.skipif(not POLARS_SETUP, reason="Polars is not available")
+@pytest.mark.skipif(not _POLARS_INSTALLED, reason="Polars is not available")
 def test_get_namespace_polars():
     import polars as pl
 

--- a/skrub/_dataframe/tests/test_pandas.py
+++ b/skrub/_dataframe/tests/test_pandas.py
@@ -1,12 +1,10 @@
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_frame_equal
 
 from skrub._dataframe._pandas import (
     aggregate,
     join,
-    make_dataframe,
-    make_series,
     rename_columns,
 )
 
@@ -101,26 +99,6 @@ def test_no_agg_operation():
             num_operations=None,
             categ_operations=None,
         )
-
-
-@pytest.mark.parametrize("dtypes", [None, {"a": "int64", "b": "category"}])
-def test_make_dataframe(dtypes):
-    X = dict(a=[1, 2], b=["z", "e"])
-
-    expected_df = pd.DataFrame(dict(a=[1, 2], b=["z", "e"]))
-    if dtypes is not None:
-        expected_df = expected_df.astype(dtypes)
-
-    df = make_dataframe(X, index=[0, 1], dtypes=dtypes)
-    assert_frame_equal(df, expected_df)
-
-
-@pytest.mark.parametrize("dtype", [None, "category"])
-def test_make_series(dtype):
-    X = ["1", "2", "3"]
-    expected_series = pd.Series(X, dtype=dtype)
-    series = make_series(X, index=[0, 1, 2], dtype=dtype)
-    assert_series_equal(series, expected_series)
 
 
 def test_rename_columns():

--- a/skrub/_dataframe/tests/test_polars.py
+++ b/skrub/_dataframe/tests/test_polars.py
@@ -2,17 +2,15 @@ import pandas as pd
 import pytest
 
 from skrub._dataframe._polars import (
-    POLARS_SETUP,
     aggregate,
     join,
-    make_dataframe,
-    make_series,
     rename_columns,
 )
+from skrub.conftest import _POLARS_INSTALLED
 
-if POLARS_SETUP:
+if _POLARS_INSTALLED:
     import polars as pl
-    from polars.testing import assert_frame_equal, assert_series_equal
+    from polars.testing import assert_frame_equal
 
     main = pl.DataFrame(
         {
@@ -74,32 +72,6 @@ def test_incorrect_dataframe_inputs():
             cols_to_agg="rating",
             num_operations="mean",
         )
-
-
-@pytest.mark.parametrize("dtypes", [None, {"a": pl.Int64, "b": pl.Utf8}])
-def test_make_dataframe(dtypes):
-    X = dict(a=[1, 2], b=["z", "e"])
-
-    expected_df = pl.DataFrame(dict(a=[1, 2], b=["z", "e"]))
-    if dtypes is not None:
-        expected_df = expected_df.cast(dtypes)
-
-    df = make_dataframe(X, dtypes=dtypes)
-    assert_frame_equal(df, expected_df)
-
-    with pytest.raises(ValueError, match=r"(?=.*Polars dataframe)(?=.*index)"):
-        make_dataframe(X, index=[0, 1])
-
-
-@pytest.mark.parametrize("dtype", [None, pl.Int64])
-def test_make_series(dtype):
-    X = [1, 2, 3]
-    expected_series = pl.Series(X, dtype=dtype)
-    series = make_series(X, index=None, dtype=dtype)
-    assert_series_equal(series, expected_series)
-
-    with pytest.raises(ValueError, match=r"(?=.*Polars series)(?=.*index)"):
-        make_series(X, index=[0, 1])
 
 
 def test_rename_columns():


### PR DESCRIPTION
- Removed `make_dataframe`, `make_series` as we’re using dispatched functions now
- Removed `skrub._dataframe._polars import POLARS_SETUP` → use `conftest`’s `_POLARS_INSTALLED` instead
- Removed `DATAFRAME_MODULE_NAME` in `_pandas` and `_polars`, only used in `ns.skrub_namespace`

I plan on removing more stuff from `_dataframe._pandas/_polars/_namespace` in my next PRs