### PR TITLE
Ellided cells a bit more visible

### DIFF
--- a/skrub/_reporting/_data/templates/dataframe-sample.css
+++ b/skrub/_reporting/_data/templates/dataframe-sample.css
@@ -93,7 +93,7 @@ table:not(:focus-within):not(:has(:active)) .table-cell[data-is-active] {
 /* The gap separating the head and the tail of the table */
 
 #report .ellided-table-part {
-    border: 1px dashed #e8e8e8;
+    border: 1px dashed  var(--mediumg);
     text-align: center;
     border-top: 0;
     border-bottom: 0;

--- a/skrub/_reporting/_data/templates/dataframe-sample.css
+++ b/skrub/_reporting/_data/templates/dataframe-sample.css
@@ -92,16 +92,27 @@ table:not(:focus-within):not(:has(:active)) .table-cell[data-is-active] {
 
 /* The gap separating the head and the tail of the table */
 
-#report .ellided-table-part {
-    border: 1px dashed  var(--mediumg);
+#report .ellided-table-part,
+#report .ellided-table-part td {
+    border: 2px dashed var(--mediumg);
     text-align: center;
     border-top: 0;
     border-bottom: 0;
     background: inherit;
 }
 
-#report table:has([data-role="index-level-value"]) .ellided-table-part:first-child{
-    text-align: right;
+#report .ellided-table-part td {
+    padding: var(--tiny);
+}
+
+#report .ellipsis-icon {
+    display: flex;
+    flex-direction: column;
+    max-height: var(--large);
+}
+
+#report table:has([data-role="index-level-value"]) .ellided-table-part td:first-child .ellipsis-icon * {
+    align-self: flex-end;
 }
 
 .table-bar-wrapper {

--- a/skrub/_reporting/_data/templates/dataframe-sample.css
+++ b/skrub/_reporting/_data/templates/dataframe-sample.css
@@ -93,7 +93,7 @@ table:not(:focus-within):not(:has(:active)) .table-cell[data-is-active] {
 /* The gap separating the head and the tail of the table */
 
 #report .ellided-table-part {
-    border: 1px solid white;
+    border: 1px dashed #e8e8e8;
     text-align: center;
     border-top: 0;
     border-bottom: 0;

--- a/skrub/_reporting/_data/templates/dataframe-sample.html
+++ b/skrub/_reporting/_data/templates/dataframe-sample.html
@@ -26,7 +26,7 @@ data-spans__{{ i }}__{{ j }}
         >
             {% for table_part in summary["sample_table"]["parts"] %}
             {% if table_part["name"] == "ellipsis" %}
-            <tbody>
+            <tbody class="ellided-table-part">
                 <tr>
                     {% for i in range(summary["sample_table"]["start_j"], summary["sample_table"]["stop_j"])%}
                     <td

--- a/skrub/_reporting/_data/templates/dataframe-sample.html
+++ b/skrub/_reporting/_data/templates/dataframe-sample.html
@@ -30,13 +30,12 @@ data-spans__{{ i }}__{{ j }}
                 <tr>
                     {% for i in range(summary["sample_table"]["start_j"], summary["sample_table"]["stop_j"])%}
                     <td
-                        class="ellided-table-part"
                         {% if i >= 0%}
                         data-manager="FilterableColumn"
                         data-column-idx="{{ i }}"
                         data-role="ellipsis"
                         {% endif %}
-                    >⋮</td>
+                        ><div class="ellipsis-icon">{% include "icons/three-dots-vertical.svg" %}</div></td>
                     {% endfor %}
                 </tr>
             </tbody>

--- a/skrub/_reporting/_data/templates/icons/three-dots-vertical.svg
+++ b/skrub/_reporting/_data/templates/icons/three-dots-vertical.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16">
+  <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0"/>
+</svg>


### PR DESCRIPTION
A tiny change to make ellided cells a bit more visible, as I find that the implementation in main can be understood as two different tables:

This PR:
![image](https://github.com/user-attachments/assets/dfaa33de-b28b-4177-93b5-11eadc60ac57)

Main:
![image](https://github.com/user-attachments/assets/8c0ddba0-219b-4242-a033-63824064b149)
