### PR TITLE
DOC: Add version switcher

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -210,6 +210,7 @@ html_theme_options = {
         "json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
         "version_match": release,
     },
+    "show_version_warning_banner": True,
 }
 
 # Additional templates that should be rendered to pages, maps page names to

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -206,10 +206,8 @@ html_theme_options = {
     # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["index.html"],  # Remove the source buttons
     "switcher": {
-        #"json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/versions.json",
-        "json_url": (
-            "https://www.normalesup.org/~varoquau/version.json"
-        ),
+        #"json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/version.json",
+        #"json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
         "version_match": release,
     },
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -191,14 +191,14 @@ html_theme_options = {
     "show_toc_level": 1,
     # "navbar_align": [left, content, right] to test that navbar items align properly
     "navbar_align": "left",
-    "navbar_center": ["version-switcher", "navbar-nav"],
-    # "navbar_center": ["navbar-nav"],
+    # "navbar_center": ["version-switcher", "navbar-nav"],
+    "navbar_center": ["navbar-nav"],
     "announcement": (
         "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/announcement.html"
     ),
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
-    # "navbar_end": ["theme-switcher", "navbar-icon-links"],
+    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     # "navbar_persistent": ["search-button"],
     # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "article_footer_items": ["prev-next.html", "test.html", "test.html"],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -205,10 +205,10 @@ html_theme_options = {
     # "content_footer_items": ["prev-next.html", "test.html", "test.html"],
     # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["index.html"],  # Remove the source buttons
-    # "switcher": {
-    #     "json_url": json_url,
-    #     "version_match": version_match,
-    # },
+    "switcher": {
+        "json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/versions.json",
+        "version_match": release,
+    },
 }
 
 # Additional templates that should be rendered to pages, maps page names to

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -191,8 +191,8 @@ html_theme_options = {
     "show_toc_level": 1,
     # "navbar_align": [left, content, right] to test that navbar items align properly
     "navbar_align": "left",
-    # "navbar_center": ["version-switcher", "navbar-nav"],
-    "navbar_center": ["navbar-nav"],
+    "navbar_center": ["version-switcher", "navbar-nav"],
+    # "navbar_center": ["navbar-nav"],
     "announcement": (
         "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/announcement.html"
     ),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -208,7 +208,7 @@ html_theme_options = {
     "switcher": {
         # "json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/version.json",
         "json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
-        "version_match": release,
+        "version_match": "dev",
     },
     "show_version_warning_banner": True,
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -206,7 +206,7 @@ html_theme_options = {
     # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["index.html"],  # Remove the source buttons
     "switcher": {
-        #"json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/version.json",
+        # "json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/version.json",
         "json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
         "version_match": release,
     },

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,7 +207,7 @@ html_theme_options = {
     # "secondary_sidebar_items": ["index.html"],  # Remove the source buttons
     "switcher": {
         #"json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/version.json",
-        #"json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
+        "json_url": "https://raw.githubusercontent.com/GaelVaroquaux/skrub/version_selector_doc/doc/version.json",
         "version_match": release,
     },
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -206,7 +206,10 @@ html_theme_options = {
     # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["index.html"],  # Remove the source buttons
     "switcher": {
-        "json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/versions.json",
+        #"json_url": "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/versions.json",
+        "json_url": (
+            "https://www.normalesup.org/~varoquau/version.json"
+        ),
         "version_match": release,
     },
 }

--- a/doc/version.json
+++ b/doc/version.json
@@ -1,0 +1,10 @@
+[
+    {
+        "version": "dev",
+        "url": "https://skrub-data/dev/"
+    },
+    {
+        "version": "stable",
+        "url": "https://skrub-data/stable/"
+    }
+]

--- a/doc/version.json
+++ b/doc/version.json
@@ -6,6 +6,6 @@
     {
         "version": "stable",
         "url": "https://skrub-data.org/stable/",
-	"preferred"
+	"preferred": true
     }
 ]

--- a/doc/version.json
+++ b/doc/version.json
@@ -1,10 +1,11 @@
 [
     {
         "version": "dev",
-        "url": "https://skrub-data/dev/"
+        "url": "https://skrub-data.org/dev/"
     },
     {
         "version": "stable",
-        "url": "https://skrub-data/stable/"
+        "url": "https://skrub-data.org/stable/",
+	"preferred"
     }
 ]


### PR DESCRIPTION
Add a version switcher to easily go from dev to stable.
![image](https://github.com/user-attachments/assets/ad7bd608-8238-4a44-8193-cfb44bd42d1a)


For now, the version.json file points to this PR, but we will need to change it to point to main branch on skrub