### PR TITLE
hide column filter selector when in associations tab

### DIFF
--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -105,6 +105,9 @@ dd {
 /* Generic utility classes */
 /* ----------------------- */
 
+[data-not-visible] {
+    visibility: hidden;
+}
 
 .margin-r-s {
     margin-inline-end: var(--small);

--- a/skrub/_reporting/_data/templates/column-filters.html
+++ b/skrub/_reporting/_data/templates/column-filters.html
@@ -1,5 +1,5 @@
 
-<div class="wrapper">
+<div class="wrapper" id="col-filter-select-wrapper">
     <label for="col-filter-select">Show: </label>
     <select id="col-filter-select" class="col-filter-select"
         onchange='getReport(event).onFilterChange()'

--- a/skrub/_reporting/_data/templates/skrub-report.js
+++ b/skrub/_reporting/_data/templates/skrub-report.js
@@ -84,6 +84,12 @@ if (customElements.get('skrub-table-report') === undefined) {
             if (removeWarnings && tabButton.hasAttribute("data-has-warning")) {
                 tabButton.removeAttribute("data-has-warning");
             }
+            const filterSelect = this.shadowRoot.getElementById("col-filter-select-wrapper");
+            if (tab.id === "interactions-tab"){
+                filterSelect.dataset.notVisible = "";
+            } else {
+                delete filterSelect.dataset.notVisible;
+            }
         }
 
         displayValue(event) {

--- a/skrub/_reporting/js_tests/cypress/e2e/column-filters.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/column-filters.cy.js
@@ -10,4 +10,17 @@ describe ('test filtering visible columns', () => {
         cy.get('@report').find('#col_7').should('not.be.visible');
         cy.get('@report').find('#col_0').should('be.visible');
     });
+
+    it('only shows the select input in columns and sample tabs', () => {
+        cy.visit('_reports/employee_salaries.html');
+        cy.get('skrub-table-report').shadow().as('report');
+        cy.get('@report').find('#col-filter-select').as('select');
+        cy.get('@select').should('be.visible');
+        cy.get('@report').find('button[data-target-tab="columns-tab"]').click();
+        cy.get('@select').should('be.visible');
+        cy.get('@report').find('button[data-target-tab="interactions-tab"]').click();
+        cy.get('@select').should('not.be.visible');
+        cy.get('@report').find('button[data-target-tab="columns-tab"]').click();
+        cy.get('@select').should('be.visible');
+    });
 });


### PR DESCRIPTION
variant of #1010 : hide the select altogether instead of disabling it