### PR TITLE
align copy buttons to flex-start + always visible

### DIFF
--- a/skrub/_reporting/_data/templates/buttons.html
+++ b/skrub/_reporting/_data/templates/buttons.html
@@ -1,6 +1,6 @@
 {% macro copybutton(target) %}
 <button
-    class="copybutton"
+    class="copybutton copybutton-left"
     type="button"
     onclick="copyButtonClick(event)"
     data-target-id="{{ target }}">

--- a/skrub/_reporting/_data/templates/copybutton.css
+++ b/skrub/_reporting/_data/templates/copybutton.css
@@ -35,6 +35,10 @@
     align-self: flex-start;
 }
 
+.copybutton-left {
+    order: -1;
+}
+
 .copybutton {
     background: #e0e0e0;
 }
@@ -62,9 +66,14 @@
     padding: 5px;
     border-radius: var(--radius, 5px);
     position: absolute;
-    right: calc(100% + 5px);
     top: 1px;
     margin: 0;
+    right: calc(100% + 5px);
+}
+
+.copybutton-left .copied-message {
+    left: calc(100% + 5px);
+    right: auto;
 }
 
 [data-shows-placeholder] {

--- a/skrub/_reporting/_data/templates/copybutton.css
+++ b/skrub/_reporting/_data/templates/copybutton.css
@@ -23,19 +23,28 @@
 }
 
 .copybutton {
-    margin-left: -2rem;
+    margin: 1px;
     min-width: 2rem;
-    display: none;
+    min-height: calc(1.8rem - 4px);
+    display: inline-block;
     padding: var(--micro);
     padding-left: var(--tiny);
     padding-right: var(--tiny);
     border: none;
-    background: var(--lightg);
     position: relative;
+    align-self: flex-start;
 }
 
-.copybutton[data-show-checkmark]{
-    display: inline-block;
+.copybutton {
+    background: #e0e0e0;
+}
+
+.copybutton:hover {
+    background: #eee;
+}
+
+.copybutton:active {
+    background: #cccccc;
 }
 
 .copybutton:not([data-show-checkmark]) > :not(:first-child) {
@@ -54,20 +63,9 @@
     border-radius: var(--radius, 5px);
     position: absolute;
     right: calc(100% + 5px);
-    top: 3px;
+    top: 1px;
     margin: 0;
 }
-
-.box:hover .copybutton {
-    display: inline-block;
-    background: var(--lightg);
-}
-
-.box:hover .copybutton:hover {
-    display: inline-block;
-    background: var(--mediumg);
-}
-
 
 [data-shows-placeholder] {
     color: #777777;


### PR DESCRIPTION
the copy buttons stretch across the box they copy which is fine in the most common case of just 1 line but weird otherwise.

also @Vincent-Maladiere said it would be best to have them always visible and I agree

this pr also improves a bit the colors of default/hover/active states


**before**


![screenshot_2024-09-24T10:04:14+02:00](https://github.com/user-attachments/assets/e5d695c0-112b-493a-86e7-109d6551ebfe)

**after**

![screenshot_2024-09-24T10:03:56+02:00](https://github.com/user-attachments/assets/fd415186-161d-4be9-b294-b0848d4b24b2)
