### PR TITLE
DOC reorder properly the numpydoc docstring

### DIFF
--- a/doc/_templates/numpydoc_docstring.rst
+++ b/doc/_templates/numpydoc_docstring.rst
@@ -1,0 +1,16 @@
+{{index}}
+{{summary}}
+{{extended_summary}}
+{{parameters}}
+{{returns}}
+{{yields}}
+{{other_parameters}}
+{{attributes}}
+{{raises}}
+{{warns}}
+{{warnings}}
+{{see_also}}
+{{notes}}
+{{references}}
+{{examples}}
+{{methods}}


### PR DESCRIPTION
This should solve the issue having the attributes appearing after the examples.
