### PR TITLE
ensure aggjoiner & aggtarget have consistent output names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Major changes
 
 Minor changes
 -------------
+* :class:`AggJoiner` and :class:`AggTarget` could produce outputs whose column
+  names varied across calls to `transform` in some cases in the presence of
+  duplicate column names, now the output names are always the same.
+  :pr:`1013` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Release 0.2.0
 =============

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -11,10 +11,13 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import check_is_fitted
 
+from skrub import _dataframe as sbd
 from skrub import _join_utils
 from skrub._dataframe._namespace import get_df_namespace, is_pandas, is_polars
 from skrub._dataframe._pandas import _parse_argument
 from skrub._utils import atleast_1d_or_none
+
+from ._check_input import CheckInputDataFrame
 
 NUM_OPERATIONS = ["sum", "mean", "std", "min", "max", "hist", "value_counts"]
 CATEG_OPERATIONS = ["mode", "count", "value_counts"]
@@ -244,6 +247,44 @@ class AggJoiner(TransformerMixin, BaseEstimator):
         if not isinstance(self.suffix, str):
             raise ValueError(f"'suffix' must be a string. Got {self.suffix}")
 
+    def fit_transform(self, X, y=None):
+        """Aggregate auxiliary table based on the main keys.
+
+        Parameters
+        ----------
+        X : DataFrameLike
+            Input data, based table on which to left join the
+            auxiliary table.
+        y : None
+            Unused, only here for compatibility.
+
+        Returns
+        -------
+        DataFrame
+            The augmented input.
+        """
+        self._check_inputs(X)
+        self._main_check_input = CheckInputDataFrame()
+        X = self._main_check_input.fit_transform(X)
+
+        skrub_px, _ = get_df_namespace(self._aux_table)
+        self.aux_table_ = skrub_px.aggregate(
+            self._aux_table,
+            self._aux_key,
+            self._cols,
+            self.num_operations,
+            self.categ_operations,
+            suffix=self.suffix,
+        )
+        result = _join_utils.left_join(
+            X,
+            right=self.aux_table_,
+            left_on=self._main_key,
+            right_on=self._aux_key,
+        )
+        self.all_outputs_ = sbd.column_names(result)
+        return result
+
     def fit(self, X, y=None):
         """Aggregate auxiliary table based on the main keys.
 
@@ -260,16 +301,7 @@ class AggJoiner(TransformerMixin, BaseEstimator):
         AggJoiner
             Fitted :class:`AggJoiner` instance (self).
         """
-        self._check_inputs(X)
-        skrub_px, _ = get_df_namespace(self._aux_table)
-        self.aux_table_ = skrub_px.aggregate(
-            self._aux_table,
-            self._aux_key,
-            self._cols,
-            self.num_operations,
-            self.categ_operations,
-            suffix=self.suffix,
-        )
+        _ = self.fit_transform(X, y)
         return self
 
     def transform(self, X):
@@ -287,16 +319,17 @@ class AggJoiner(TransformerMixin, BaseEstimator):
         """
         check_is_fitted(self, "aux_table_")
         X, _ = self._check_dataframes(X, self.aux_table_)
-        _join_utils.check_missing_columns(X, self._main_key, "'X' (the main table)")
+        X = self._main_check_input.transform(X)
 
-        X = _join_utils.left_join(
+        result = _join_utils.left_join(
             X,
             right=self.aux_table_,
             left_on=self._main_key,
             right_on=self._aux_key,
         )
 
-        return X
+        result = sbd.set_column_names(result, self.all_outputs_)
+        return result
 
 
 class AggTarget(TransformerMixin, BaseEstimator):
@@ -379,6 +412,60 @@ class AggTarget(TransformerMixin, BaseEstimator):
         self.operation = operation
         self.suffix = suffix
 
+    def fit_transform(self, X, y):
+        """Aggregate the target ``y`` based on keys from ``X``.
+
+        Parameters
+        ----------
+        X : DataFrameLike
+            Must contains the columns names defined in `main_key`.
+
+        y : DataFrameLike or SeriesLike or ArrayLike
+            `y` length must match `X` length, with matching indices.
+            The target can be continuous or discrete, with multiple columns.
+
+            If the target is continuous, only numerical operations,
+            listed in `num_operations`, can be applied.
+
+            If the target is discrete, only categorical operations,
+            listed in `categ_operations`, can be applied.
+
+            Note that the target type is determined by
+            :func:`sklearn.utils.multiclass.type_of_target`.
+
+        Returns
+        -------
+        Dataframe
+            The augmented input.
+        """
+        y_ = self.check_inputs(X, y)
+        self._main_check_input = CheckInputDataFrame()
+        X = self._main_check_input.fit_transform(X)
+        skrub_px, _ = get_df_namespace(X, y_)
+
+        # Add the main key on the target
+        y_[self.main_key_] = X[self.main_key_]
+
+        num_operations, categ_operations = split_num_categ_operations(self.operation_)
+
+        self.y_ = skrub_px.aggregate(
+            y_,
+            key=self.main_key_,
+            cols_to_agg=self.cols_,
+            num_operations=num_operations,
+            categ_operations=categ_operations,
+            suffix=self.suffix_,
+        )
+
+        result = _join_utils.left_join(
+            X,
+            right=self.y_,
+            left_on=self.main_key_,
+            right_on=self.main_key_,
+        )
+        self.all_outputs_ = sbd.column_names(result)
+        return result
+
     def fit(self, X, y):
         """Aggregate the target ``y`` based on keys from ``X``.
 
@@ -405,23 +492,7 @@ class AggTarget(TransformerMixin, BaseEstimator):
         AggTarget
             Fitted :class:`AggTarget` instance (self).
         """
-        y_ = self.check_inputs(X, y)
-        skrub_px, _ = get_df_namespace(X, y_)
-
-        # Add the main key on the target
-        y_[self.main_key_] = X[self.main_key_]
-
-        num_operations, categ_operations = split_num_categ_operations(self.operation_)
-
-        self.y_ = skrub_px.aggregate(
-            y_,
-            key=self.main_key_,
-            cols_to_agg=self.cols_,
-            num_operations=num_operations,
-            categ_operations=categ_operations,
-            suffix=self.suffix_,
-        )
-
+        _ = self.fit_transform(X, y)
         return self
 
     def transform(self, X):
@@ -438,13 +509,16 @@ class AggTarget(TransformerMixin, BaseEstimator):
             The augmented input.
         """
         check_is_fitted(self, "y_")
+        X = self._main_check_input.transform(X)
 
-        return _join_utils.left_join(
+        result = _join_utils.left_join(
             X,
             right=self.y_,
             left_on=self.main_key_,
             right_on=self.main_key_,
         )
+        result = sbd.set_column_names(result, self.all_outputs_)
+        return result
 
     def check_inputs(self, X, y):
         """Perform a check on column names data type and suffixes.

--- a/skrub/_multi_agg_joiner.py
+++ b/skrub/_multi_agg_joiner.py
@@ -4,7 +4,6 @@ The MultiAggJoiner extends AggJoiner to multiple auxiliary tables.
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
-from skrub import _join_utils
 from skrub._agg_joiner import AggJoiner
 from skrub._dataframe._namespace import is_pandas, is_polars
 from skrub._utils import _is_array_like
@@ -440,7 +439,7 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
                 )
         return suffixes
 
-    def fit(self, X, y=None):
+    def fit_transform(self, X, y=None):
         """Aggregate auxiliary tables based on the main keys.
 
         Parameters
@@ -453,8 +452,8 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        MultiAggJoiner
-            Fitted :class:`MultiAggJoiner` instance (self).
+        DataFrame
+            The augmented input.
         """
         X, self._aux_tables = self._check_dataframes(X, self.aux_tables)
         self._main_keys, self._aux_keys = self._check_keys(
@@ -484,6 +483,25 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
             X = agg_joiner.fit_transform(X)
             self.agg_joiners_.append(agg_joiner)
 
+        return X
+
+    def fit(self, X, y=None):
+        """Aggregate auxiliary tables based on the main keys.
+
+        Parameters
+        ----------
+        X : DataFrameLike
+            Input data, based table on which to left join the
+            auxiliary tables.
+        y : None
+            Unused, only here for compatibility.
+
+        Returns
+        -------
+        MultiAggJoiner
+            Fitted :class:`MultiAggJoiner` instance (self).
+        """
+        _ = self.fit_transform(X, y)
         return self
 
     def transform(self, X):
@@ -500,11 +518,6 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
             The augmented input.
         """
         check_is_fitted(self, "agg_joiners_")
-        X, _ = self._check_dataframes(X, self._aux_tables)
-        for main_key in self._main_keys:
-            _join_utils.check_missing_columns(X, main_key, "'X' (the main table)")
-
         for agg_joiner in self.agg_joiners_:
             X = agg_joiner.transform(X)
-
         return X

--- a/skrub/_multi_agg_joiner.py
+++ b/skrub/_multi_agg_joiner.py
@@ -481,7 +481,7 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
                 operations=operations,
                 suffix=suffix,
             )
-            agg_joiner.fit(X)
+            X = agg_joiner.fit_transform(X)
             self.agg_joiners_.append(agg_joiner)
 
         return self

--- a/skrub/tests/test_agg_joiner.py
+++ b/skrub/tests/test_agg_joiner.py
@@ -369,7 +369,7 @@ def test_not_fitted_dataframe(df_module, main_table):
         key="userId",
     )
     agg_joiner.fit(main_table)
-    error_msg = r"(?=.*columns cannot be used because they do not exist)"
+    error_msg = r"Columns of dataframes passed to fit\(\) and transform\(\) differ"
     with pytest.raises(ValueError, match=error_msg):
         agg_joiner.transform(not_main_table)
 
@@ -458,3 +458,20 @@ def test_wrong_args_ops(main_table):
     )
     with pytest.raises(ValueError, match=r"(?=.*'mean')(?=.*argument)"):
         agg_target.fit(main_table, y)
+
+
+def test_duplicate_columns(main_table):
+    joiner = AggJoiner(aux_table=main_table, key="userId")
+    X = sbd.with_columns(main_table, rating_mean=sbd.col(main_table, "rating"))
+    out_1 = joiner.fit_transform(X)
+    out_2 = joiner.transform(X)
+    assert sbd.column_names(out_1) == sbd.column_names(out_2)
+
+
+def test_duplicate_columns_target(main_table):
+    joiner = AggTarget(main_key="userId", operation="mean")
+    y = sbd.col(main_table, "rating")
+    X = sbd.with_columns(main_table, rating_mean_target=sbd.col(main_table, "rating"))
+    out_1 = joiner.fit_transform(X, y)
+    out_2 = joiner.transform(X)
+    assert sbd.column_names(out_1) == sbd.column_names(out_2)

--- a/skrub/tests/test_multi_agg_joiner.py
+++ b/skrub/tests/test_multi_agg_joiner.py
@@ -600,6 +600,6 @@ def test_not_fitted_dataframe(main_table, df_module):
         keys=[["userId"]],
     )
     multi_agg_joiner.fit(main_table)
-    error_msg = r"(?=.*columns cannot be used because they do not exist)"
+    error_msg = r"Columns of dataframes passed to fit\(\) and transform\(\) differ"
     with pytest.raises(ValueError, match=error_msg):
         multi_agg_joiner.transform(not_main)


### PR DESCRIPTION
Fixes #1005 

this ensures that AggJoiner and AggTarget outputs always have the same names even in the presence of duplicated column names in the inputs