### PR TITLE
Better distinguish focus & selection in sample table

### DIFF
--- a/skrub/_reporting/_data/templates/dataframe-sample.css
+++ b/skrub/_reporting/_data/templates/dataframe-sample.css
@@ -22,12 +22,19 @@ tr:nth-child(2n -1) .table-cell[data-is-in-active-column] {
 
 
 .table-cell[data-is-active] {
-    outline: 2px solid black;
+    outline: 2px dotted black;
 }
 
-.table-cell[data-is-active][data-just-copied] {
-    outline: 2px dashed black;
+.table-cell[data-is-active]:focus {
+    outline: 2px solid Highlight;
+    outline: 2px solid -webkit-focus-ring-color;
 }
+
+.table-cell[data-is-active][data-just-copied]:focus {
+    outline: 2px dashed Highlight !important;
+    outline: 2px dashed -webkit-focus-ring-color !important;
+}
+
 
 /* The gap separating the head and the tail of the table */
 

--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -303,7 +303,7 @@ if (customElements.get('skrub-table-report') === undefined) {
             if (msg.cellId === this.elem.id) {
                 this.elem.dataset.isActive = "";
                 this.elem.setAttribute("tabindex", 0);
-                this.elem.focus({focusVisible: false});
+                this.elem.focus({focusVisible: true});
             } else {
                 delete this.elem.dataset.isActive;
                 this.elem.setAttribute("tabindex", -1);


### PR DESCRIPTION
ATM the selected table cell is outlined in black. that's ok in firefox but that is the color used by chrome to draw the focus ring, so there it makes it look like the selected cell has the keyboard focus even when it doesn't.

This PR makes the outline dotted when the focus is outside of the table and makes sure the cell has the default focus ring when it is in it