### PR TITLE
DOC reorganize a bit user guide structure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 .. _changes:
 
-========
-Changes
-========
+===============
+Release history
+===============
 
 .. currentmodule:: skrub
 

--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -231,3 +231,15 @@ div.sk-landing-footer {
 	max-width: 60rem;
     }
 }
+
+/** Scikit-learn buttons ***************************/
+a.sk-btn-orange {
+    font-size: 1.1rem;
+    font-weight: 500;
+    background-color: #f99f44;  /* sk-orange-tint-1 */
+    color: black !important;
+}
+
+a.sk-btn-orange:hover {
+    background-color: #fcb575;  /* --sk-orange-tint-3 */
+}

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -235,14 +235,4 @@ class="pre">df</span></code>: <i>(expand for full code)</i></summary>
 {% endblock docs_main %}
 
 {%- block footer %}
-<div class="container-fluid sk-landing-footer">
-  <div class="row justify-content-md-center">
-    <div class="col-lg-4">
-	<p><a href="CHANGES.html">Recent changes</a></p>
-    </div>
-    <div class="col-lg-4">
-	<p><a href="CONTRIBUTING.html">Contributing</a></p>
-    </div>
-  </div>
-</div>
 {%- endblock footer %}

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -17,6 +17,8 @@ still full-width (unlike the article) #}
 	<div class="col-md-6 mb-3 mb-md-0">
 	    <h1 class="sk-landing-header text-white text-monospace">skrub</h1>
 	    <h4 class="sk-landing-subheader text-white font-italic mb-3"><i>Prepping tables for machine learning</i></h4>
+      <a class="btn sk-btn-orange mb-1" href="{{ pathto('CONTRIBUTING') }}" role="button">Contribute</code></a>
+      <a class="btn sk-btn-orange mb-1" href="{{ pathto('CHANGES') }}" role="button">Recent changes</a>
 	</div>
 	<div class="col-md-6 d-flex">
 	    <ul class="sk-landing-header-body">

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -1,6 +1,6 @@
 
 About
-------
+-----
 
 skrub shares much of its DNA with `scikit-learn
 <https://scikit-learn.org>`__.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -223,6 +223,15 @@ html_context = {
     "doc_path": "doc",
 }
 
+# Custom sidebar templates, maps document names to template names.
+# Workaround for removing the left sidebar on pages without TOC
+# A better solution would be to follow the merge of:
+# https://github.com/pydata/pydata-sphinx-theme/pull/1682
+html_sidebars = {
+    "install": [],
+    "CHANGES": [],
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -1,9 +1,9 @@
 
-=============
+===========
 Development
-=============
+===========
 
-While skrub is still being born, we believe in openess and community
+While `skrub` is still being born, we believe in openness and community
 development from the start. Join us in building a great package to
 facilitate learning on databases.
 
@@ -13,5 +13,4 @@ facilitate learning on databases.
 
     vision
     about
-    CONTRIBUTING.rst
-    CHANGES.rst
+    CONTRIBUTING

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -20,8 +20,8 @@ typically with `scikit-learn <http://scikit-learn.org>`_ with its
 .. include:: includes/big_toc_css.rst
 
 .. toctree::
+   :maxdepth: 2
 
    encoding
    assembling
    cleaning
-   development

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,9 @@
+.. title:: Index
 
 .. toctree::
    :maxdepth: 2
 
 .. currentmodule:: skrub
-
 
 .. toctree::
    :hidden:
@@ -12,3 +12,5 @@
    documentation
    api
    auto_examples/index
+   CHANGES
+   development

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-.. title:: Index
+.. title:: Home
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This PR will:

- move the development page to its own section to have the user guide only about the library tools
- add the changelog out of the development page
- remove the left sidebar when there is no item to click on
- add a title to the index page
- remove the footer on the page. We should probably make it more visible to get access to the changelog and contributing guideline.