### PR TITLE
improve tabular learner for unseen categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ Major changes
 
 Minor changes
 -------------
+
+* For tree-based models, :func:`tabular_learner` now adds
+  `handle_unknown='use_encoded_value'` to the `OrdinalEncoder`, to avoid
+  errors with new categories in the test set. This is consistent with the
+  setting of `OneHotEncoder` used by default in the
+  :class:`TableVectorizer`. :pr:`1078` by :user:`Gaël Varoquaux <gaelvaroquaux>`
+
 * The reports created by :class:`TableReport`, when inserted in an html page (or
   displayed in a notebook), now use the same font as the surrounding page.
   :pr:`1038` by :user:`Jérôme Dockès <jeromedockes>`.

--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -262,7 +262,10 @@ def tabular_learner(estimator, *, n_jobs=None):
         )
     elif isinstance(estimator, _TREE_ENSEMBLE_CLASSES):
         vectorizer.set_params(
-            low_cardinality=OrdinalEncoder(),
+            low_cardinality=OrdinalEncoder(
+                handle_unknown='use_encoded_value',
+                unknown_values=-1,
+                ),
             high_cardinality=MinHashEncoder(),
         )
     steps = [vectorizer]


### PR DESCRIPTION
When used with trees, tabular_learner created a pipeline that could fail with unknown categories, as noticed by @rcap107 

This fixes the problem