### PR TITLE
Discussion: apply column filter to similarity table in TableReport

### DIFF
--- a/skrub/_reporting/_data/templates/dataframe-columns.css
+++ b/skrub/_reporting/_data/templates/dataframe-columns.css
@@ -49,7 +49,7 @@
 
 /* Hide cards of columns that do not match the filter (eg "all()", "numeric()", ...) */
 
-.filterable-column[data-is-excluded-by-filter] {
+:is(.filterable-column, .filterable-column-pair)[data-is-excluded-by-filter] {
     display: none;
 }
 

--- a/skrub/_reporting/_data/templates/dataframe-interactions.html
+++ b/skrub/_reporting/_data/templates/dataframe-interactions.html
@@ -1,41 +1,58 @@
-<article class="flex-reverse wrapper wrapper-vert-l gap-l">
+<article>
     {% if summary["top_associations"] %}
+    <div class="if-else interactions-toggle"
+         data-predicate="true"
+         id="interactions-content"
+         data-similarity-threshold="{{ column_similarity_threshold }}" >
+        <div class="flex-reverse wrapper gap-l wrapper-vert-l">
+            <div class="horizontal-scroll">
+                <table class="pure-table">
+                    <thead>
+                        <tr>
+                            <th>Column 1</th>
+                            <th>Column 2</th>
+                            <th><a
+                                    href="https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V">Cramér's
+                                    V</a></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for association in summary["top_associations"] %}
+                        <tr class="filterable-column-pair"
+                            data-left-column="{{ association['left_column'] }}"
+                            data-right-column="{{ association['right_column'] }}"
+                            data-similarity="{{ association['cramer_v'] }}">
+                            <td>{{ association["left_column"] }}</td>
+                            <td>{{ association["right_column"] }}</td>
+                            <td {% if association["cramer_v"] is gt column_similarity_threshold %}
+                                class="critical" {%- endif -%}>
+                                {{ association["cramer_v"] | format_number }}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
 
-    <div class="horizontal-scroll">
-    <table class="pure-table">
-        <thead>
-            <tr>
-                <th>Column 1</th>
-                <th>Column 2</th>
-                <th><a href="https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V">Cramér's V</a></th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for association in summary["top_associations"] %}
-            <tr>
-                <td>{{ association["left_column"] }}</td>
-                <td>{{ association["right_column"] }}</td>
-                <td
-                    {% if association["cramer_v"] is gt column_similarity_threshold %}
-                    class="critical"
-                    {%- endif -%}
-                    >
-                    {{ association["cramer_v"] | format_number }}
-                </td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-    </div>
-
-    <div class="text shrinkable-text">
-        The table below shows the strength of association between the most similar columns in the dataframe.
-        <a href="https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V">Cramér's V</a> statistic is a number between 0 and 1.
-        When it is close to 1 the columns are strongly associated — they contain similar information.
-        In this case, one of them may be redundant and for some models (such as linear models) it might be beneficial to remove it.
-    </div>
-
-    {% else %}
-    No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-    {% endif %}
+            <div class="text shrinkable-text">
+                The table shows the strength of association between the most similar
+                columns in the dataframe.
+                <a href="https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V">Cramér's V</a>
+                statistic is a number between 0 and 1.
+                When it is close to 1 the columns are strongly associated — they contain
+                similar
+                information.
+                In this case, one of them may be redundant and for some models (such as
+                linear
+                models) it might be beneficial to remove it.
+            </div>
+        </div>
+        <div class="text announcement wrapper" data-test="interactions-no-match">
+            {% set no_match_msg = "None of the columns in the similarity table match the selected filter" %}
+            {% include "no-filter-matches.html" %}
+        </div>
+        {% else %}
+        No strong associations between any pair of columns were identified by a quick
+        screening of a subsample of the dataframe.
+        {% endif %}
 </article>

--- a/skrub/_reporting/_data/templates/no-filter-matches.html
+++ b/skrub/_reporting/_data/templates/no-filter-matches.html
@@ -1,5 +1,7 @@
 <p>
-No columns match the selected filter: <strong class="selected-filter-display"></strong>. You can change the column filter in the dropdown menu above.
+    {{ no_match_msg or "No columns match the selected filter" }}:
+    <strong class="selected-filter-display"></strong>.
+    You can change the column filter in the dropdown menu above.
 </p>
 <p>
     <button onclick="getReport(event).clearColFilter(event)">Show all columns</button>

--- a/skrub/_reporting/_data/templates/skrub-report.js
+++ b/skrub/_reporting/_data/templates/skrub-report.js
@@ -168,7 +168,16 @@ if (customElements.get('skrub-table-report') === undefined) {
             const selectElem = this.shadowRoot.getElementById("col-filter-select");
             const colFilters = window[`columnFiltersForReport${this.id}`];
             const filterName = selectElem.value;
+            const filterDisplayName = colFilters[filterName][
+                "display_name"
+            ];
             const acceptedCols = colFilters[filterName]["columns"];
+            this.filterColumns(filterName, filterDisplayName, acceptedCols);
+            this.filterInteractionsTable(filterName, filterDisplayName,
+                acceptedCols);
+        }
+
+        filterColumns(filterName, filterDisplayName, acceptedCols) {
             const colElements = this.shadowRoot.querySelectorAll(
                 ".filterable-column");
             colElements.forEach(elem => {
@@ -193,10 +202,41 @@ if (customElements.get('skrub-table-report') === undefined) {
                     "true";
                 const filterDisplay = toggle.querySelector(
                     ".selected-filter-display");
-                filterDisplay.textContent = '"' + colFilters[filterName][
-                    "display_name"
-                ] + '"';
+                filterDisplay.textContent = '"' + filterDisplayName + '"';
             }
+        }
+
+        filterInteractionsTable(filterName, filterDisplayName, acceptedCols) {
+            const interactions = this.shadowRoot.getElementById(
+                "interactions-content");
+            if (!interactions) {
+                return;
+            }
+            const threshold = interactions.dataset.similarityThreshold;
+            const rows = interactions.querySelectorAll(
+                ".filterable-column-pair");
+            let allExcluded = true;
+            rows.forEach(row => {
+                let isExcluded;
+                if (filterName === "high_similarity") {
+                    isExcluded = row.dataset.similarity <= threshold;
+                } else {
+                    isExcluded = ![row.dataset.leftColumn, row.dataset
+                        .rightColumn
+                    ].some((c) => acceptedCols.includes(c));
+                }
+                if (isExcluded) {
+                    row.dataset.isExcludedByFilter = "";
+                } else {
+                    row.removeAttribute("data-is-excluded-by-filter");
+                    allExcluded = false;
+                }
+            });
+            const toggle = this.shadowRoot.querySelector(".interactions-toggle");
+            toggle.dataset.predicate = allExcluded ? "false" : "true";
+            const filterDisplay = toggle.querySelector(
+                ".selected-filter-display");
+            filterDisplay.textContent = '"' + filterDisplayName + '"';
         }
 
 

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -77,7 +77,7 @@ def summarize_dataframe(df, *, order_by=None, with_plots=True, title=None):
 
 def _add_interactions(df, dataframe_summary):
     df = sbd.sample(df, n=min(sbd.shape(df)[0], _SUBSAMPLE_SIZE))
-    associations = _interactions.cramer_v(df)[:20]
+    associations = _interactions.cramer_v(df)[:30]
     dataframe_summary["top_associations"] = [
         dict(zip(("left_column", "right_column", "cramer_v"), a))
         for a in associations

--- a/skrub/_reporting/js_tests/cypress/e2e/column-filters.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/column-filters.cy.js
@@ -10,4 +10,18 @@ describe ('test filtering visible columns', () => {
         cy.get('@report').find('#col_7').should('not.be.visible');
         cy.get('@report').find('#col_0').should('be.visible');
     });
+
+    it('hides column associatiosn not matched by the selector', () => {
+        cy.visit('_reports/employee_salaries.html');
+        cy.get('skrub-table-report').shadow().as('report');
+        cy.get('@report').find('button[data-target-tab="interactions-tab"]').click();
+        cy.get('@report').find('tr[data-left-column="division"]').first().as('row');
+        cy.get('@row').should('be.visible');
+        cy.get('@report').find('#col-filter-select').select('Columns with high similarity');
+        cy.get('@row').should('not.be.visible');
+        cy.get('@report').find('[data-test="interactions-no-match"]').as('announcement');
+        cy.get('@announcement').should('not.be.visible');
+        cy.get('@report').find('#col-filter-select').select('Numeric columns');
+        cy.get('@announcement').should('be.visible');
+    });
 });


### PR DESCRIPTION
As @lesteve  rightly pointed out, the fact that the column filter doesn't apply to the table of column similarities is surprising. This PR filters the similarity table: the row containing the similarity of column A and column B only appears if either A or B matches the column filter. 
There is also a special case for the "Columns with high similarity" filter: only rows corresponding to the high similarities appear

I also noted in the code there is a mix of "interactions", "associations" and "similarities" as our preferred term for this has evolved, I'll address that in a separate PR