### PR TITLE
FIX handle polars transformer output in scikit-learn < 1.4

### DIFF
--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import numpy as np
 import pandas as pd
@@ -33,6 +33,7 @@ __all__ = [
     "null_value_for",
     "all_null_like",
     "concat_horizontal",
+    "is_column_list",
     "to_column_list",
     "col",
     "collect",
@@ -314,12 +315,22 @@ def _concat_horizontal_polars(*dataframes):
     return pl.concat(dataframes, how="horizontal")
 
 
+def is_column_list(obj):
+    if not isinstance(obj, Sequence):
+        return False
+    if not len(obj):
+        return True
+    if is_column(obj[0]):
+        return True
+    return False
+
+
 def to_column_list(obj):
     if is_column(obj):
         return [obj]
     if is_dataframe(obj):
         return [col(obj, c) for c in column_names(obj)]
-    if not hasattr(obj, "__iter__") or (len(obj) and not is_column(next(iter(obj)))):
+    if not is_column_list(obj):
         raise TypeError("obj should be a DataFrame, a Column or a list of Columns.")
     return obj
 

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -26,6 +26,7 @@ def test_not_implemented():
         "collect",
         "is_lazyframe",
         "pandas_convert_dtypes",
+        "is_column_list",
         "to_column_list",
         "reset_index",
         "index",
@@ -165,6 +166,23 @@ def test_concat_horizontal(df_module, example_data_dict):
     df2 = ns.set_column_names(df1, list(map("{}1".format, ns.column_names(df1))))
     df = ns.concat_horizontal(df1, df2)
     assert ns.column_names(df) == ns.column_names(df1) + ns.column_names(df2)
+
+
+def test_is_column_list(df_module):
+    assert ns.is_column_list([])
+    assert ns.is_column_list(())
+    assert ns.is_column_list(ns.to_column_list(df_module.example_dataframe))
+    assert ns.is_column_list(tuple(ns.to_column_list(df_module.example_dataframe)))
+    assert ns.is_column_list([df_module.example_column])
+
+    assert not ns.is_column_list(df_module.example_dataframe)
+    assert not ns.is_column_list(df_module.example_column)
+    assert not ns.is_column_list([df_module.example_dataframe])
+    assert not ns.is_column_list([np.ones(3)])
+    assert not ns.is_column_list(np.ones(3))
+    assert not ns.is_column_list(np.ones((3, 3)))
+    assert not ns.is_column_list((df_module.example_column for i in range(2)))
+    assert not ns.is_column_list({"col": df_module.example_column})
 
 
 def test_to_column_list(df_module, example_data_dict):

--- a/skrub/_on_subframe.py
+++ b/skrub/_on_subframe.py
@@ -2,9 +2,8 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
-from . import _selectors
+from . import _selectors, _utils
 from ._join_utils import pick_column_names
-from ._utils import renaming_func, transformer_output_type_error
 
 __all__ = ["OnSubFrame"]
 
@@ -153,17 +152,14 @@ class OnSubFrame(TransformerMixin, BaseEstimator):
         passthrough_names = sbd.column_names(passthrough)
         if self._columns:
             self.transformer_ = clone(self.transformer)
-            if hasattr(self.transformer_, "set_output"):
-                df_module_name = sbd.dataframe_module_name(X)
-                self.transformer_.set_output(transform=df_module_name)
+            _utils.set_output(self.transformer_, X)
             transformed = self.transformer_.fit_transform(to_transform, y)
-            if not sbd.is_dataframe(transformed):
-                transformer_output_type_error(
-                    self.transformer_, to_transform, transformed
-                )
+            transformed = _utils.check_output(
+                self.transformer_, to_transform, transformed, allow_column_list=False
+            )
             suggested_names = sbd.column_names(transformed)
             suggested_names = list(
-                map(renaming_func(self.rename_columns), suggested_names)
+                map(_utils.renaming_func(self.rename_columns), suggested_names)
             )
             self._transformed_output_names = pick_column_names(
                 suggested_names, forbidden_names=passthrough_names
@@ -198,6 +194,9 @@ class OnSubFrame(TransformerMixin, BaseEstimator):
         if not self._columns:
             return passthrough
         transformed = self.transformer_.transform(to_transform)
+        # we do not call `_utils.check_output` here, assuming that if the output
+        # had a correct type (e.g. polars dataframe) in `fit_transform` it will
+        # have the same (correct) type in `transform`.
         transformed = sbd.set_column_names(transformed, self._transformed_output_names)
         return sbd.concat_horizontal(passthrough, transformed)
 

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -1,7 +1,6 @@
 import collections
 import importlib
 import secrets
-import warnings
 from collections.abc import Hashable
 from typing import Any, Iterable
 
@@ -167,14 +166,9 @@ def set_output(transformer, X):
         "1.4"
     ):
         # TODO: remove when scikit-learn 1.3 support is dropped.
-        warnings.warn(
-            "To use polars, we recommend using scikit-learn version 1.4 or newer. The"
-            f" current version is {sklearn.__version__!r}. This will produce correct"
-            " results but may cause an extra copy of the transformer's output."
-        )
         transformer.set_output(transform="pandas")
-        return
-    transformer.set_output(transform=module_name)
+    else:
+        transformer.set_output(transform=module_name)
 
 
 def check_output(

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -1,13 +1,16 @@
 import collections
 import importlib
 import secrets
+import warnings
 from collections.abc import Hashable
 from typing import Any, Iterable
 
 import numpy as np
+import sklearn
 from numpy.typing import NDArray
 from sklearn.base import clone
 from sklearn.utils import check_array
+from sklearn.utils.fixes import parse_version
 
 from skrub import _dataframe as sbd
 
@@ -156,22 +159,82 @@ def repr_args(args, kwargs, defaults={}):
     )
 
 
-def transformer_output_type_error(transformer, transform_input, transform_output):
-    module = sbd.dataframe_module_name(transform_input)
+def set_output(transformer, X):
+    if not hasattr(transformer, "set_output"):
+        return
+    module_name = sbd.dataframe_module_name(X)
+    if module_name == "polars" and parse_version(sklearn.__version__) < parse_version(
+        "1.4"
+    ):
+        warnings.warn(
+            "To use polars, we recommend using scikit-learn version 1.4 or newer. The"
+            f" current version is {sklearn.__version__!r}. This will produce correct"
+            " results but may cause an extra copy of the transformer's output."
+        )
+        transformer.set_output(transform="pandas")
+        return
+    transformer.set_output(transform=module_name)
+
+
+def check_output(
+    transformer, transform_input, transform_output, allow_column_list=True
+):
+    target_module = sbd.dataframe_module_name(transform_input)
+
+    def has_correct_module(obj):
+        return sbd.dataframe_module_name(obj) == target_module
+
+    if (
+        sbd.is_dataframe(transform_output)
+        and target_module == "polars"
+        and sbd.dataframe_module_name(transform_output) == "pandas"
+        and hasattr(transformer, "set_output")
+        and parse_version(sklearn.__version__) < parse_version("1.4")
+    ):
+        # For older scikit-learn versions that do not support
+        # `set_output(transform='polars')`, we fall back to using
+        # `set_output(transform='pandas')` and converting the output dataframe
+        # to polars ourselves.
+        # Therefore having pandas output when the input is polars is tolerated,
+        # when:
+        #   - the scikit-learn version is < 1.4
+        #   - and the transformer relies on the set_output API
+        #     (this implies that the output is a dataframe -- not a column or
+        #     list of columns).
+        # In all other cases having the output backed by the wrong dataframe
+        # library (e.g. pandas instead of polars) will result in an error.
+
+        # transform_input is a polars object so we know we can import it
+        import polars as pl
+
+        return pl.from_pandas(transform_output)
+    if sbd.is_dataframe(transform_output) and has_correct_module(transform_output):
+        return transform_output
+    if (
+        allow_column_list
+        and sbd.is_column(transform_output)
+        and has_correct_module(transform_output)
+    ):
+        return transform_output
+    if (
+        allow_column_list
+        and sbd.is_column_list(transform_output)
+        and (not len(transform_output) or has_correct_module(transform_output[0]))
+    ):
+        return transform_output
     message = (
         f"{transformer.__class__.__name__}.fit_transform returned a result of type"
-        f" {transform_output.__class__.__name__}, but a {module} DataFrame was"
+        f" {transform_output.__class__.__name__}, but a {target_module} DataFrame was"
         f" expected. If {transformer.__class__.__name__} is a custom transformer class,"
-        f" please make sure that the output is a {module} container when the input is a"
-        f" {module} container."
+        f" please make sure that the output is a {target_module} container when the"
+        f" input is a {target_module} container."
     )
     if not hasattr(transformer, "set_output"):
         message += (
-            f" One way of enabling a transformer to output {module} DataFrames is"
-            " inheriting from the sklearn.base.TransformerMixin class and defining the"
-            " 'get_feature_names_out' method. See"
-            " https://scikit-learn.org/stable/auto_examples/"
-            "miscellaneous/plot_set_output.html"
+            f" One way of enabling a transformer to output {target_module} DataFrames"
+            " is inheriting from the sklearn.base.TransformerMixin class and defining"
+            " the 'get_feature_names_out' method. See"
+            " https://scikit-learn.org/stable/auto_examples/miscellaneous/plot_set_output.html"
             " for details."
         )
     raise TypeError(message)

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -166,6 +166,7 @@ def set_output(transformer, X):
     if module_name == "polars" and parse_version(sklearn.__version__) < parse_version(
         "1.4"
     ):
+        # TODO: remove when scikit-learn 1.3 support is dropped.
         warnings.warn(
             "To use polars, we recommend using scikit-learn version 1.4 or newer. The"
             f" current version is {sklearn.__version__!r}. This will produce correct"
@@ -191,6 +192,8 @@ def check_output(
         and hasattr(transformer, "set_output")
         and parse_version(sklearn.__version__) < parse_version("1.4")
     ):
+        # TODO: remove when scikit-learn 1.3 support is dropped.
+        #
         # For older scikit-learn versions that do not support
         # `set_output(transform='polars')`, we fall back to using
         # `set_output(transform='pandas')` and converting the output dataframe

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -684,6 +684,8 @@ def test_accept_pipeline():
 
 def test_clean_null_downcast_warning():
     # non-regression test for https://github.com/skrub-data/skrub/issues/894
+    if parse_version(sklearn.__version__) < parse_version("1.4"):
+        pytest.skip()
     pl = pytest.importorskip("polars")
     df = pl.DataFrame(dict(a=[0, 1], b=["a", "b"]))
     with warnings.catch_warnings():

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -684,8 +684,6 @@ def test_accept_pipeline():
 
 def test_clean_null_downcast_warning():
     # non-regression test for https://github.com/skrub-data/skrub/issues/894
-    if parse_version(sklearn.__version__) < parse_version("1.4"):
-        pytest.skip()
     pl = pytest.importorskip("polars")
     df = pl.DataFrame(dict(a=[0, 1], b=["a", "b"]))
     with warnings.catch_warnings():


### PR DESCRIPTION
I think this may be a better option than #940 

when the input is a polars dataframe and the transformer given to OnEachColumn or OnSubFrame is a scikit-learn transformer which exposes the `set_output` API, we would like to call `set_output(transform='polars')` so that it returns us a polars dataframe.
However, in scikit-learn < 1.3, the 'polars' option is not available, only 'pandas'.
so we have a few options:
- force scikit-learn >= 1.4 but that is quite constraining for users because it is very recent
- basically re-implement set_output ourselves, which is not good because it duplicates code that is already in scikit-learn 
- use `set_output(transform='pandas')` and convert the result to `polars` with `polars.from_pandas`. This lets scikit-learn deal with the conversion from numpy, getting the column names from `get_feature_names_out` etc and produce a pandas dataframe which is easy to convert to polars. This is what this PR does. (for scikit-learn >= 1.4 it just uses `set_output(transform='polars')`

it does not complicate the code much, and avoids complicating the combinations of versions that we allow. it may also result in better error messages for custom estimators that don't support the set_output api.

In addition to doing the logic around scikit-learn 1.4 and pandas-> polars conversion this PR improves the checks of the transformer's output type