### PR TITLE
Set sphinx gallery default thumbnail?

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -438,6 +438,7 @@ sphinx_gallery_conf = {
         "dependencies": "./binder/requirements.txt",
         "use_jupyter_lab": True,
     },
+    "default_thumb_file": "./_static/skrub.svg",
 }
 if with_jupyterlite:
     sphinx_gallery_conf["jupyterlite"] = {


### PR DESCRIPTION
the default sphinx gallery thumbnail for examples without a plot is faded out giving the impression that something went wrong or something is missing. But it's valid for an example not to create any matplotlib plots, for example example 0 getting started.

shall we consider replacing the default thumbnail with something else, like the skrub logo?