### PR TITLE
tablereport captures keydown events in reveal js (slides)

### DIFF
--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -779,7 +779,7 @@ if (customElements.get('skrub-table-report') === undefined) {
         };
     }
 
-    if (document.querySelector(".jp-Cell, .widgetarea")) {
+    if (document.querySelector(".jp-Cell, .widgetarea, .reveal")) {
         window.addEventListener("keydown", forwardKeyboardEvent, true);
     }
 


### PR DESCRIPTION
in jupyter and vscode we make sure that the tablereport gets arrow key keydown events which are otherwise captured by the notebook or vscode.

this adds revealjs slides to the list where this is done