### PR TITLE
MAINT xfail the fetch_movielens test

### DIFF
--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -479,6 +479,7 @@ def _fetch_movielens(dataset_id: str, data_directory: Path | None = None) -> dic
 
 def _download_and_write_movielens_dataset(dataset_id, data_directory, zip_directory):
     url = MOVIELENS_URL.format(zip_directory=zip_directory)
+    tmp_file = None
     try:
         tmp_file, _ = urllib.request.urlretrieve(url)
         data_file = str((zip_directory / f"{dataset_id}.csv").as_posix())
@@ -489,7 +490,7 @@ def _download_and_write_movielens_dataset(dataset_id, data_directory, zip_direct
                 members=[data_file, readme_file],
             )
     except Exception:
-        if Path(tmp_file).exists():
+        if tmp_file is not None and Path(tmp_file).exists():
             Path(tmp_file).unlink()
         raise
 

--- a/skrub/datasets/tests/test_fetching.py
+++ b/skrub/datasets/tests/test_fetching.py
@@ -163,6 +163,7 @@ def test_fetch_world_bank_indicator():
             assert disk_loaded_info == returned_info
 
 
+@pytest.mark.xfail(run=False, reason="temporary SSL certificate issue")
 def test_fetch_movielens():
     """
     Tests the ``fetch_movielens()`` function in a real environment.


### PR DESCRIPTION
this test if causing the CI to fail due to a download error. here also, (as for the ken embeddings) the real fix is to mock doownloads in tests but in the meanwhile this allows the ci to run @glemaitre 