### PR TITLE
Remove pypi button

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,11 +178,6 @@ html_theme_options = {
             "url": "https://github.com/skrub-data/skrub/",
             "icon": "fa-brands fa-github",
         },
-        {
-            "name": "PyPI",
-            "url": "https://pypi.org/project/skrub",
-            "icon": "fa-custom fa-pypi",
-        },
     ],
     # alternative way to set twitter and github header icons
     # "github_url": "https://github.com/pydata/pydata-sphinx-theme",


### PR DESCRIPTION
Removing the pypi button with no logo

before:
<img width="356" alt="Capture d’écran 2024-07-22 à 14 30 51" src="https://github.com/user-attachments/assets/b16bc2ab-7bad-4753-be53-4668f2de1ba1">

after:
<img width="384" alt="Capture d’écran 2024-07-22 à 16 17 45" src="https://github.com/user-attachments/assets/67ab5998-960c-4268-ad89-a791b29c162d">
