### PR TITLE
use browser default style for focus-visible

### DIFF
--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -46,6 +46,14 @@
     overflow: hidden;
 }
 
+/* pure.css / Normalize.css overrides the default firefox blue ring around focussed */
+/* elements with something almost impossible to see, making it impossible to use */
+/* tab navigation. We revert it to the browser's appropriate default. */
+:focus-visible {
+    outline: revert !important;
+}
+
+
 :is(select, summary, button) {
     cursor: pointer;
 }


### PR DESCRIPTION
in the report we include the copy of normalize.css distributed with pure which provides some baseline default styling and makes stuff more similar across browsers.

one problem with it is it hides the browser's default highlighting of the element that has keyboard focus, this PR removes that rule