### PR TITLE
flush stdout after computing all column summaries

### DIFF
--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -69,7 +69,7 @@ def summarize_dataframe(df, *, order_by=None, with_plots=True, title=None):
                 order_by_column=None if order_by is None else sbd.col(df, order_by),
             )
         )
-    print()
+    print(flush=True)
     summary["n_constant_columns"] = sum(
         c["value_is_constant"] for c in summary["columns"]
     )


### PR DESCRIPTION
tiny detail: make sure the stream is flushed otherwise the last line may take longer to appear eg in ci logs