### PR TITLE
[MAINT] Harmonize parameter names in private helpers: col, df & specify argument_type in dispatched .specialize

### DIFF
--- a/skrub/_check_input.py
+++ b/skrub/_check_input.py
@@ -42,7 +42,7 @@ def _check_not_pandas_sparse(df):
     pass
 
 
-@_check_not_pandas_sparse.specialize("pandas")
+@_check_not_pandas_sparse.specialize("pandas", argument_type="DataFrame")
 def _check_not_pandas_sparse_pandas(df):
     import pandas as pd
 

--- a/skrub/_clean_categories.py
+++ b/skrub/_clean_categories.py
@@ -8,31 +8,31 @@ __all__ = ["CleanCategories"]
 
 
 @dispatch
-def _with_string_categories(column):
+def _with_string_categories(col):
     raise NotImplementedError()
 
 
 @_with_string_categories.specialize("pandas", argument_type="Column")
-def _with_string_categories_pandas(column):
-    categories = column.cat.categories.to_series()
+def _with_string_categories_pandas(col):
+    categories = col.cat.categories.to_series()
     if sbd.is_string(categories) and not sbd.is_pandas_extension_dtype(categories):
-        return column
+        return col
     try:
-        return column.cat.rename_categories(categories.astype("str"))
+        return col.cat.rename_categories(categories.astype("str"))
     except ValueError:
         # unlikely case that different values in categories have the same
         # string representation: recompute unique categories after casting to
         # string
-        is_na = column.isna()
-        column = column.astype("str")
-        column[is_na] = np.nan
-        column = column.astype("category")
-        return column
+        is_na = col.isna()
+        col = col.astype("str")
+        col[is_na] = np.nan
+        col = col.astype("category")
+        return col
 
 
 @_with_string_categories.specialize("polars", argument_type="Column")
-def _with_string_categories_polars(column):
-    return column
+def _with_string_categories_polars(col):
+    return col
 
 
 class CleanCategories(SingleColumnTransformer):

--- a/skrub/_clean_null_strings.py
+++ b/skrub/_clean_null_strings.py
@@ -30,19 +30,19 @@ STR_NA_VALUES = [
 
 
 @dispatch
-def _trim_whitespace_only(column):
+def _trim_whitespace_only(col):
     raise NotImplementedError()
 
 
 @_trim_whitespace_only.specialize("pandas", argument_type="Column")
-def _trim_whitespace_only_pandas(column):
-    return column.replace(r"^\s*$", "", regex=True)
+def _trim_whitespace_only_pandas(col):
+    return col.replace(r"^\s*$", "", regex=True)
 
 
 @_trim_whitespace_only.specialize("polars", argument_type="Column")
-def _trim_whitespace_only_polars(column):
-    assert sbd.is_string(column), column.dtype
-    return column.str.replace(r"^\s*$", "", literal=False)
+def _trim_whitespace_only_polars(col):
+    assert sbd.is_string(col), col.dtype
+    return col.str.replace(r"^\s*$", "", literal=False)
 
 
 class CleanNullStrings(SingleColumnTransformer):

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -118,7 +118,7 @@ def is_polars(obj):
 
 @dispatch
 def is_dataframe(obj):
-    """Return True if ``obj`` is a DataFrame or a LazyFrame"""
+    """Return True if ``obj`` is a DataFrame or a LazyFrame."""
     return False
 
 
@@ -127,19 +127,19 @@ def _is_dataframe_pandas(obj):
     return True
 
 
-@is_dataframe.specialize("polars", argument_type=["DataFrame", "LazyFrame"])
+@is_dataframe.specialize("polars", argument_type="DataFrame")
 def _is_dataframe_polars(obj):
     return True
 
 
 @dispatch
-def is_lazyframe(df):
-    """Return True if ``df`` is a polars LazyFrame"""
+def is_lazyframe(obj):
+    """Return True if ``obj`` is a polars LazyFrame."""
     return False
 
 
 @is_lazyframe.specialize("polars", argument_type="LazyFrame")
-def _is_lazyframe_polars_lazyframe(df):
+def _is_lazyframe_polars_lazyframe(obj):
     return True
 
 
@@ -214,13 +214,13 @@ def _to_pandas_polars(obj):
 
 
 @dispatch
-def make_dataframe_like(df, data):
-    """Create a dataframe from `data` using the module of `df`.
+def make_dataframe_like(obj, data):
+    """Create a dataframe from `data` using the module of `obj`.
 
     `data` can either be a dictionary {column_name: column} or a list of columns
     (with names).
 
-    `df` can either be a dataframe or a column, and it is only used for dispatch,
+    `obj` can either be a dataframe or a column, and it is only used for dispatch,
     i.e. to determine if the resulting dataframe should be a pandas or polars
     dataframe.
     """
@@ -228,29 +228,29 @@ def make_dataframe_like(df, data):
 
 
 @make_dataframe_like.specialize("pandas")
-def _make_dataframe_like_pandas(df, data):
+def _make_dataframe_like_pandas(obj, data):
     if isinstance(data, Mapping):
         return pd.DataFrame({k: reset_index(v) for k, v in data.items()}, copy=False)
     return pd.DataFrame({name(col): reset_index(col) for col in data}, copy=False)
 
 
 @make_dataframe_like.specialize("polars")
-def _make_dataframe_like_polars(df, data):
+def _make_dataframe_like_polars(obj, data):
     return pl.DataFrame(data)
 
 
 @dispatch
-def make_column_like(column, values, name):
+def make_column_like(obj, values, name):
     raise NotImplementedError()
 
 
 @make_column_like.specialize("pandas")
-def _make_column_like_pandas(column, values, name):
+def _make_column_like_pandas(obj, values, name):
     return pd.Series(data=values, name=name)
 
 
 @make_column_like.specialize("polars")
-def _make_column_like_polars(column, values, name):
+def _make_column_like_polars(obj, values, name):
     return pl.Series(values=values, name=name)
 
 
@@ -272,29 +272,29 @@ def _null_value_for_polars(obj):
 
 
 @dispatch
-def all_null_like(column, length=None, dtype=None, name=None):
+def all_null_like(col, length=None, dtype=None, name=None):
     raise NotImplementedError()
 
 
-@all_null_like.specialize("pandas")
-def _all_null_like_pandas(column, length=None, dtype=None, name=None):
+@all_null_like.specialize("pandas", argument_type="Column")
+def _all_null_like_pandas(col, length=None, dtype=None, name=None):
     if length is None:
-        length = len(column)
+        length = len(col)
     if dtype is None:
-        dtype = column.dtype
+        dtype = col.dtype
     if name is None:
-        name = column.name
-    return pd.Series(dtype=dtype, index=column.index, name=name)
+        name = col.name
+    return pd.Series(dtype=dtype, index=col.index, name=name)
 
 
-@all_null_like.specialize("polars")
-def _all_null_like_polars(column, length=None, dtype=None, name=None):
+@all_null_like.specialize("polars", argument_type="Column")
+def _all_null_like_polars(col, length=None, dtype=None, name=None):
     if length is None:
-        length = len(column)
+        length = len(col)
     if dtype is None:
-        dtype = column.dtype
+        dtype = col.dtype
     if name is None:
-        name = column.name
+        name = col.name
     return pl.Series(name, [None] * length, dtype=dtype)
 
 
@@ -329,12 +329,12 @@ def col(df, col_name):
     raise NotImplementedError()
 
 
-@col.specialize("pandas")
+@col.specialize("pandas", argument_type="DataFrame")
 def _col_pandas(df, col_name):
     return df[col_name]
 
 
-@col.specialize("polars")
+@col.specialize("polars", argument_type="DataFrame")
 def _col_polars(df, col_name):
     return df[col_name]
 
@@ -375,12 +375,12 @@ def name(col):
     raise NotImplementedError()
 
 
-@name.specialize("pandas")
+@name.specialize("pandas", argument_type="Column")
 def _name_pandas(col):
     return col.name
 
 
-@name.specialize("polars")
+@name.specialize("polars", argument_type="Column")
 def _name_polars(col):
     return col.name
 
@@ -390,12 +390,12 @@ def column_names(df):
     raise NotImplementedError()
 
 
-@column_names.specialize("pandas")
+@column_names.specialize("pandas", argument_type="DataFrame")
 def _column_names_pandas(df):
     return list(df.columns.values)
 
 
-@column_names.specialize("polars")
+@column_names.specialize("polars", argument_type="DataFrame")
 def _column_names_polars(df):
     return df.columns
 
@@ -405,29 +405,29 @@ def rename(col, new_name):
     raise NotImplementedError()
 
 
-@rename.specialize("pandas")
+@rename.specialize("pandas", argument_type="Column")
 def _rename_pandas(col, new_name):
     return col.rename(new_name)
 
 
-@rename.specialize("polars")
+@rename.specialize("polars", argument_type="Column")
 def _rename_polars(col, new_name):
     return col.rename(new_name)
 
 
 @dispatch
-def set_column_names(df, new_column_names):
+def set_column_names(df, new_col_names):
     raise NotImplementedError()
 
 
-@set_column_names.specialize("pandas")
-def _set_column_names_pandas(df, new_column_names):
-    return df.set_axis(new_column_names, axis=1)
+@set_column_names.specialize("pandas", argument_type="DataFrame")
+def _set_column_names_pandas(df, new_col_names):
+    return df.set_axis(new_col_names, axis=1)
 
 
-@set_column_names.specialize("polars")
-def _set_column_names_polars(df, new_column_names):
-    return df.rename(dict(zip(df.columns, new_column_names)))
+@set_column_names.specialize("polars", argument_type="DataFrame")
+def _set_column_names_polars(df, new_col_names):
+    return df.rename(dict(zip(df.columns, new_col_names)))
 
 
 @dispatch
@@ -462,18 +462,18 @@ def _index_pandas(obj):
 
 
 @dispatch
-def dtype(column):
+def dtype(col):
     raise NotImplementedError()
 
 
 @dtype.specialize("pandas", argument_type="Column")
-def _dtype_pandas(column):
-    return column.dtype
+def _dtype_pandas(col):
+    return col.dtype
 
 
 @dtype.specialize("polars", argument_type="Column")
-def _dtype_polars(column):
-    return column.dtype
+def _dtype_polars(col):
+    return col.dtype
 
 
 @dispatch
@@ -492,22 +492,22 @@ def _dtypes_polars(df):
 
 
 @dispatch
-def cast(column, dtype):
+def cast(col, dtype):
     raise NotImplementedError()
 
 
-@cast.specialize("pandas")
-def _cast_pandas(column, dtype):
-    if column.dtype == dtype:
-        return column
-    return column.astype(dtype)
+@cast.specialize("pandas", argument_type="Column")
+def _cast_pandas(col, dtype):
+    if col.dtype == dtype:
+        return col
+    return col.astype(dtype)
 
 
-@cast.specialize("polars")
-def _cast_polars(column, dtype):
-    if column.dtype == dtype:
-        return column
-    return column.cast(dtype)
+@cast.specialize("polars", argument_type="Column")
+def _cast_polars(col, dtype):
+    if col.dtype == dtype:
+        return col
+    return col.cast(dtype)
 
 
 @dispatch
@@ -536,232 +536,232 @@ def _pandas_convert_dtypes_pandas(obj):
 
 
 @dispatch
-def is_bool(column):
+def is_bool(col):
     raise NotImplementedError()
 
 
-@is_bool.specialize("pandas")
-def _is_bool_pandas(column):
-    if pd.api.types.is_object_dtype(column):
-        return pandas.api.types.is_bool_dtype(column.convert_dtypes())
-    return pandas.api.types.is_bool_dtype(column)
+@is_bool.specialize("pandas", argument_type="Column")
+def _is_bool_pandas(col):
+    if pd.api.types.is_object_dtype(col):
+        return pandas.api.types.is_bool_dtype(col.convert_dtypes())
+    return pandas.api.types.is_bool_dtype(col)
 
 
-@is_bool.specialize("polars")
-def _is_bool_polars(column):
-    return column.dtype == pl.Boolean
+@is_bool.specialize("polars", argument_type="Column")
+def _is_bool_polars(col):
+    return col.dtype == pl.Boolean
 
 
 @dispatch
-def is_numeric(column):
+def is_numeric(col):
     raise NotImplementedError()
 
 
-@is_numeric.specialize("pandas")
-def _is_numeric_pandas(column):
+@is_numeric.specialize("pandas", argument_type="Column")
+def _is_numeric_pandas(col):
     # polars and pandas disagree about whether Booleans are numbers
     return pandas.api.types.is_numeric_dtype(
-        column
-    ) and not pandas.api.types.is_bool_dtype(column)
+        col
+    ) and not pandas.api.types.is_bool_dtype(col)
 
 
-@is_numeric.specialize("polars")
-def _is_numeric_polars(column):
-    return column.dtype.is_numeric()
+@is_numeric.specialize("polars", argument_type="Column")
+def _is_numeric_polars(col):
+    return col.dtype.is_numeric()
 
 
 @dispatch
-def is_integer(column):
+def is_integer(col):
     raise NotImplementedError()
 
 
-@is_integer.specialize("pandas")
-def _is_integer_pandas(column):
-    return pd.api.types.is_integer_dtype(column)
+@is_integer.specialize("pandas", argument_type="Column")
+def _is_integer_pandas(col):
+    return pd.api.types.is_integer_dtype(col)
 
 
-@is_integer.specialize("polars")
-def _is_integer_polars(column):
-    return column.dtype.is_integer()
+@is_integer.specialize("polars", argument_type="Column")
+def _is_integer_polars(col):
+    return col.dtype.is_integer()
 
 
 @dispatch
-def is_float(column):
+def is_float(col):
     raise NotImplementedError()
 
 
-@is_float.specialize("pandas")
-def _is_float_pandas(column):
-    return pd.api.types.is_float_dtype(column)
+@is_float.specialize("pandas", argument_type="Column")
+def _is_float_pandas(col):
+    return pd.api.types.is_float_dtype(col)
 
 
-@is_float.specialize("polars")
-def _is_float_polars(column):
-    return column.dtype.is_float()
+@is_float.specialize("polars", argument_type="Column")
+def _is_float_polars(col):
+    return col.dtype.is_float()
 
 
 @dispatch
-def to_float32(column, strict=True):
+def to_float32(col, strict=True):
     raise NotImplementedError()
 
 
 @to_float32.specialize("pandas", argument_type="Column")
-def _to_float32_pandas(column, strict=True):
-    if not pd.api.types.is_numeric_dtype(column):
-        column = pd.to_numeric(column, errors="raise" if strict else "coerce")
-    if column.dtype == np.float32:
-        return column
-    return column.astype(np.float32)
+def _to_float32_pandas(col, strict=True):
+    if not pd.api.types.is_numeric_dtype(col):
+        col = pd.to_numeric(col, errors="raise" if strict else "coerce")
+    if col.dtype == np.float32:
+        return col
+    return col.astype(np.float32)
 
 
 @to_float32.specialize("polars", argument_type="Column")
-def _to_float32_polars(column, strict=True):
-    if column.dtype == pl.Float32:
-        return column
-    return column.cast(pl.Float32, strict=strict)
+def _to_float32_polars(col, strict=True):
+    if col.dtype == pl.Float32:
+        return col
+    return col.cast(pl.Float32, strict=strict)
 
 
 @dispatch
-def is_string(column):
+def is_string(col):
     raise NotImplementedError()
 
 
-@is_string.specialize("pandas")
-def _is_string_pandas(column):
-    if column.dtype == pd.StringDtype():
+@is_string.specialize("pandas", argument_type="Column")
+def _is_string_pandas(col):
+    if col.dtype == pd.StringDtype():
         return True
-    if not pd.api.types.is_object_dtype(column):
+    if not pd.api.types.is_object_dtype(col):
         return False
     if parse_version(pd.__version__) < parse_version("2.0.0"):
         # on old pandas versions
         # `pd.api.types.is_string_dtype(pd.Series([1, ""]))` is True
-        return column.convert_dtypes().dtype == pd.StringDtype()
-    return pandas.api.types.is_string_dtype(column[~column.isna()])
+        return col.convert_dtypes().dtype == pd.StringDtype()
+    return pandas.api.types.is_string_dtype(col[~col.isna()])
 
 
-@is_string.specialize("polars")
-def _is_string_polars(column):
-    return column.dtype == pl.String
+@is_string.specialize("polars", argument_type="Column")
+def _is_string_polars(col):
+    return col.dtype == pl.String
 
 
 @dispatch
-def to_string(column):
+def to_string(col):
     raise NotImplementedError()
 
 
-@to_string.specialize("pandas")
-def _to_string_pandas(column):
-    is_na = column.isna()
-    if not (is_pandas_object(column) and is_string(column)):
-        column = column.astype("str")
-        column[is_na] = np.nan
-        return column
+@to_string.specialize("pandas", argument_type="Column")
+def _to_string_pandas(col):
+    is_na = col.isna()
+    if not (is_pandas_object(col) and is_string(col)):
+        col = col.astype("str")
+        col[is_na] = np.nan
+        return col
     if not is_na.any():
-        return column
-    return column.fillna(np.nan)
+        return col
+    return col.fillna(np.nan)
 
 
-@to_string.specialize("polars")
-def _to_string_polars(column):
-    if column.dtype != pl.Object:
+@to_string.specialize("polars", argument_type="Column")
+def _to_string_polars(col):
+    if col.dtype != pl.Object:
         # Objects are mere passengers in polars dataframes and we can't do
         # anything with them; map_elements raises an exception.
-        return _cast_polars(column, pl.String)
-    return column.map_elements(str)
+        return _cast_polars(col, pl.String)
+    return col.map_elements(str)
 
 
 @dispatch
-def is_object(column):
+def is_object(col):
     raise NotImplementedError()
 
 
-@is_object.specialize("pandas")
-def _is_object_pandas(column):
-    return pandas.api.types.is_object_dtype(column)
+@is_object.specialize("pandas", argument_type="Column")
+def _is_object_pandas(col):
+    return pandas.api.types.is_object_dtype(col)
 
 
-@is_object.specialize("polars")
-def _is_object_polars(column):
-    return column.dtype == pl.Object
+@is_object.specialize("polars", argument_type="Column")
+def _is_object_polars(col):
+    return col.dtype == pl.Object
 
 
-def is_pandas_object(column):
-    return is_pandas(column) and is_object(column)
+def is_pandas_object(col):
+    return is_pandas(col) and is_object(col)
 
 
 @dispatch
-def is_any_date(column):
+def is_any_date(col):
     raise NotImplementedError()
 
 
-@is_any_date.specialize("pandas")
-def _is_any_date_pandas(column):
-    return pandas.api.types.is_datetime64_any_dtype(column)
+@is_any_date.specialize("pandas", argument_type="Column")
+def _is_any_date_pandas(col):
+    return pandas.api.types.is_datetime64_any_dtype(col)
 
 
-@is_any_date.specialize("polars")
-def _is_any_date_polars(column):
-    return column.dtype in (pl.Date, pl.Datetime)
+@is_any_date.specialize("polars", argument_type="Column")
+def _is_any_date_polars(col):
+    return col.dtype in (pl.Date, pl.Datetime)
 
 
 @dispatch
-def to_datetime(column, format, strict=True):
+def to_datetime(col, format, strict=True):
     raise NotImplementedError()
 
 
-@to_datetime.specialize("pandas")
-def _to_datetime_pandas(column, format, strict=True):
-    if _is_any_date_pandas(column):
-        return column
+@to_datetime.specialize("pandas", argument_type="Column")
+def _to_datetime_pandas(col, format, strict=True):
+    if _is_any_date_pandas(col):
+        return col
     errors = "raise" if strict else "coerce"
     utc = (format is None) or ("%z" in format)
-    return pd.to_datetime(column, format=format, errors=errors, utc=utc)
+    return pd.to_datetime(col, format=format, errors=errors, utc=utc)
 
 
-@to_datetime.specialize("polars")
-def _to_datetime_polars(column, format, strict=True):
-    if _is_any_date_polars(column):
-        return column
+@to_datetime.specialize("polars", argument_type="Column")
+def _to_datetime_polars(col, format, strict=True):
+    if _is_any_date_polars(col):
+        return col
     try:
         # avoid ChronoFormatWarning due to pandas and polars writing this
         # differently.
         format = format.replace(".%f", "%.f")
-        return column.str.to_datetime(format=format, strict=strict)
+        return col.str.to_datetime(format=format, strict=strict)
     except pl.ComputeError as e:
         raise ValueError("Failed to convert to datetime") from e
 
 
 @dispatch
-def is_categorical(column):
+def is_categorical(col):
     raise NotImplementedError()
 
 
-@is_categorical.specialize("pandas")
-def _is_categorical_pandas(column):
-    return isinstance(column.dtype, pd.CategoricalDtype)
+@is_categorical.specialize("pandas", argument_type="Column")
+def _is_categorical_pandas(col):
+    return isinstance(col.dtype, pd.CategoricalDtype)
 
 
-@is_categorical.specialize("polars")
-def _is_categorical_polars(column):
-    return column.dtype in (pl.Categorical, pl.Enum)
+@is_categorical.specialize("polars", argument_type="Column")
+def _is_categorical_polars(col):
+    return col.dtype in (pl.Categorical, pl.Enum)
 
 
 @dispatch
-def to_categorical(column):
+def to_categorical(col):
     raise NotImplementedError()
 
 
-@to_categorical.specialize("pandas")
-def _to_categorical_pandas(column):
-    return _cast_pandas(column, "category")
+@to_categorical.specialize("pandas", argument_type="Column")
+def _to_categorical_pandas(col):
+    return _cast_pandas(col, "category")
 
 
-@to_categorical.specialize("polars")
-def _to_categorical_polars(column):
-    if column.dtype in (pl.Categorical, pl.Enum):
-        return column
-    column = to_string(column)
-    return _cast_polars(column, pl.Categorical())
+@to_categorical.specialize("polars", argument_type="Column")
+def _to_categorical_polars(col):
+    if col.dtype in (pl.Categorical, pl.Enum):
+        return col
+    col = to_string(col)
+    return _cast_polars(col, pl.Categorical())
 
 
 #
@@ -771,71 +771,71 @@ def _to_categorical_polars(column):
 
 
 @dispatch
-def all(column):
+def all(col):
     raise NotImplementedError()
 
 
-@all.specialize("pandas")
-def _all_pandas(column):
-    return column.all()
+@all.specialize("pandas", argument_type="Column")
+def _all_pandas(col):
+    return col.all()
 
 
-@all.specialize("polars")
-def _all_polars(column):
-    return column.all()
+@all.specialize("polars", argument_type="Column")
+def _all_polars(col):
+    return col.all()
 
 
 @dispatch
-def any(column):
+def any(col):
     raise NotImplementedError()
 
 
-@any.specialize("pandas")
-def _any_pandas(column):
-    return column.any()
+@any.specialize("pandas", argument_type="Column")
+def _any_pandas(col):
+    return col.any()
 
 
-@any.specialize("polars")
-def _any_polars(column):
-    return column.any()
+@any.specialize("polars", argument_type="Column")
+def _any_polars(col):
+    return col.any()
 
 
 @dispatch
-def is_null(column):
+def is_null(col):
     raise NotImplementedError()
 
 
-@is_null.specialize("pandas")
-def _is_null_pandas(column):
-    return rename(column.isna(), name(column))
+@is_null.specialize("pandas", argument_type="Column")
+def _is_null_pandas(col):
+    return rename(col.isna(), name(col))
 
 
-@is_null.specialize("polars")
-def _is_null_polars(column):
-    if column.dtype.is_float():
-        return column.is_null() | column.is_nan()
-    return column.is_null()
+@is_null.specialize("polars", argument_type="Column")
+def _is_null_polars(col):
+    if col.dtype.is_float():
+        return col.is_null() | col.is_nan()
+    return col.is_null()
 
 
-def has_nulls(column):
-    return any(is_null(column))
+def has_nulls(col):
+    return any(is_null(col))
 
 
 @dispatch
-def drop_nulls(column):
+def drop_nulls(col):
     raise NotImplementedError()
 
 
-@drop_nulls.specialize("pandas")
-def _drop_nulls_pandas(column):
-    return column.dropna().reset_index(drop=True)
+@drop_nulls.specialize("pandas", argument_type="Column")
+def _drop_nulls_pandas(col):
+    return col.dropna().reset_index(drop=True)
 
 
-@drop_nulls.specialize("polars")
-def _drop_nulls_polars(column):
-    if column.dtype.is_float():
-        return column.drop_nulls().drop_nans()
-    return column.drop_nulls()
+@drop_nulls.specialize("polars", argument_type="Column")
+def _drop_nulls_polars(col):
+    if col.dtype.is_float():
+        return col.drop_nulls().drop_nans()
+    return col.drop_nulls()
 
 
 @dispatch
@@ -849,10 +849,10 @@ def _fill_nulls_pandas(obj, value):
 
 
 @fill_nulls.specialize("polars", argument_type="Column")
-def _fill_nulls_polars_column(column, value):
-    if column.dtype.is_float():
-        return column.fill_nan(value).fill_null(value)
-    return column.fill_null(value)
+def _fill_nulls_polars_col(col, value):
+    if col.dtype.is_float():
+        return col.fill_nan(value).fill_null(value)
+    return col.fill_null(value)
 
 
 @fill_nulls.specialize("polars", argument_type="DataFrame")
@@ -865,51 +865,51 @@ def _fill_nulls_polars_dataframe(df, value):
 
 
 @dispatch
-def n_unique(column):
+def n_unique(col):
     raise NotImplementedError()
 
 
-@n_unique.specialize("pandas")
-def _n_unique_pandas(column):
-    return column.nunique()
+@n_unique.specialize("pandas", argument_type="Column")
+def _n_unique_pandas(col):
+    return col.nunique()
 
 
-@n_unique.specialize("polars")
-def _n_unique_polars(column):
-    n = column.n_unique()
-    if column.is_null().any():
+@n_unique.specialize("polars", argument_type="Column")
+def _n_unique_polars(col):
+    n = col.n_unique()
+    if col.is_null().any():
         n -= 1
     return n
 
 
 @dispatch
-def unique(column):
+def unique(col):
     raise NotImplementedError()
 
 
-@unique.specialize("pandas")
-def _unique_pandas(column):
-    return pd.Series(column.dropna().unique()).rename(column.name)
+@unique.specialize("pandas", argument_type="Column")
+def _unique_pandas(col):
+    return pd.Series(col.dropna().unique()).rename(col.name)
 
 
-@unique.specialize("polars")
-def _unique_polars(column):
-    return column.unique().drop_nulls()
+@unique.specialize("polars", argument_type="Column")
+def _unique_polars(col):
+    return col.unique().drop_nulls()
 
 
 @dispatch
-def where(column, mask, other):
+def where(col, mask, other):
     raise NotImplementedError()
 
 
-@where.specialize("pandas")
-def _where_pandas(column, mask, other):
-    return column.where(mask, pd.Series(other))
+@where.specialize("pandas", argument_type="Column")
+def _where_pandas(col, mask, other):
+    return col.where(mask, pd.Series(other))
 
 
-@where.specialize("polars")
-def _where_polars(column, mask, other):
-    return column.zip_with(mask, pl.Series(other))
+@where.specialize("polars", argument_type="Column")
+def _where_polars(col, mask, other):
+    return col.zip_with(mask, pl.Series(other))
 
 
 @dispatch
@@ -928,30 +928,30 @@ def _sample_polars(obj, n, seed=None):
 
 
 @dispatch
-def head(df, n=5):
+def head(obj, n=5):
     raise NotImplementedError()
 
 
 @head.specialize("pandas")
-def _head_pandas(df, n=5):
-    return df.head(n=n)
+def _head_pandas(obj, n=5):
+    return obj.head(n=n)
 
 
 @head.specialize("polars")
-def _head_polars(df, n=5):
-    return df.head(n=n)
+def _head_polars(obj, n=5):
+    return obj.head(n=n)
 
 
 @dispatch
-def replace(column, old, new):
+def replace(col, old, new):
     raise NotImplementedError()
 
 
-@replace.specialize("pandas")
-def _replace_pandas(column, old, new):
-    return column.replace(old, new, regex=False)
+@replace.specialize("pandas", argument_type="Column")
+def _replace_pandas(col, old, new):
+    return col.replace(old, new, regex=False)
 
 
-@replace.specialize("polars")
-def _replace_polars(column, old, new):
-    return column.replace(old, new)
+@replace.specialize("polars", argument_type="Column")
+def _replace_polars(col, old, new):
+    return col.replace(old, new)

--- a/skrub/_dispatch.py
+++ b/skrub/_dispatch.py
@@ -224,7 +224,7 @@ def dispatch(function):
         if argument_type is None:
             # Use all type names in the module's description by default.
             argument_type = list(module_info.types.keys())
-        if isinstance(argument_type, str):
+        elif isinstance(argument_type, str):
             argument_type = (argument_type,)
 
         # Define a decorator that adds specialized implementations to

--- a/skrub/_selectors/_base.py
+++ b/skrub/_selectors/_base.py
@@ -158,16 +158,16 @@ def make_selector(obj):
 
 
 @dispatch
-def _select_col_names(df, selector):
+def _select_col_names(df, col_names):
     raise NotImplementedError()
 
 
-@_select_col_names.specialize("pandas")
+@_select_col_names.specialize("pandas", argument_type="DataFrame")
 def _select_col_names_pandas(df, col_names):
     return df[col_names]
 
 
-@_select_col_names.specialize("polars")
+@_select_col_names.specialize("polars", argument_type="DataFrame")
 def _select_col_names_polars(df, col_names):
     return df.select(col_names)
 

--- a/skrub/_to_datetime.py
+++ b/skrub/_to_datetime.py
@@ -45,7 +45,7 @@ def _convert_time_zone(col, time_zone):
     raise NotImplementedError()
 
 
-@_convert_time_zone.specialize("pandas")
+@_convert_time_zone.specialize("pandas", argument_type="Column")
 def _convert_time_zone_pandas(col, time_zone):
     is_localized = _get_time_zone(col) is not None
     if is_localized:
@@ -60,7 +60,7 @@ def _convert_time_zone_pandas(col, time_zone):
             return col.dt.tz_localize("UTC").dt.tz_convert(time_zone)
 
 
-@_convert_time_zone.specialize("polars")
+@_convert_time_zone.specialize("polars", argument_type="Column")
 def _convert_time_zone_polars(col, time_zone):
     import polars as pl
 


### PR DESCRIPTION
- Uniformize `df`, `col`, `obj` arguments in dispatched functions
- Specify `argument_type` when applicable