### PR TITLE
FIX use keyword-only argument

### DIFF
--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -22,7 +22,7 @@ _TREE_ENSEMBLE_CLASSES = (
 )
 
 
-def tabular_learner(estimator, n_jobs=None):
+def tabular_learner(estimator, *, n_jobs=None):
     """Get a simple machine-learning pipeline for tabular data.
 
     Given a scikit-learn ``estimator``, this function creates a


### PR DESCRIPTION
Small nitpicks where I would like to require all arguments apart from `estimator` to be keyword only. It would allow us to introduce any new parameter in the future without caring that our user was passing by position or not.

It is removing the future hassle questioning if we should put a new parameter or not of the signature.