### PR TITLE
FIX always take into account suffix parameter in fetch_ken_embeddings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,10 @@ Minor changes
 
 * Skrub supports numpy 2. :pr:`946` by :user:`Jérôme Dockès <jeromedockes>`.
 
+* :func:`~datasets.fetch_ken_embeddings` now add suffix even with the default
+  value for the parameter `pca_components`.
+  :pr:`956` by :user:`Guillaume Lemaitre <glemaitre>`.
+
 skrub release 0.1.0
 ===================
 

--- a/skrub/datasets/_ken_embeddings.py
+++ b/skrub/datasets/_ken_embeddings.py
@@ -281,6 +281,11 @@ def fetch_ken_embeddings(
             )
             emb_final.append(emb_pca)
         else:
+            if suffix != "":
+                emb_extracts.columns = [
+                    col if col in ["Entity", "Type"] else col + suffix
+                    for col in emb_extracts.columns
+                ]
             emb_final.append(emb_extracts)
     emb_df = pd.concat(emb_final)
     emb_df["Entity"] = emb_df["Entity"].str[1:-1]

--- a/skrub/datasets/tests/test_ken_embeddings.py
+++ b/skrub/datasets/tests/test_ken_embeddings.py
@@ -90,6 +90,7 @@ def test_ken_embedding_suffix(pca_components):
     Non-regression test for:
     https://github.com/skrub-data/skrub/issues/955
     """
+    pytest.importorskip("pyarrow")
     suffix = "_aux"
     embedding = fetch_ken_embeddings(
         search_types="game_designers",

--- a/skrub/datasets/tests/test_ken_embeddings.py
+++ b/skrub/datasets/tests/test_ken_embeddings.py
@@ -84,14 +84,14 @@ def test_big_ken_embeddings():
 
 
 @pytest.mark.parametrize("pca_components", [None, 5])
-def test_ken_embedding_suffix(pca_components):
+@pytest.mark.parametrize("suffix", ["", "_aux"])
+def test_ken_embedding_suffix(pca_components, suffix):
     """Check that we always add the suffix to the columns names.
 
     Non-regression test for:
     https://github.com/skrub-data/skrub/issues/955
     """
     pytest.importorskip("pyarrow")
-    suffix = "_aux"
     embedding = fetch_ken_embeddings(
         search_types="game_designers",
         embedding_table_id="39254360",

--- a/skrub/datasets/tests/test_ken_embeddings.py
+++ b/skrub/datasets/tests/test_ken_embeddings.py
@@ -81,3 +81,25 @@ def test_big_ken_embeddings():
         pca_components=10,
     )
     assert emb4.shape[1] == 12
+
+
+@pytest.mark.parametrize("pca_components", [None, 5])
+def test_ken_embedding_suffix(pca_components):
+    """Check that we always add the suffix to the columns names.
+
+    Non-regression test for:
+    https://github.com/skrub-data/skrub/issues/955
+    """
+    suffix = "_aux"
+    embedding = fetch_ken_embeddings(
+        search_types="game_designers",
+        embedding_table_id="39254360",
+        embedding_type_id="39266678",
+        suffix=suffix,
+        pca_components=pca_components,
+    )
+    column_names = embedding.columns.drop(["Entity", "Type"])
+    expected_n_components = pca_components or 200
+    assert column_names.tolist() == [
+        f"X{i}{suffix}" for i in range(expected_n_components)
+    ]


### PR DESCRIPTION
When `pca_components=None`, the parameter `suffix` was disregarded in `fetch_ken_embeddings`.

This PR fixes this bug and add a non-regression test.