### PR TITLE
always show top 20 associations regardless of their value

### DIFF
--- a/skrub/_reporting/_associations.py
+++ b/skrub/_reporting/_associations.py
@@ -59,7 +59,7 @@ def _stack_symmetric_associations(associations, column_names):
         associations[order],
     )
     return [
-        (column_names[left], column_names[right], a)
+        (column_names[left], column_names[right], float(a))
         for (left, right, a) in zip(left_indices, right_indices, associations)
     ]
 

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -5,7 +5,7 @@ from . import _associations, _plotting, _utils
 
 _HIGH_CARDINALITY_THRESHOLD = 10
 _SUBSAMPLE_SIZE = 3000
-_ASSOCIATION_THRESHOLD = 0.2
+_N_TOP_ASSOCIATIONS = 20
 
 
 def summarize_dataframe(df, *, order_by=None, with_plots=True, title=None):
@@ -82,11 +82,9 @@ def summarize_dataframe(df, *, order_by=None, with_plots=True, title=None):
 
 def _add_associations(df, dataframe_summary):
     df = sbd.sample(df, n=min(sbd.shape(df)[0], _SUBSAMPLE_SIZE))
-    associations = _associations.cramer_v(df)[:20]
+    associations = _associations.cramer_v(df)[:_N_TOP_ASSOCIATIONS]
     dataframe_summary["top_associations"] = [
-        dict(zip(("left_column", "right_column", "cramer_v"), a))
-        for a in associations
-        if a[2] > _ASSOCIATION_THRESHOLD
+        dict(zip(("left_column", "right_column", "cramer_v"), a)) for a in associations
     ]
 
 

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -123,11 +123,7 @@ def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
             break
     else:
         assert False
-    assert asso[-1] == {
-        "cramer_v": 0.0,
-        "right_column": "parameter",
-        "left_column": "country",
-    }
+    assert asso[-1]["cramer_v"] == 0.0
 
 
 def test_no_title(pd_module):

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -110,7 +110,7 @@ def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
 
     # checking top associations
 
-    assert len(summary["top_associations"]) == 15
+    assert len(summary["top_associations"]) == 20
     asso = [
         d | {"cramer_v": round(d["cramer_v"], 1)} for d in summary["top_associations"]
     ]
@@ -124,9 +124,9 @@ def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
     else:
         assert False
     assert asso[-1] == {
-        "cramer_v": 0.5,
-        "right_column": "loc_with_nulls",
-        "left_column": "value",
+        "cramer_v": 0.0,
+        "right_column": "parameter",
+        "left_column": "country",
     }
 
 


### PR DESCRIPTION
before we would show at most 20 but only those that have an association above 0.2
having 2 cutoffs was confusing: if usually there are 20 but on my data only 15 show up (even if I have many columns in the dataframe) it is not clear why

this pr always shows the top 20