### PR TITLE
Allow duplicate column names in Joiner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Major changes
 
 Minor changes
 -------------
+* :class:`Joiner` and :func:`fuzzy_join` used to raise an error when columns
+  with the same name appeared in the main and auxiliary table (after adding the
+  suffix). This is now allowed and a random string is inserted in the duplicate
+  column to ensure all names are unique.
+  :pr:`1014` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Release 0.2.0
 =============

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -196,9 +196,6 @@ def fuzzy_join(
     )
     _join_utils.check_missing_columns(left, left_key, "'left' (the left table)")
     _join_utils.check_missing_columns(right, right_key, "'right' (the right table)")
-    _join_utils.check_column_name_duplicates(
-        left, right, suffix, main_table_name="left", aux_table_name="right"
-    )
 
     join = Joiner(
         aux_table=right,

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -99,54 +99,6 @@ def check_missing_columns(table, key, table_name):
     )
 
 
-def check_column_name_duplicates(
-    main_table,
-    aux_table,
-    suffix,
-    main_table_name="main_table",
-    aux_table_name="aux_table",
-):
-    """Check that there are no duplicate column names after applying a suffix.
-
-    The suffix is applied to (a copy of) `aux_columns` before checking for
-    duplicates.
-
-    Parameters
-    ----------
-    main_table : dataframe
-        The main table to join.
-    aux_table : dataframe
-        The auxiliary table to join.
-    suffix : str
-        The suffix that was provided by the user and will be appended to the
-        auxiliary column names.
-    main_table_name : str
-        How to refer to ``main_table`` in error messages.
-    aux_table_name : str
-        How to refer to ``aux_table`` in error messages.
-    Raises
-    ------
-    ValueError
-        If any of the table has duplicate column names, or if there are column
-        names that are used in both tables.
-    """
-    main_columns = list(main_table.columns)
-    aux_columns = [f"{col}{suffix}" for col in aux_table.columns]
-    for columns, table_name in [
-        (main_columns, main_table_name),
-        (aux_columns, aux_table_name),
-    ]:
-        _utils.check_duplicated_column_names(columns, table_name=table_name)
-    overlap = list(set(main_columns).intersection(aux_columns))
-    if overlap:
-        raise ValueError(
-            f"After applying the suffix {suffix!r} to column names, the following"
-            f" column names are found in both tables '{main_table_name}' and"
-            f" '{aux_table_name}': {overlap}. Please make sure column names do not"
-            " overlap by renaming some columns or choosing a different suffix."
-        )
-
-
 def add_column_name_suffix(dataframe, suffix):
     ns, _ = get_df_namespace(dataframe)
     return ns.rename_columns(dataframe, f"{{}}{suffix}".format)

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -282,6 +282,45 @@ class Joiner(TransformerMixin, BaseEstimator):
             )
         self._matching = _MATCHERS[self.ref_dist]()
 
+    def fit_transform(self, X, y=None):
+        """Fit the instance to the main table.
+
+        Parameters
+        ----------
+        X : dataframe
+            The main table, to be joined to the auxiliary ones.
+        y : None
+            Unused, only here for compatibility.
+
+        Returns
+        -------
+        dataframe
+            The final joined table.
+        """
+        self._aux_table = CheckInputDataFrame().fit_transform(self.aux_table)
+        self._main_check_input = CheckInputDataFrame()
+        X = self._main_check_input.fit_transform(X)
+        self._check_ref_dist()
+        self._check_max_dist()
+        self._main_key, self._aux_key = _join_utils.check_key(
+            self.main_key, self.aux_key, self.key
+        )
+        _join_utils.check_missing_columns(X, self._main_key, "'X' (the main table)")
+        _join_utils.check_missing_columns(self._aux_table, self._aux_key, "'aux_table'")
+        self._right_cols_renaming = f"{{}}{self.suffix}".format
+        self.vectorizer_ = _make_vectorizer(
+            s.select(self._aux_table, s.cols(*self._aux_key)),
+            self.string_encoder,
+            rescale=self.ref_dist != "no_rescaling",
+        )
+        aux = self.vectorizer_.fit_transform(
+            _compat_df(s.select(self._aux_table, s.cols(*self._aux_key)))
+        )
+        self._matching.fit(aux)
+        result = self._transform(X, y)
+        self.all_outputs_ = sbd.column_names(result)
+        return result
+
     def fit(self, X, y=None):
         """Fit the instance to the main table.
 
@@ -297,30 +336,7 @@ class Joiner(TransformerMixin, BaseEstimator):
         Joiner
             Fitted Joiner instance (self).
         """
-        del y
-        self._aux_table = CheckInputDataFrame().fit_transform(self.aux_table)
-        self._main_check_input = CheckInputDataFrame()
-        X = self._main_check_input.fit_transform(X)
-        self._check_ref_dist()
-        self._check_max_dist()
-        self._main_key, self._aux_key = _join_utils.check_key(
-            self.main_key, self.aux_key, self.key
-        )
-        _join_utils.check_missing_columns(X, self._main_key, "'X' (the main table)")
-        _join_utils.check_missing_columns(self._aux_table, self._aux_key, "'aux_table'")
-        _join_utils.check_column_name_duplicates(
-            X, self._aux_table, self.suffix, main_table_name="X"
-        )
-        self._right_cols_renaming = f"{{}}{self.suffix}".format
-        self.vectorizer_ = _make_vectorizer(
-            s.select(self._aux_table, s.cols(*self._aux_key)),
-            self.string_encoder,
-            rescale=self.ref_dist != "no_rescaling",
-        )
-        aux = self.vectorizer_.fit_transform(
-            _compat_df(s.select(self._aux_table, s.cols(*self._aux_key)))
-        )
-        self._matching.fit(aux)
+        _ = self.fit_transform(X, y)
         return self
 
     def transform(self, X, y=None):
@@ -338,13 +354,12 @@ class Joiner(TransformerMixin, BaseEstimator):
         dataframe
             The final joined table.
         """
-        del y
         check_is_fitted(self, "vectorizer_")
         X = self._main_check_input.transform(X)
-        _join_utils.check_missing_columns(X, self._main_key, "'X' (the main table)")
-        _join_utils.check_column_name_duplicates(
-            X, self._aux_table, self.suffix, main_table_name="X"
-        )
+        result = self._transform(X)
+        return sbd.set_column_names(result, self.all_outputs_)
+
+    def _transform(self, X, y=None):
         main = sbd.set_column_names(s.select(X, s.cols(*self._main_key)), self._aux_key)
         main = self.vectorizer_.transform(_compat_df(main))
         match_result = self._matching.match(main, self.max_dist_)

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -294,7 +294,7 @@ class Joiner(TransformerMixin, BaseEstimator):
 
         Returns
         -------
-        dataframe
+        DataFrame
             The final joined table.
         """
         self._aux_table = CheckInputDataFrame().fit_transform(self.aux_table)
@@ -326,7 +326,7 @@ class Joiner(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        X : dataframe
+        X : DataFrame
             The main table, to be joined to the auxiliary ones.
         y : None
             Unused, only here for compatibility.
@@ -334,7 +334,7 @@ class Joiner(TransformerMixin, BaseEstimator):
         Returns
         -------
         Joiner
-            Fitted Joiner instance (self).
+            Fitted :class:`Joiner`instance (self).
         """
         _ = self.fit_transform(X, y)
         return self

--- a/skrub/tests/test_join_utils.py
+++ b/skrub/tests/test_join_utils.py
@@ -48,25 +48,6 @@ def test_check_key_length_mismatch():
         )
 
 
-def test_check_no_column_name_duplicates_with_no_suffix(df_module):
-    left = df_module.make_dataframe({"A": [], "B": []})
-    right = df_module.make_dataframe({"C": []})
-    _join_utils.check_column_name_duplicates(left, right, "")
-
-
-def test_check_no_column_name_duplicates_after_adding_a_suffix(df_module):
-    left = df_module.make_dataframe({"A": [], "B": []})
-    right = df_module.make_dataframe({"B": []})
-    _join_utils.check_column_name_duplicates(left, right, "_right")
-
-
-def test_check_column_name_duplicates_after_adding_a_suffix(df_module):
-    left = df_module.make_dataframe({"A": [], "B_right": []})
-    right = df_module.make_dataframe({"B": []})
-    with pytest.raises(ValueError, match=".*suffix '_right'.*['B_right']"):
-        _join_utils.check_column_name_duplicates(left, right, "_right")
-
-
 def test_add_column_name_suffix(df_module):
     df = df_module.make_dataframe({"one": [], "two three": [], "x": []})
     df = _join_utils.add_column_name_suffix(df, "")

--- a/skrub/tests/test_joiner.py
+++ b/skrub/tests/test_joiner.py
@@ -164,3 +164,10 @@ def test_preprocessing(df_module):
     )
     out = Joiner(df2, key="date", suffix="_", add_match_info=False).fit_transform(df1)
     assert ns.to_list(ns.col(out, "v_")) == ["A"]
+
+
+def test_duplicate_names(df_module):
+    joiner = Joiner(df_module.example_dataframe, key="int-not-null-col")
+    out_1 = joiner.fit_transform(df_module.example_dataframe)
+    out_2 = joiner.transform(df_module.example_dataframe)
+    assert ns.column_names(out_1) == ns.column_names(out_2)


### PR DESCRIPTION
random (but consistent across calls to transform) strings are inserted in duplicate names to avoid errors.
This is to be consistent with the AggJoiner and AggTarget