### PR TITLE
Fonts in inline report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Major changes
 
 Minor changes
 -------------
+* The reports created by :class:`TableReport`, when inserted in an html page (or
+  displayed in a notebook), now use the same font as the surrounding page.
+  :pr:`1038` by :user:`Jérôme Dockès <jeromedockes>`.
 
 
 Release 0.3.0

--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -79,6 +79,7 @@ pre {
 
 code, pre {
     font-family: var(--fontStack-monospace);
+    font-size: calc(0.9 * var(--small));
 }
 
 :is(td, th) {

--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -22,15 +22,14 @@
     --lightg: #f0f0f0;
 
     --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, "DejaVu Sans Mono", Liberation Mono, monospace;
-    --fontStack-sansSerif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
 }
 
 :host {
-    font-family: var(--fontStack-sansSerif);
     font-size: 1rem;
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
 }
+
 
 /* The report is in a shadow DOM so outside selectors don't reach it but properties */
 /* can still be inherited from a parent element. We make sure it has black text on */

--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -260,9 +260,9 @@ dd {
 }
 
 .announcement  {
-    font-size: var(--large);
-    padding-block-start: var(--huge);
-    padding-block-end: var(--huge);
+    font-size: var(--small);
+    padding-block-start: var(--small);
+    padding-block-end: var(--small);
 }
 
 .important-note {

--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -44,6 +44,10 @@
     max-width: max-content;
 }
 
+h1 {
+    font-size: var(--huge);
+}
+
 button > * {
     pointer-events: none;
 }

--- a/skrub/_reporting/_data/templates/copybutton.css
+++ b/skrub/_reporting/_data/templates/copybutton.css
@@ -17,7 +17,7 @@
 
 .box pre {
     overflow-x: auto;
-    padding: var(--tiny);
+    padding: var(--micro);
     flex-grow: 1;
     white-space: pre;
 }
@@ -54,7 +54,7 @@
     border-radius: var(--radius, 5px);
     position: absolute;
     right: calc(100% + 5px);
-    top: 5px;
+    top: 3px;
     margin: 0;
 }
 

--- a/skrub/_reporting/_data/templates/standalone-report.css
+++ b/skrub/_reporting/_data/templates/standalone-report.css
@@ -1,0 +1,7 @@
+:root {
+    --fontStack-sansSerif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+body {
+    font-family: var(--fontStack-sansSerif);
+}

--- a/skrub/_reporting/_data/templates/standalone-report.html
+++ b/skrub/_reporting/_data/templates/standalone-report.html
@@ -5,6 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ summary.file_name if summary.file_name else "skrub report" }}</title>
+    <style>
+     {% include "standalone-report.css" %}
+    </style>
 </head>
 <body>
     <main>


### PR DESCRIPTION
partly addresses #1037 

- [x] don't set the font when the report is inserted in another page
- [x] reduce monspaced text size
- [x] reduce banner font size


can be discussed in another pr:

- [ ] scale report according to parent element's font size
- [ ] reduce the font size further