### PR TITLE
Rename TableVectorizer parameters

### DIFF
--- a/benchmarks/bench_gap_divergence.py
+++ b/benchmarks/bench_gap_divergence.py
@@ -206,7 +206,7 @@ def benchmark(max_iter_e_step, dataset_name):
                 (
                     "encoding",
                     TableVectorizer(
-                        high_cardinality_transformer=ModifiedGapEncoder(
+                        many_unique=ModifiedGapEncoder(
                             min_iter=5,
                             max_iter=5,
                             max_iter_e_step=max_iter_e_step,

--- a/benchmarks/bench_tablevectorizer_tuning.py
+++ b/benchmarks/bench_tablevectorizer_tuning.py
@@ -58,8 +58,8 @@ def benchmark(
     dataset_name,
 ):
     tv = TableVectorizer(
-        cardinality_threshold=tv_cardinality_threshold,
-        high_cardinality_transformer=MinHashEncoder(n_components=minhash_n_components),
+        n_unique_threshold=tv_cardinality_threshold,
+        many_unique=MinHashEncoder(n_components=minhash_n_components),
     )
 
     dataset = dataset_map[dataset_name]

--- a/benchmarks/run_on_openml_datasets.py
+++ b/benchmarks/run_on_openml_datasets.py
@@ -47,14 +47,14 @@ openml.config.cache_directory = os.path.expanduser(args.cache_directory)
 
 classification_pipeline = Pipeline(
     [
-        ("vectorizer", TableVectorizer(high_cardinality_transformer=MinHashEncoder())),
+        ("vectorizer", TableVectorizer(many_unique=MinHashEncoder())),
         ("classifier", HistGradientBoostingClassifier()),
     ]
 )
 
 regression_pipeline = Pipeline(
     [
-        ("vectorizer", TableVectorizer(high_cardinality_transformer=MinHashEncoder())),
+        ("vectorizer", TableVectorizer(many_unique=MinHashEncoder())),
         ("regressor", HistGradientBoostingRegressor()),
     ]
 )

--- a/examples/01_encodings.py
+++ b/examples/01_encodings.py
@@ -244,8 +244,8 @@ print(f"mean fit time: {np.mean(results['fit_time']):.3f} seconds")
 from skrub import MinHashEncoder, ToCategorical
 
 vectorizer = TableVectorizer(
-    low_cardinality_transformer=ToCategorical(),
-    high_cardinality_transformer=MinHashEncoder(),
+    few_unique=ToCategorical(),
+    many_unique=MinHashEncoder(),
 )
 pipeline = make_pipeline(
     vectorizer, HistGradientBoostingRegressor(categorical_features="from_dtype")

--- a/examples/03_datetime_encoder.py
+++ b/examples/03_datetime_encoder.py
@@ -121,7 +121,7 @@ pprint(table_vec.get_feature_names_out())
 # Here, for example, we want it to extract the day of the week.
 
 table_vec = TableVectorizer(
-    datetime_transformer=DatetimeEncoder(add_weekday=True),
+    datetime=DatetimeEncoder(add_weekday=True),
 ).fit(X)
 pprint(table_vec.get_feature_names_out())
 
@@ -258,7 +258,7 @@ plt.show()
 from sklearn.inspection import permutation_importance
 
 table_vec = TableVectorizer(
-    datetime_transformer=DatetimeEncoder(add_weekday=True),
+    datetime=DatetimeEncoder(add_weekday=True),
 )
 
 # In this case, we don't use a pipeline, because we want to compute the

--- a/examples/08_join_aggregation.py
+++ b/examples/08_join_aggregation.py
@@ -85,9 +85,7 @@ X.head()
 # columns, and doesn't interact with numerical columns.
 from skrub import DatetimeEncoder, TableVectorizer
 
-table_vectorizer = TableVectorizer(
-    datetime_transformer=DatetimeEncoder(add_weekday=True)
-)
+table_vectorizer = TableVectorizer(datetime=DatetimeEncoder(add_weekday=True))
 X_date_encoded = table_vectorizer.fit_transform(X)
 X_date_encoded.head()
 

--- a/examples/FIXME/07_grid_searching_with_the_tablevectorizer.py
+++ b/examples/FIXME/07_grid_searching_with_the_tablevectorizer.py
@@ -63,7 +63,7 @@ pprint(tv.transformers_)
 from skrub import MinHashEncoder
 
 tv = TableVectorizer(
-    high_cardinality_transformer=MinHashEncoder(),
+    many_unique=MinHashEncoder(),
 )
 tv.fit(X)
 
@@ -117,7 +117,7 @@ from skrub import GapEncoder
 
 pipeline = make_pipeline(
     TableVectorizer(
-        high_cardinality_transformer=GapEncoder(),
+        many_unique=GapEncoder(),
         specific_transformers=[
             ("mh_dep_name", MinHashEncoder(), ["department_name"]),
         ],

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -14,7 +14,7 @@ from skrub import _join_utils, _utils
 from skrub._minhash_encoder import MinHashEncoder
 from skrub._table_vectorizer import TableVectorizer
 
-DEFAULT_VECTORIZER = TableVectorizer(high_cardinality_transformer=MinHashEncoder())
+DEFAULT_VECTORIZER = TableVectorizer(many_unique=MinHashEncoder())
 DEFAULT_REGRESSOR = HistGradientBoostingRegressor()
 DEFAULT_CLASSIFIER = HistGradientBoostingClassifier()
 

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -200,7 +200,7 @@ def test_join_on_date(df_module):
             aux_key="date",
             regressor=KNeighborsRegressor(1),
         )
-        .set_params(vectorizer__datetime_transformer__resolution=None)
+        .set_params(vectorizer__datetime__resolution=None)
         .fit_transform(sales)
     )
     assert_array_equal(ns.to_list(ns.col(transformed, "temp")), [-10, 10])


### PR DESCRIPTION
rename the TableVectorizer parameters and corresponding attributes according to #671 and this morning's skrub meeting discussion:

```
cardinality_threshold → n_unique_threshold
high_cardinality_transformer → many_unique
low_cardinality_transformer → few_unique
datetime_transformer → datetime
numeric_transformer → numeric
```

I'm not 100% sure the new names are better esp. the "cardinality" replacement  :thinking: 