### PR TITLE
[DOC] Fix small typo in landing page

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -21,7 +21,7 @@ still full-width (unlike the article) #}
         <ul class="sk-landing-header-body">
           <li>scikit-learn compatible</li>
           <li>Pandas and Polars dataframes inputs and outputs</li>
-          <li>Work on heterogenous types (numeric, categorical, dates, text, missing values...)</li>
+          <li>Work on heterogeneous types (numeric, categorical, dates, text, missing values...)</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
On another note, maybe "Create strong scikit-learn pipeline baselines effortlessly with TableVectorizer and tabular_learner" is a bit hard to read, WDYT ?