### PR TITLE
make sample table sequentially focusable when no cell is active

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,15 @@ It is currently undergoing fast development and backward compatibility is not en
 Major changes
 -------------
 
+Minor changes
+-------------
+
+* In the TableReport it is now possible, before clicking any of the cells, to
+  reach the dataframe sample table and activate a cell with tab key navigation.
+  :pr:`1101` by :user:`Jérôme Dockès <jeromedockes>`.
+
+Release 0.3.1
+=============
 
 Minor changes
 -------------

--- a/skrub/_reporting/_data/templates/dataframe-sample.html
+++ b/skrub/_reporting/_data/templates/dataframe-sample.html
@@ -16,7 +16,7 @@ data-spans__{{ i }}__{{ j }}
     data-hide-on="EMPTY_COLUMN_FILTER_SELECTED">
     {% include "table-bar.html" %}
 
-    <div class="horizontal-scroll">
+    <div class="horizontal-scroll" tabindex="-1">
         <table class="pure-table pure-table-striped table-with-selectable-cells"
                data-manager="SampleTable"
         data-start-i="{{ summary['sample_table']['start_i'] }}"

--- a/skrub/_reporting/js_tests/cypress/e2e/dataframe-sample.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/dataframe-sample.cy.js
@@ -140,4 +140,10 @@ describe('test the dataframe sample tab', () => {
         getIJ(0, 0).should('have.focus');
         getIJ(0, 0).should('have.attr', 'data-role', 'dataframe-data');
     });
+
+    it('can reach the sample table with the tab key', () => {
+        // TODO whenever cypress adds support for testing tab key navigation,
+        // or we start using a testing tool that does
+        // https://github.com/cypress-io/cypress/issues/299
+    });
 });


### PR DESCRIPTION
currently before clicking on any of the cells it is not possible to bring focus to the sample table with the keyboard. this PR makes the table sequentially focusable (with Tab); when it receives focus it activates the first cell