### PR TITLE
make the 'column name' column always visible in summary stats table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,15 @@ It is currently undergoing fast development and backward compatibility is not en
 Major changes
 -------------
 
+Minor changes
+-------------
+
+* The "Column name" column of the "summary statistics" table in the TableReport
+  is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
+  Dockès <jeromedockes>`.
+
+Release 0.3.0
+=============
 
 Minor changes
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Minor changes
   is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
   Dockès <jeromedockes>`.
 
-Release 0.3.0
+Release 0.3.1
 =============
 
 Minor changes

--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -283,6 +283,7 @@ dd {
 
 .box-shadow {
     --shadow-color: 0deg 0% 63%;
+
     box-shadow:
     0.3px 0.5px 0.7px hsl(var(--shadow-color) / 0.36),
     0.8px 1.6px 2px -0.8px hsl(var(--shadow-color) / 0.36),

--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -590,6 +590,50 @@ if (customElements.get('skrub-table-report') === undefined) {
     }
     SkrubTableReport.register(SortableTable);
 
+    /*
+      Add the "data-is-scrolling" attribute to the scrolling div whenever a
+      given column is partially hidden; used to manage the border of the sticky
+      column in the summary statistics table.
+    */
+    class StickyColTableScroller extends Manager {
+        constructor(elem, exchange) {
+            super(elem, exchange);
+            this.stickyCol = Number(this.elem.dataset.stickyCol) || 1;
+            this.registerObserver();
+        }
+
+        registerObserver() {
+            const options = {
+                root: this.elem,
+                // The first threshold is crossed when the parent becomes
+                // visible (eg when the summary statistics table is loaded, it
+                // is in a hidden tab panel so the intersection is 0). The other
+                // thresholds are crossed when the left border is just past the
+                // edge of the scrollable area.
+                threshold: [0.01, 0.93, 0.97]
+            };
+            const observer = new IntersectionObserver(e => this
+                .intersectionCallback(e), options);
+            this.elem.querySelectorAll(`:is(th, td):nth-child(${this.stickyCol})`)
+                .forEach((e) => observer.observe(e));
+        }
+
+        intersectionCallback(entries) {
+            entries.forEach((entry) => {
+                if (!entry.isIntersecting) {
+                    return;
+                }
+                if (entry.intersectionRatio >= 0.95) {
+                    this.elem.removeAttribute("data-is-scrolling");
+                } else {
+                    this.elem.dataset.isScrolling = "";
+                }
+            });
+        }
+
+    }
+    SkrubTableReport.register(StickyColTableScroller);
+
     class SelectedColumnsDisplay extends Manager {
 
         constructor(elem, exchange) {

--- a/skrub/_reporting/_data/templates/summary-statistics.css
+++ b/skrub/_reporting/_data/templates/summary-statistics.css
@@ -1,7 +1,61 @@
 .summary-stats-table {
     margin: var(--border-m);
+
+    /* "collapse" prevents reliably showing the right border of the sticky
+       column when it overlaps others */
+    border-collapse: separate;
+
+    /* Avoid a border twice as thick on the left of the table due to separate
+       border (there is already a left border on the table cells). */
+    border-left: none;
 }
 
+.relative {
+    position: relative;
+}
+
+/* pure.css puts the border on the left of each cell, but we want one on the
+   right of the second column which will overlap other columns. */
+#report .summary-stats-table tr > :is(th, td):nth-child(3){
+    border-left: none;
+}
+
+/* Make the second column sticky and allow it to overlap others. */
+#report .summary-stats-table tr > :is(th, td):nth-child(2) {
+
+    /* We allow part of the column to be hidden to save space; seeing the end of
+       the column name should be enough to recognize to which column a row
+       belongs. */
+    --left-overlap: calc(4 * var(--base-size));
+
+    position: sticky;
+    left: calc(-1 * var(--left-overlap));
+    z-index: 10;
+
+    text-align: right;
+    max-width: calc(min(30ch, var(--left-overlap) + 40vw));
+
+    border-right: 1px solid #cbcbcb;
+    box-shadow: 0px 0 0 0 #aaa;
+    transition: box-shadow 200ms;
+}
+
+/* Draw a larger & darker border when the 2nd column is overlapping others. */
+#report [data-is-scrolling] > .summary-stats-table tr > :is(th, td):nth-child(2) {
+    box-shadow: 2px 0 0 0 #aaa;
+    transition: box-shadow 400ms;
+}
+
+/* Elements in the 2nd column should have an opaque background as they overlap
+   others. */
+
+#report .summary-stats-table tr > td:nth-child(2) {
+    background: white;
+}
+
+#report .summary-stats-table tr > th:nth-child(2) {
+    background: #e0e0e0;
+}
 
 #report th.sort-button-group-wrapper {
     --btn-width: var(--button-m);
@@ -14,11 +68,11 @@
 
 .sort-button-group {
     position: absolute;
-    top: calc(-1 * var(--border-s));
-    bottom: 0;
+    top: 0;
+    bottom: var(--border-s);
     right: calc(-1 * var(--btn-group-width));
     left: 100%;
-    transform: translateX(calc(-1 * var(--btn-group-width) + var(--border-s)));
+    transform: translateX(calc(-1 * var(--btn-group-width)));
     display: flex;
     gap: 0px;
     padding: 0px;

--- a/skrub/_reporting/_data/templates/summary-statistics.html
+++ b/skrub/_reporting/_data/templates/summary-statistics.html
@@ -1,5 +1,5 @@
 {% macro th(name, ascending, descending, is_numeric) %}
-<th class="sort-button-group-wrapper" scope="col">
+<th class="sort-button-group-wrapper  {{ 'ellided' if name == 'Column name' }}" scope="col">
     {% if name %}
     <span class="margin-r-m">{{ name }}</span>
     {% endif %}
@@ -28,9 +28,11 @@
 {{ th(name, "from columns with " + low + " to columns with " + high, "from columns with " + high + " to columns with " + low, is_numeric) }}
 {% endmacro %}
 
-<article class="wrapper margin-t-s" data-show-on="NON_EMPTY_COLUMN_FILTER_SELECTED"
+<article class="wrapper relative margin-t-s" data-show-on="NON_EMPTY_COLUMN_FILTER_SELECTED"
     data-hide-on="EMPTY_COLUMN_FILTER_SELECTED">
-    <div class="horizontal-scroll">
+    <div class="horizontal-scroll"
+         data-manager="StickyColTableScroller"
+         data-sticky-col="2">
         <table class="pure-table pure-table-bordered summary-stats-table"
             data-manager="SortableTable">
             <thead>
@@ -54,7 +56,7 @@
                     data-dataframe-column-idx="{{ column.idx }}">
                     <td data-value="{{ loop.index0 }}" data-numeric>{{ loop.index0 }}
                     </td>
-                    <td>{{ column.name }}</td>
+                    <td class="ellided">{{ column.name }}</td>
                     <td>{{ column.dtype }}</td>
                     <td class="{{ column.nulls_level }}"
                         data-value="{{ column.null_count }}" data-numeric>


### PR DESCRIPTION
The column containing the column name in the summary statistics tab panel sticks on the left of the table, so that when we scroll horizontally we can still see (the end of) the column names