### PR TITLE
disable column filter when column associations tab is selected

### DIFF
--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -102,6 +102,10 @@ dd {
     margin: 0;
 }
 
+*[disabled] {
+    cursor: not-allowed;
+}
+
 /* Generic utility classes */
 /* ----------------------- */
 

--- a/skrub/_reporting/_data/templates/column-filters.html
+++ b/skrub/_reporting/_data/templates/column-filters.html
@@ -1,12 +1,27 @@
+{% set options %}
+{% for filter_name in column_filters %}
+<option value="{{ filter_name }}" {{ "selected" if filter_name == "all()" }}>
+    {{ column_filters[filter_name]["display_name"] }}</option>
+{% endfor %}
+{% endset %}
 
 <div class="wrapper">
-    <label for="col-filter-select">Show: </label>
-    <select id="col-filter-select" class="col-filter-select"
-        onchange='getReport(event).onFilterChange()'
-        data-report-id="{{ report_id }}" autocomplete="off">
-        {% for filter_name in column_filters %}
-        <option value="{{ filter_name }}" {{ "selected" if filter_name == "all()" }}>
-            {{ column_filters[filter_name]["display_name"] }}</option>
-        {% endfor %}
-    </select>
+    <div class="if-else" data-predicate="true" id="col-filter-select-enable">
+        <div>
+            <label for="col-filter-select">Show: </label>
+            <select id="col-filter-select" class="col-filter-select"
+                    onchange='getReport(event).onFilterChange()'
+                    data-report-id="{{ report_id }}" autocomplete="off">
+                {{ options }}
+            </select>
+        </div>
+        <div>
+            <label for="col-filter-select-fake">Show: </label>
+            <select disabled
+                    id="col-filter-select-fake"
+                    title="Column similarities cannot be filtered. All of them are shown.">
+                {{ options }}
+            </select>
+        </div>
+    </div>
 </div>

--- a/skrub/_reporting/_data/templates/skrub-report.js
+++ b/skrub/_reporting/_data/templates/skrub-report.js
@@ -84,6 +84,8 @@ if (customElements.get('skrub-table-report') === undefined) {
             if (removeWarnings && tabButton.hasAttribute("data-has-warning")) {
                 tabButton.removeAttribute("data-has-warning");
             }
+            const toggle =  this.shadowRoot.getElementById("col-filter-select-enable");
+            toggle.dataset.predicate = tab.id === "interactions-tab" ? "false": "true";
         }
 
         displayValue(event) {


### PR DESCRIPTION
alternative to #1009 as suggested in [comment](https://github.com/skrub-data/skrub/pull/1009#issuecomment-2247015741)  (at least IIUC): disable the column filter menu when in the similarities tab