### PR TITLE
no "index" column in aggtarget output

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,11 @@ Minor changes
   duplicate column names, now the output names are always the same.
   :pr:`1013` by :user:`Jérôme Dockès <jeromedockes>`.
 
+* In some cases :class:`AggJoiner` and :class:`AggTarget` inserted a column in
+  the output named "index" containing the pandas index of the auxiliary table.
+  This has been corrected.
+  :pr:`1020` by :user:`Jérôme Dockès <jeromedockes>`.
+
 Release 0.2.0
 =============
 

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -447,7 +447,6 @@ class AggTarget(TransformerMixin, BaseEstimator):
         y_[self.main_key_] = X[self.main_key_]
 
         num_operations, categ_operations = split_num_categ_operations(self.operation_)
-
         self.y_ = skrub_px.aggregate(
             y_,
             key=self.main_key_,

--- a/skrub/_dataframe/_pandas.py
+++ b/skrub/_dataframe/_pandas.py
@@ -70,7 +70,7 @@ def aggregate(
 
     named_agg = {**num_named_agg, **categ_named_agg}
     if named_agg:
-        base_group = table.groupby(key).agg(**named_agg)
+        base_group = table.groupby(key).agg(**named_agg).reset_index(drop=False)
     else:
         base_group = None
 
@@ -104,7 +104,7 @@ def aggregate(
     ]
     sorted_cols = sorted(base_group.columns)
 
-    return base_group[sorted_cols].reset_index(drop=False)
+    return base_group[sorted_cols]
 
 
 def get_named_agg(table, cols, operations):

--- a/skrub/_dataframe/tests/test_pandas.py
+++ b/skrub/_dataframe/tests/test_pandas.py
@@ -30,6 +30,7 @@ def test_simple_agg():
         "rating_mean": ("rating", "mean"),
     }
     expected = main.groupby("movieId").agg(**aggfunc).reset_index()
+    expected = expected.loc[:, sorted(expected.columns)]
     assert_frame_equal(aggregated, expected)
 
 
@@ -49,7 +50,7 @@ def test_value_counts_agg():
             "rating_4.0_user": [3.0, 1.0],
             "userId": [1, 2],
         }
-    ).reset_index(drop=False)
+    )
     assert_frame_equal(aggregated, expected)
 
     aggregated = aggregate(
@@ -66,7 +67,7 @@ def test_value_counts_agg():
             "rating_(3.0, 4.0]_user": [3, 1],
             "userId": [1, 2],
         }
-    ).reset_index(drop=False)
+    )
     assert_frame_equal(aggregated, expected)
 
 

--- a/skrub/tests/test_agg_joiner.py
+++ b/skrub/tests/test_agg_joiner.py
@@ -400,7 +400,6 @@ def test_agg_target(main_table, y, col_name):
             "movieId": [1, 3, 6, 318, 6, 1704],
             "rating": [4.0, 4.0, 4.0, 3.0, 2.0, 4.0],
             "genre": ["drama", "drama", "comedy", "sf", "comedy", "sf"],
-            "index": [0, 0, 0, 1, 1, 1],
             f"{col_name}_(1.999, 3.0]_user": [0, 0, 0, 2, 2, 2],
             f"{col_name}_(3.0, 4.0]_user": [3, 3, 3, 1, 1, 1],
             f"{col_name}_2.0_user": [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],


### PR DESCRIPTION
ATM the AggJoiner and AggTarget when using value counts or histogram include an unwanted "index" column in their output.

After performing a groupby, the grouping column is in the index of the pandas result. to have it as a column and be able to join on it, we need to do a `reset_index`. `skrub._dataframe._pandas.aggregate` used to do it for histogram and value counts, but not for other aggregation functions. This went unnoticed/was not a problem because the aggjoiner and aggtarget used pandas.merge which then performed the merge on the index rather than a column, because it allows "right_on" to be either a column index or an index level index.

in #945 a `reset_index` was added, but in both for mean() and for value_counts(). So before the reset_index was done 0 times for mean(), 1 times for value_counts(); after it was done 1 time for mean() and 2 times for value_counts() -- the second one resulting in the "index" column.

what we want is to do reset_index once in all cases.

At least that's what I understand from a quick look, it would be great if @TheooJ and @Vincent-Maladiere can confirm