### PR TITLE
ENH polars support for InterpolationJoiner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ It is currently undergoing fast development and backward compatibility is not en
 
 Major changes
 -------------
+* The :class:`InterpolationJoiner` now supports polars dataframes. :pr:`1016`
+  by :user:`Théo Jolivet <TheooJ>`.
 * The :class:`TableReport` provides an interactive report on a dataframe's
   contents: an overview, summary statistics and plots, statistical associations
   between columns. It can be displayed in a jupyter notebook, a browser tab or

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -301,7 +301,7 @@ def _all_null_like_pandas(col, length=None, dtype=None, name=None):
         dtype = col.dtype
     if name is None:
         name = col.name
-    return pd.Series(dtype=dtype, index=col.index, name=name).head(length)
+    return pd.Series(dtype=dtype, index=np.arange(length), name=name)
 
 
 @all_null_like.specialize("polars", argument_type="Column")

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -7,6 +7,8 @@ import pandas as pd
 import pandas.api.types
 from sklearn.utils.fixes import parse_version
 
+from skrub import _join_utils
+
 try:
     import polars as pl
 except ImportError:
@@ -321,11 +323,13 @@ def concat_horizontal(*dataframes):
 @concat_horizontal.specialize("pandas")
 def _concat_horizontal_pandas(*dataframes):
     dataframes = [df.reset_index(drop=True) for df in dataframes]
+    dataframes = _join_utils.make_column_names_unique(dataframes)
     return pd.concat(dataframes, axis=1, copy=False)
 
 
 @concat_horizontal.specialize("polars")
 def _concat_horizontal_polars(*dataframes):
+    dataframes = _join_utils.make_column_names_unique(dataframes)
     return pl.concat(dataframes, how="horizontal")
 
 

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -320,12 +320,36 @@ def concat_horizontal(*dataframes):
 
 @concat_horizontal.specialize("pandas")
 def _concat_horizontal_pandas(*dataframes):
+    parsed_names = set()
+    overlap = set()
+    for df in dataframes:
+        col_names = set(column_names(df))
+        overlap.update(parsed_names.intersection(col_names))
+        parsed_names.update(col_names)
+    if overlap:
+        raise ValueError(
+            "Can't concatenate dataframes containing duplicate column names."
+            f" The following column names are found in multiple tables: {overlap}."
+            " Please make sure column names do not overlap before concatenating them."
+        )
     dataframes = [df.reset_index(drop=True) for df in dataframes]
     return pd.concat(dataframes, axis=1, copy=False)
 
 
 @concat_horizontal.specialize("polars")
 def _concat_horizontal_polars(*dataframes):
+    parsed_names = set()
+    overlap = set()
+    for df in dataframes:
+        col_names = set(column_names(df))
+        overlap.update(parsed_names.intersection(col_names))
+        parsed_names.update(col_names)
+    if overlap:
+        raise ValueError(
+            "Can't concatenate dataframes containing duplicate column names."
+            f" The following column names are found in multiple tables: {overlap}."
+            " Please make sure column names do not overlap before concatenating them."
+        )
     return pl.concat(dataframes, how="horizontal")
 
 

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -323,13 +323,13 @@ def concat_horizontal(*dataframes):
 @concat_horizontal.specialize("pandas")
 def _concat_horizontal_pandas(*dataframes):
     dataframes = [df.reset_index(drop=True) for df in dataframes]
-    dataframes = _join_utils.make_column_names_unique(dataframes)
+    dataframes = _join_utils.make_column_names_unique(*dataframes)
     return pd.concat(dataframes, axis=1, copy=False)
 
 
 @concat_horizontal.specialize("polars")
 def _concat_horizontal_polars(*dataframes):
-    dataframes = _join_utils.make_column_names_unique(dataframes)
+    dataframes = _join_utils.make_column_names_unique(*dataframes)
     return pl.concat(dataframes, how="horizontal")
 
 

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -320,36 +320,12 @@ def concat_horizontal(*dataframes):
 
 @concat_horizontal.specialize("pandas")
 def _concat_horizontal_pandas(*dataframes):
-    parsed_names = set()
-    overlap = set()
-    for df in dataframes:
-        col_names = set(column_names(df))
-        overlap.update(parsed_names.intersection(col_names))
-        parsed_names.update(col_names)
-    if overlap:
-        raise ValueError(
-            "Can't concatenate dataframes containing duplicate column names."
-            f" The following column names are found in multiple tables: {overlap}."
-            " Please make sure column names do not overlap before concatenating them."
-        )
     dataframes = [df.reset_index(drop=True) for df in dataframes]
     return pd.concat(dataframes, axis=1, copy=False)
 
 
 @concat_horizontal.specialize("polars")
 def _concat_horizontal_polars(*dataframes):
-    parsed_names = set()
-    overlap = set()
-    for df in dataframes:
-        col_names = set(column_names(df))
-        overlap.update(parsed_names.intersection(col_names))
-        parsed_names.update(col_names)
-    if overlap:
-        raise ValueError(
-            "Can't concatenate dataframes containing duplicate column names."
-            f" The following column names are found in multiple tables: {overlap}."
-            " Please make sure column names do not overlap before concatenating them."
-        )
     return pl.concat(dataframes, how="horizontal")
 
 

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -322,9 +322,12 @@ def concat_horizontal(*dataframes):
 
 @concat_horizontal.specialize("pandas")
 def _concat_horizontal_pandas(*dataframes):
+    init_index = dataframes[0].index
     dataframes = [df.reset_index(drop=True) for df in dataframes]
     dataframes = _join_utils.make_column_names_unique(*dataframes)
-    return pd.concat(dataframes, axis=1, copy=False)
+    result = pd.concat(dataframes, axis=1, copy=False)
+    result.index = init_index
+    return result
 
 
 @concat_horizontal.specialize("polars")

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -301,7 +301,7 @@ def _all_null_like_pandas(col, length=None, dtype=None, name=None):
         dtype = col.dtype
     if name is None:
         name = col.name
-    return pd.Series(dtype=dtype, index=col.index, name=name)
+    return pd.Series(dtype=dtype, index=col.index, name=name).head(length)
 
 
 @all_null_like.specialize("polars", argument_type="Column")

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -167,10 +167,20 @@ def test_all_null_like(df_module):
 
 
 def test_concat_horizontal(df_module, example_data_dict):
-    df1 = df_module.make_dataframe(example_data_dict)
+    df1 = df_module.example_dataframe
     df2 = ns.set_column_names(df1, list(map("{}1".format, ns.column_names(df1))))
     df = ns.concat_horizontal(df1, df2)
     assert ns.column_names(df) == ns.column_names(df1) + ns.column_names(df2)
+
+    df2 = df_module.make_dataframe({"int-col": example_data_dict["int-col"]})
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"(Can't concatenate dataframes containing duplicate column names.)"
+            r".*({'int-col'})"
+        ),
+    ):
+        df = ns.concat_horizontal(df1, df2)
 
 
 def test_is_column_list(df_module):

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -4,6 +4,7 @@ in ``skrub.conftest``. See the corresponding docstrings for details.
 """
 
 import inspect
+import re
 import warnings
 from datetime import datetime
 from functools import partial
@@ -179,6 +180,13 @@ def test_concat_horizontal(df_module, example_data_dict):
     df2 = ns.set_column_names(df1, list(map("{}1".format, ns.column_names(df1))))
     df = ns.concat_horizontal(df1, df2)
     assert ns.column_names(df) == ns.column_names(df1) + ns.column_names(df2)
+
+    # Test concatenating dataframes with the same column names
+    df2 = df1
+    df = ns.concat_horizontal(df1, df2)
+    assert ns.shape(df) == (4, 16)
+    for n in ns.column_names(df)[8:]:
+        assert re.match(r".*__skrub_[0-9a-f]+__", n)
 
 
 def test_is_column_list(df_module):

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -188,6 +188,15 @@ def test_concat_horizontal(df_module, example_data_dict):
     for n in ns.column_names(df)[8:]:
         assert re.match(r".*__skrub_[0-9a-f]+__", n)
 
+    # Test concatenating pandas dataframes with different indexes (of same length)
+    if df_module.name == "pandas":
+        df1 = df_module.DataFrame(data=[1.0, 2.0], columns=["a"], index=[10, 20])
+        df2 = df_module.DataFrame(data=[3.0, 4.0], columns=["b"], index=[1, 2])
+        df = ns.concat_horizontal(df1, df2)
+        assert ns.shape(df) == (2, 2)
+        # Index of the first dataframe is kept
+        assert_array_equal(df.index, [10, 20])
+
 
 def test_is_column_list(df_module):
     assert ns.is_column_list([])

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -167,20 +167,10 @@ def test_all_null_like(df_module):
 
 
 def test_concat_horizontal(df_module, example_data_dict):
-    df1 = df_module.example_dataframe
+    df1 = df_module.make_dataframe(example_data_dict)
     df2 = ns.set_column_names(df1, list(map("{}1".format, ns.column_names(df1))))
     df = ns.concat_horizontal(df1, df2)
     assert ns.column_names(df) == ns.column_names(df1) + ns.column_names(df2)
-
-    df2 = df_module.make_dataframe({"int-col": example_data_dict["int-col"]})
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"(Can't concatenate dataframes containing duplicate column names.)"
-            r".*({'int-col'})"
-        ),
-    ):
-        df = ns.concat_horizontal(df1, df2)
 
 
 def test_is_column_list(df_module):

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -168,6 +168,11 @@ def test_all_null_like(df_module):
     col = ns.all_null_like(df_module.example_column, length=2)
     assert ns.shape(col)[0] == 2
 
+    # Test can set length greater than column length
+    max_len = ns.shape(df_module.example_column)[0]
+    col = ns.all_null_like(df_module.example_column, length=max_len + 2)
+    assert ns.shape(col)[0] == (max_len + 2)
+
 
 def test_concat_horizontal(df_module, example_data_dict):
     df1 = df_module.make_dataframe(example_data_dict)

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -165,6 +165,9 @@ def test_all_null_like(df_module):
         expected = expected.astype("bool")
     df_module.assert_column_equal(ns.is_null(col), expected)
 
+    col = ns.all_null_like(df_module.example_column, length=2)
+    assert ns.shape(col)[0] == 2
+
 
 def test_concat_horizontal(df_module, example_data_dict):
     df1 = df_module.make_dataframe(example_data_dict)

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -291,9 +291,7 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
             main_table, self._main_key, "'X' (the main table)"
         )
         key_values = self.vectorizer_.transform(
-            sbd.set_column_names(
-                s.select(main_table, s.cols(*self._main_key)), self._aux_key
-            )
+            sbd.set_column_names(s.select(main_table, s.cols(*self._main_key)), self._aux_key)
         )
         prediction_results = joblib.Parallel(self.n_jobs)(
             joblib.delayed(_predict)(

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -317,7 +317,6 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
         failed_columns = []
         for res in results:
             new_res = dict(**res)
-            breakpoint()
             if res["failed"]:
                 _pred = [
                     sbd.all_null_like(

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -323,6 +323,7 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
                     dtype = float
                 else:
                     dtype = object
+                print({col: [None] * res["shape"][0] for col in res["columns"]})
                 pred = sbd.make_dataframe_like(
                     self.aux_table,
                     {col: [None] * res["shape"][0] for col in res["columns"]},
@@ -419,8 +420,10 @@ def _fit(key_values, target_table, estimator, propagate_exceptions):
     null_values = [sbd.is_null(col) for col in sbd.to_column_list(target_table)]
     discarded_rows = np.array(null_values).any(axis=0)
     key_values = sbd.filter(key_values, ~discarded_rows)
-    # TODO: dispatch
-    Y = target_table.to_numpy()[~discarded_rows]
+    Y = np.concatenate(
+        [sbd.to_numpy(col).reshape(-1, 1) for col in sbd.to_column_list(target_table)],
+        axis=1,
+    )[~discarded_rows]
 
     # Estimators that expect a single output issue a DataConversionWarning if
     # passing a column vector rather than a 1-D array

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -452,7 +452,7 @@ def _predict(main_table, key_values, columns, estimator, propagate_exceptions):
             Y_values = Y_values.T
             data = dict(zip(columns, Y_values))
         else:
-            data = {columns[0]: Y_values}
+            data = {columns[0]: Y_values.ravel()}
         predictions = sbd.make_dataframe_like(main_table, data)
     return {
         "predictions": predictions,

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -418,7 +418,7 @@ def _fit(key_values, target_table, estimator, propagate_exceptions):
 
     # Estimators that expect a single output issue a DataConversionWarning if
     # passing a column vector rather than a 1-D array
-    if len(sbd.column_names(target_table)) == 1:
+    if sbd.shape(target_table)[1] == 1:
         Y = Y.ravel()
     failed = False
     try:
@@ -449,7 +449,7 @@ def _predict(main_table, key_values, columns, estimator, propagate_exceptions):
         # If more than one prediction, need to set predictions as columns
         # in order to create the dataframe
         if len(columns) > 1:
-            Y_values = np.swapaxes(Y_values, 0, 1)
+            Y_values = Y_values.T
             data = dict(zip(columns, Y_values))
         else:
             data = {columns[0]: Y_values}

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -225,13 +225,13 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
         if X is not None:
             _join_utils.check_missing_columns(X, self._main_key, "'X' (the main table)")
         key_values = self.vectorizer_.fit_transform(
-            sbd.col(self.aux_table, self._aux_key)
+            s.select(self.aux_table, s.cols(*self._aux_key))
         )
         estimators = self._get_estimator_assignments()
         fit_results = joblib.Parallel(self.n_jobs)(
             joblib.delayed(_fit)(
                 key_values,
-                sbd.col(self.aux_table, assignment["columns"]),
+                s.select(self.aux_table, s.cols(*assignment["columns"])),
                 assignment["estimator"],
                 propagate_exceptions=(self.on_estimator_failure == "raise"),
             )
@@ -291,7 +291,9 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
             main_table, self._main_key, "'X' (the main table)"
         )
         key_values = self.vectorizer_.transform(
-            sbd.set_column_names(sbd.col(main_table, self._main_key), self._aux_key)
+            sbd.set_column_names(
+                s.select(main_table, s.cols(*self._main_key)), self._aux_key
+            )
         )
         prediction_results = joblib.Parallel(self.n_jobs)(
             joblib.delayed(_predict)(

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -291,7 +291,9 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
             main_table, self._main_key, "'X' (the main table)"
         )
         key_values = self.vectorizer_.transform(
-            sbd.set_column_names(s.select(main_table, s.cols(*self._main_key)), self._aux_key)
+            sbd.set_column_names(
+                s.select(main_table, s.cols(*self._main_key)), self._aux_key
+            )
         )
         prediction_results = joblib.Parallel(self.n_jobs)(
             joblib.delayed(_predict)(

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -320,6 +320,9 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
                     sbd.all_null_like(sbd.col(self.aux_table, col))
                     for col in res["columns"]
                 ]
+                _pred = [
+                    sbd.make_dataframe_like(self.aux_table, [col]) for col in _pred
+                ]
                 pred = sbd.concat_horizontal(*_pred)
                 new_res["predictions"] = pred
                 failed_columns.extend(res["columns"])

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -320,17 +320,14 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
         for res in results:
             new_res = dict(**res)
             if res["failed"]:
-                _pred = [
+                cols = [
                     sbd.all_null_like(
                         sbd.col(self.aux_table, col),
                         length=res["shape"][0],
                     )
                     for col in res["columns"]
                 ]
-                _pred = [
-                    sbd.make_dataframe_like(main_table, [col]) for col in _pred.copy()
-                ]
-                pred = sbd.concat_horizontal(*_pred)
+                pred = sbd.make_dataframe_like(main_table, cols)
                 new_res["predictions"] = pred
                 failed_columns.extend(res["columns"])
             checked_results.append(new_res)

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -224,6 +224,28 @@ def _get_new_name(suggested_name, forbidden_names):
     return f"{untagged_name}__skrub_{token}__"
 
 
+def make_column_names_unique(dataframes):
+    """Select new column names with a random suffix.
+
+    Parameters
+    ----------
+    dataframes: list of dataframes
+        The dataframes to pick new names for.
+
+    Returns
+    -------
+    result: list of dataframes
+        Dataframes with unique names.
+    """
+    used = set()
+    result = []
+    for df in dataframes:
+        new_names = pick_column_names(sbd.column_names(df), forbidden_names=used)
+        result.append(sbd.set_column_names(df, new_names))
+        used.update(new_names)
+    return result
+
+
 def left_join(left, right, left_on, right_on, rename_right_cols="{}"):
     """Left join two dataframes of the same type.
 

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -224,7 +224,7 @@ def _get_new_name(suggested_name, forbidden_names):
     return f"{untagged_name}__skrub_{token}__"
 
 
-def make_column_names_unique(dataframes):
+def make_column_names_unique(*dataframes):
     """Select new column names with a random suffix.
 
     Parameters

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -229,7 +229,7 @@ def make_column_names_unique(*dataframes):
 
     Parameters
     ----------
-    dataframes: list of dataframes
+    *dataframes: DataFrame
         The dataframes to pick new names for.
 
     Returns

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -157,7 +157,9 @@ def test_mismatched_indexes(df_module):
     ).fit_transform(main)
     assert_array_equal(ns.to_list(ns.col(join, "B")), [10, 11])
     # TODO: dispatch ``.values`` and ``.index``
-    assert_array_equal(join.index.values, [1, 0])
+
+
+#    assert_array_equal(join.index.values, [1, 0])
 
 
 def test_fit_on_none(df_module):
@@ -177,7 +179,9 @@ def test_fit_on_none(df_module):
     join = joiner.transform(main)
     assert_array_equal(ns.to_list(ns.col(join, "B")), [10, 11])
     # TODO: dispatch ``.values`` and ``.index``
-    assert_array_equal(join.index.values, [1, 0])
+
+
+#    assert_array_equal(join.index.values, [1, 0])
 
 
 def test_join_on_date(df_module):

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -137,7 +137,6 @@ def test_duplicate_column(df_module):
         aux, key="A", regressor=KNeighborsRegressor(1)
     ).fit_transform(join)
     assert ns.shape(join_2) == (3, 3)
-    print(join_2)
     assert re.match(r"C__skrub_[0-9a-f]+__", ns.column_names(join_2)[2])
 
 
@@ -314,7 +313,6 @@ def test_transform_failures_dtype(df_module, buildings, weather):
         on_estimator_failure="pass",
     )
     join = joiner.fit_transform(buildings)
-    #  print(join)
     assert ns.is_null(ns.col(join, "avg_temp")).all()
     assert ns.dtype(ns.col(join, "avg_temp")) == ns.dtype(ns.col(weather, "avg_temp"))
     assert ns.shape(join) == (2, 5)

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -57,14 +57,29 @@ def test_join_two_numeric_columns(df_module, buildings, weather):
 
 
 def test_no_multioutput(df_module, buildings, weather):
+    # Two str cols, not containing nulls, a model that handles them separately
     weather = df_module.DataFrame(weather)
-    weather = ns.with_columns(weather, **{"city": ["1", "1", "2", "2", "3", "3"]})
+    weather = ns.with_columns(weather, **{"new_col": ["1", "1", "2", "2", "3", "3"]})
     buildings = df_module.DataFrame(buildings)
     transformed = InterpolationJoiner(
         weather,
         main_key=("latitude", "longitude"),
         aux_key=("latitude", "longitude"),
         classifier=LogisticRegression(),
+    ).fit_transform(buildings)
+    assert ns.shape(transformed) == (2, 6)
+
+
+def test_multioutput(df_module, buildings, weather):
+    # Two str cols, not containing nulls, a model that handles both at once
+    weather = df_module.DataFrame(weather)
+    weather = ns.with_columns(weather, **{"new_col": ["1", "1", "2", "2", "3", "3"]})
+    buildings = df_module.DataFrame(buildings)
+    transformed = InterpolationJoiner(
+        weather,
+        main_key=("latitude", "longitude"),
+        aux_key=("latitude", "longitude"),
+        classifier=KNeighborsClassifier(),
     ).fit_transform(buildings)
     assert ns.shape(transformed) == (2, 6)
 

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -68,6 +68,8 @@ def test_no_multioutput(df_module, buildings, weather):
         classifier=LogisticRegression(),
     ).fit_transform(buildings)
     assert ns.shape(transformed) == (2, 6)
+    assert_array_equal(ns.to_list(ns.col(transformed, "climate")), ["A", "B"])
+    assert_array_equal(ns.to_list(ns.col(transformed, "new_col")), ["1", "2"])
 
 
 def test_multioutput(df_module, buildings, weather):
@@ -79,9 +81,11 @@ def test_multioutput(df_module, buildings, weather):
         weather,
         main_key=("latitude", "longitude"),
         aux_key=("latitude", "longitude"),
-        classifier=KNeighborsClassifier(),
+        classifier=KNeighborsClassifier(2),
     ).fit_transform(buildings)
     assert ns.shape(transformed) == (2, 6)
+    assert_array_equal(ns.to_list(ns.col(transformed, "climate")), ["A", "B"])
+    assert_array_equal(ns.to_list(ns.col(transformed, "new_col")), ["1", "2"])
 
 
 @pytest.mark.parametrize("fill_nulls", [False, True])

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -41,6 +41,20 @@ def test_simple_join(df_module, buildings, weather):
     assert ns.shape(transformed) == (2, 5)
 
 
+def test_join_two_numeric_columns(df_module, buildings, weather):
+    weather = df_module.DataFrame(weather)
+    weather = ns.with_columns(
+        weather, **{"median_temp": [10.1, 10.9, 15.0, 16.2, 20.1, None]}
+    )
+    buildings = df_module.DataFrame(buildings)
+    transformed = InterpolationJoiner(
+        weather,
+        main_key=("latitude", "longitude"),
+        aux_key=("latitude", "longitude"),
+    ).fit_transform(buildings)
+    assert ns.shape(transformed) == (2, 6)
+
+
 @pytest.mark.parametrize("fill_nulls", [False, True])
 def test_custom_predictors(df_module, buildings, weather, fill_nulls):
     if fill_nulls:

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.dummy import DummyClassifier
+from sklearn.dummy import DummyClassifier, DummyRegressor
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 from skrub import InterpolationJoiner
@@ -258,16 +258,14 @@ def test_transform_failures_dtype(df_module, buildings, weather):
     assert ns.dtype(ns.col(join, "avg_temp")) == ns.dtype(ns.col(weather, "avg_temp"))
     assert ns.shape(join) == (2, 5)
 
-
-#
-#     joiner = InterpolationJoiner(
-#         weather,
-#         key=["latitude", "longitude"],
-#         regressor=DummyRegressor(),
-#         classifier=FailPredict(),
-#         on_estimator_failure="pass",
-#     )
-#     join = joiner.fit_transform(buildings)
-#     assert ns.is_null(ns.col(join, "climate")).all()
-#     assert ns.dtype(ns.col(join, "climate")) == ns.dtype(ns.col(weather, "climate"))
-#     assert ns.shape(join) == (2, 5)
+    joiner = InterpolationJoiner(
+        weather,
+        key=["latitude", "longitude"],
+        regressor=DummyRegressor(),
+        classifier=FailPredict(),
+        on_estimator_failure="pass",
+    )
+    join = joiner.fit_transform(buildings)
+    assert ns.is_null(ns.col(join, "climate")).all()
+    assert ns.dtype(ns.col(join, "climate")) == ns.dtype(ns.col(weather, "climate"))
+    assert ns.shape(join) == (2, 5)

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from sklearn.base import BaseEstimator, TransformerMixin
-from sklearn.dummy import DummyClassifier, DummyRegressor
+from sklearn.dummy import DummyClassifier
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 from skrub import InterpolationJoiner
@@ -253,18 +253,21 @@ def test_transform_failures_dtype(df_module, buildings, weather):
         on_estimator_failure="pass",
     )
     join = joiner.fit_transform(buildings)
+    #  print(join)
     assert ns.is_null(ns.col(join, "avg_temp")).all()
-    assert ns.dtype(ns.col(join, "avg_temp")) == "float64"
+    assert ns.dtype(ns.col(join, "avg_temp")) == ns.dtype(ns.col(weather, "avg_temp"))
     assert ns.shape(join) == (2, 5)
 
-    joiner = InterpolationJoiner(
-        weather,
-        key=["latitude", "longitude"],
-        regressor=DummyRegressor(),
-        classifier=FailPredict(),
-        on_estimator_failure="pass",
-    )
-    join = joiner.fit_transform(buildings)
-    assert ns.is_null(ns.col(join, "climate")).all()
-    assert ns.dtype(ns.col(join, "climate")) == object
-    assert ns.shape(join) == (2, 5)
+
+#
+#     joiner = InterpolationJoiner(
+#         weather,
+#         key=["latitude", "longitude"],
+#         regressor=DummyRegressor(),
+#         classifier=FailPredict(),
+#         on_estimator_failure="pass",
+#     )
+#     join = joiner.fit_transform(buildings)
+#     assert ns.is_null(ns.col(join, "climate")).all()
+#     assert ns.dtype(ns.col(join, "climate")) == ns.dtype(ns.col(weather, "climate"))
+#     assert ns.shape(join) == (2, 5)

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -212,8 +212,7 @@ def test_transform_failures(df_module, buildings, weather):
     join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    # TODO: fix object dtype for polars
-    assert ns.dtype(ns.col(join, "climate")) == object
+    assert ns.dtype(ns.col(join, "climate")) == ns.dtype(ns.col(weather, "climate"))
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(
@@ -227,8 +226,7 @@ def test_transform_failures(df_module, buildings, weather):
         join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    # TODO: fix object dtype for polars
-    assert ns.dtype(ns.col(join, "climate")) == object
+    assert ns.dtype(ns.col(join, "climate")) == ns.dtype(ns.col(weather, "climate"))
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -5,6 +5,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.dummy import DummyClassifier, DummyRegressor
+from sklearn.linear_model import LogisticRegression
 from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 
 from skrub import InterpolationJoiner
@@ -51,6 +52,19 @@ def test_join_two_numeric_columns(df_module, buildings, weather):
         weather,
         main_key=("latitude", "longitude"),
         aux_key=("latitude", "longitude"),
+    ).fit_transform(buildings)
+    assert ns.shape(transformed) == (2, 6)
+
+
+def test_no_multioutput(df_module, buildings, weather):
+    weather = df_module.DataFrame(weather)
+    weather = ns.with_columns(weather, **{"city": ["1", "1", "2", "2", "3", "3"]})
+    buildings = df_module.DataFrame(buildings)
+    transformed = InterpolationJoiner(
+        weather,
+        main_key=("latitude", "longitude"),
+        aux_key=("latitude", "longitude"),
+        classifier=LogisticRegression(),
     ).fit_transform(buildings)
     assert ns.shape(transformed) == (2, 6)
 

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -83,12 +83,17 @@ def test_condition_choice(df_module):
     ).fit_transform(main)
     assert_array_equal(ns.to_list(ns.col(join, "C")), [10, 11, 12])
 
-    # TODO: test impossible to concat columns with same name in polars
-    # Can't add column with same name twice
-    # join_2 = InterpolationJoiner(
-    #     aux, main_key="A", aux_key="rB", regressor=KNeighborsRegressor(1)
-    # ).fit_transform(main)
-    # assert_array_equal(ns.to_list(ns.col(join_2, "C")), [11, 12, 10])
+    # Can't add column with the same name twice
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"(Can't concatenate dataframes containing duplicate column names.)"
+            r".*({'A'})"
+        ),
+    ):
+        InterpolationJoiner(
+            aux, main_key="A", aux_key="rB", regressor=KNeighborsRegressor(1)
+        ).fit_transform(main)
 
 
 def test_wrong_key(df_module):
@@ -214,7 +219,8 @@ def test_transform_failures(df_module, buildings, weather):
     join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    # assert ns.dtype(ns.col(join, "climate")) == object
+    # TODO: fix object dtype for polars
+    assert ns.dtype(ns.col(join, "climate")) == object
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(
@@ -228,7 +234,8 @@ def test_transform_failures(df_module, buildings, weather):
         join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    # assert ns.dtype(ns.col(join, "climate")) == object
+    # TODO: fix object dtype for polars
+    assert ns.dtype(ns.col(join, "climate")) == object
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -29,15 +29,10 @@ def weather():
 
 
 @pytest.mark.parametrize("key", [["latitude", "longitude"], "latitude"])
-@pytest.mark.parametrize("with_nulls", [False, True])
-def test_interpolation_join(df_module, buildings, weather, key, with_nulls):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
-    weather = ns.fill_nulls(weather, 0.0)
+@pytest.mark.parametrize("fill_nulls", [False, True])
+def test_interpolation_join(df_module, buildings, weather, key, fill_nulls):
+    if fill_nulls:
+        weather = ns.fill_nulls(weather, 0.0)
     weather = df_module.DataFrame(weather)
     buildings = df_module.DataFrame(buildings)
     transformed = InterpolationJoiner(
@@ -51,12 +46,6 @@ def test_interpolation_join(df_module, buildings, weather, key, with_nulls):
 
 
 def test_vectorizer(df_module):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     main = df_module.make_dataframe({"A": [0, 1]})
     aux = df_module.make_dataframe({"A": [11, 110], "B": [1, 0]})
 
@@ -77,12 +66,6 @@ def test_vectorizer(df_module):
 
 
 def test_no_multioutput(df_module, buildings, weather):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     weather = df_module.DataFrame(weather)
     buildings = df_module.DataFrame(buildings)
     transformed = InterpolationJoiner(
@@ -94,12 +77,6 @@ def test_no_multioutput(df_module, buildings, weather):
 
 
 def test_condition_choice(df_module):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     main = df_module.make_dataframe({"A": [0, 1, 2]})
     aux = df_module.make_dataframe({"A": [0, 1, 2], "rB": [2, 0, 1], "C": [10, 11, 12]})
     join = InterpolationJoiner(
@@ -129,12 +106,6 @@ def test_condition_choice(df_module):
 
 
 def test_suffix(df_module):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     df = df_module.make_dataframe({"A": [0, 1], "B": [0, 1]})
     join = InterpolationJoiner(
         df, key="A", suffix="_aux", regressor=KNeighborsRegressor(1)
@@ -164,12 +135,6 @@ def test_mismatched_indexes(df_module):
 
 def test_fit_on_none(df_module):
     # X is hardly used in fit so it should be ok to fit without a main table
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     aux = df_module.make_dataframe({"A": [0, 1], "B": [10, 11]})
     joiner = InterpolationJoiner(aux, key="A", regressor=KNeighborsRegressor(1)).fit(
         None
@@ -185,12 +150,6 @@ def test_fit_on_none(df_module):
 
 
 def test_join_on_date(df_module):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     sales = df_module.make_dataframe(
         {"date": ["2023-09-20", "2023-09-29"], "n": [10, 15]}
     )
@@ -265,12 +224,6 @@ class FailPredict(DummyClassifier):
 
 
 def test_transform_failures(df_module, buildings, weather):
-    if df_module.name == "polars":
-        pytest.xfail(
-            reason=(
-                "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
-            )
-        )
     weather = df_module.DataFrame(weather)
     buildings = df_module.DataFrame(buildings)
     joiner = InterpolationJoiner(
@@ -283,7 +236,7 @@ def test_transform_failures(df_module, buildings, weather):
     join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    assert ns.dtype(ns.col(join, "climate")) == object
+    # assert ns.dtype(ns.col(join, "climate")) == object
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(
@@ -297,7 +250,7 @@ def test_transform_failures(df_module, buildings, weather):
         join = joiner.fit_transform(buildings)
     assert_array_equal(ns.to_list(ns.col(join, "avg_temp")), [10.5, 15.5])
     assert ns.is_null(ns.col(join, "climate")).all()
-    assert ns.dtype(ns.col(join, "climate")) == object
+    # assert ns.dtype(ns.col(join, "climate")) == object
     assert ns.shape(join) == (2, 5)
 
     joiner = InterpolationJoiner(

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -37,7 +37,7 @@ def test_interpolation_join(df_module, buildings, weather, key, with_nulls):
                 "In polars, DataFrame.drop() got an unexpected keyword argument 'axis'."
             )
         )
-    weather = weather.fillna(0.0)
+    weather = ns.fill_nulls(weather, 0.0)
     weather = df_module.DataFrame(weather)
     buildings = df_module.DataFrame(buildings)
     transformed = InterpolationJoiner(

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -176,8 +176,8 @@ def test_mismatched_indexes():
         aux, key="A", regressor=KNeighborsRegressor(1)
     ).fit_transform(main)
     assert_array_equal(ns.to_list(ns.col(join, "B")), [10, 11])
-    # Index is reset in ``ns.concat_horizontal``
-    assert_array_equal(join.index.values, [0, 1])
+    # Index of main is kept
+    assert_array_equal(join.index.values, [20, 30])
 
 
 def test_fit_on_none(df_module):

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -83,17 +83,10 @@ def test_condition_choice(df_module):
     ).fit_transform(main)
     assert_array_equal(ns.to_list(ns.col(join, "C")), [10, 11, 12])
 
-    # Can't add column with the same name twice
-    with pytest.raises(
-        ValueError,
-        match=(
-            r"(Can't concatenate dataframes containing duplicate column names.)"
-            r".*({'A'})"
-        ),
-    ):
-        InterpolationJoiner(
-            aux, main_key="A", aux_key="rB", regressor=KNeighborsRegressor(1)
-        ).fit_transform(main)
+    # Add column with the same name twice
+    join = InterpolationJoiner(
+        aux, main_key="A", aux_key="rB", regressor=KNeighborsRegressor(1)
+    ).fit_transform(main)
 
 
 def test_wrong_key(df_module):

--- a/skrub/tests/test_interpolation_join.py
+++ b/skrub/tests/test_interpolation_join.py
@@ -150,15 +150,26 @@ def test_suffix(df_module):
     assert_array_equal(ns.column_names(join), ["A", "B", "B_aux"])
 
 
+def test_mismatched_indexes():
+    main = pd.DataFrame({"A": [0, 1]}, index=[20, 30])
+    aux = pd.DataFrame({"A": [0, 1], "B": [10, 11]}, index=[0, 1])
+    join = InterpolationJoiner(
+        aux, key="A", regressor=KNeighborsRegressor(1)
+    ).fit_transform(main)
+    assert_array_equal(ns.to_list(ns.col(join, "B")), [10, 11])
+    # Index is reset in ``ns.concat_horizontal``
+    assert_array_equal(join.index.values, [0, 1])
+
+
 def test_fit_on_none(df_module):
     # X is hardly used in fit so it should be ok to fit without a main table
     aux = df_module.make_dataframe({"A": [0, 1], "B": [10, 11]})
     joiner = InterpolationJoiner(aux, key="A", regressor=KNeighborsRegressor(1)).fit(
         None
     )
-    main = df_module.make_dataframe({"A": [1, 0]})
+    main = df_module.make_dataframe({"A": [0, 1]})
     join = joiner.transform(main)
-    assert_array_equal(ns.to_list(ns.col(join, "B")), [11, 10])
+    assert_array_equal(ns.to_list(ns.col(join, "B")), [10, 11])
 
 
 def test_join_on_date(df_module):

--- a/skrub/tests/test_join_utils.py
+++ b/skrub/tests/test_join_utils.py
@@ -80,6 +80,15 @@ def left(df_module):
     return df_module.make_dataframe({"left_key": [1, 2, 2], "left_col": [10, 20, 30]})
 
 
+def test_make_column_names_unique(left):
+    right = left
+    result = _join_utils.make_column_names_unique(left, right)
+    assert len(result) == 2
+    assert sbd.column_names(result[0]) == ["left_key", "left_col"]
+    assert re.match(r"left_key__skrub_[0-9a-f]+__", sbd.column_names(result[1])[0])
+    assert re.match(r"left_col__skrub_[0-9a-f]+__", sbd.column_names(result[1])[1])
+
+
 def test_left_join_all_keys_in_right_dataframe(df_module, left):
     right = df_module.make_dataframe({"right_key": [2, 1], "right_col": ["b", "a"]})
     joined = _join_utils.left_join(


### PR DESCRIPTION
Closes #897 

```
>>> import polars as pl
>>> from sklearn.neighbors import KNeighborsRegressor
>>> from skrub import InterpolationJoiner

>>> buildings = pl.DataFrame(
...     {"latitude": [1.0, 2.0], "longitude": [1.0, 2.0], "n_stories": [3, 7]}
... )
>>> annual_avg_temp = pl.DataFrame(
...     {
...         "latitude": [1.2, 0.9, 1.4, 1.7, 5.0],
...         "longitude": [0.8, 1.1, 1.8, 1.8, 5.0],
...         "avg_temp": [10.0, 11.0, 15.0, 16.0, 20.0],
...     }
... )

>>> joiner = InterpolationJoiner(
...     annual_avg_temp,
...     key=["latitude", "longitude"],
...     regressor=KNeighborsRegressor(2),
... )
>>> joiner.fit_transform(buildings)

┌──────────┬───────────┬───────────┬──────────┐
│ latitude ┆ longitude ┆ n_stories ┆ avg_temp │
│ ---      ┆ ---       ┆ ---       ┆ ---      │
│ f64      ┆ f64       ┆ i64       ┆ f64      │
╞══════════╪═══════════╪═══════════╪══════════╡
│ 1.0      ┆ 1.0       ┆ 3         ┆ 10.5     │
│ 2.0      ┆ 2.0       ┆ 7         ┆ 15.5     │
└──────────┴───────────┴───────────┴──────────┘
```

As discussed with @jeromedockes, if the joined dataframe could contain duplicate column names, we add random suffixes and don't raise -- to be consistent with the behavior of the other joiners