### PR TITLE
remove _preprocess_text which is not necessary

### DIFF
--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -225,7 +225,6 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
         # Init n-grams counts vectorizer
         if self.hashing:
             self.ngrams_count_ = HashingVectorizer(
-                preprocessor=_preprocess_text,
                 analyzer=self.analyzer,
                 ngram_range=self.ngram_range,
                 n_features=self.hashing_n_features,
@@ -234,7 +233,6 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
             )
             if self.add_words:  # Init a word counts vectorizer if needed
                 self.word_count_ = HashingVectorizer(
-                    preprocessor=_preprocess_text,
                     analyzer="word",
                     n_features=self.hashing_n_features,
                     norm=None,
@@ -242,15 +240,12 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
                 )
         else:
             self.ngrams_count_ = CountVectorizer(
-                preprocessor=_preprocess_text,
                 analyzer=self.analyzer,
                 ngram_range=self.ngram_range,
                 dtype=np.float64,
             )
             if self.add_words:
-                self.word_count_ = CountVectorizer(
-                    preprocessor=_preprocess_text, dtype=np.float64
-                )
+                self.word_count_ = CountVectorizer(dtype=np.float64)
 
         # Init H_dict_ with empty dict to train from scratch
         self.H_dict_ = dict()
@@ -774,18 +769,6 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
         return result
 
 
-def _preprocess_text(text):
-    """Text preprocessor for the GapEncoder and MinHashEncoder.
-
-    It is equivalent to the default preprocessor of CountVectorizer except that
-    nulls are replaced by the empty string instead of raising an exception.
-
-    """
-    if isinstance(text, str):
-        return text.lower()
-    return ""
-
-
 def _rescale_W(W, A):
     """
     Rescale the topics `W` to have a L1-norm equal to 1.
@@ -924,7 +907,6 @@ def get_kmeans_prototypes(
       - nearest neighbor
     """
     vectorizer = HashingVectorizer(
-        preprocessor=_preprocess_text,
         analyzer=analyzer,
         norm=None,
         alternate_sign=False,

--- a/skrub/tests/test_gap_encoder.py
+++ b/skrub/tests/test_gap_encoder.py
@@ -224,9 +224,11 @@ def test_missing_values(df_module):
     observations = df_module.make_column("", observations)
     enc = GapEncoder(n_components=3)
     enc.fit_transform(observations)
+    enc.transform(observations)
     enc.partial_fit(observations)
     # non-regression for https://github.com/skrub-data/skrub/issues/921
-    assert sbd.is_null(observations)[2]
+    for null_idx in 2, 4, 5:
+        assert sbd.is_null(observations)[null_idx]
 
 
 def test_check_fitted_gap_encoder(df_module):


### PR DESCRIPTION
handling missing values is actually handled in the computation of unique values now, with the addition of `unique_strings` so passing a custom preprocessor is not necessary and anyway it works for None and pd.NA but not for numpy nan