### PR TITLE
pip install skrub instead of full url

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -381,10 +381,7 @@ def notebook_modification_function(notebook_content, notebook_filename):
     code_lines.extend(
         [
             "import micropip",
-            (
-                "await"
-                " micropip.install('https://files.pythonhosted.org/packages/eb/6d/0e78d028591bedd9580e49ae1060d9faf7fb4503e1db54227616db8f359d/skrub-0.2.0rc1-py3-none-any.whl')"
-            ),
+            "await micropip.install('skrub')",
         ]
     )
 


### PR DESCRIPTION
this doesn't really address #1029 but that looks like it will take a bit more time than expected.

in the meanwhile this makes jupyterlite get the latest version from pypi, which means that we have the right version on the stable documentation (without having to do 2 releases and update the url every time), which is already an improvement.