### PR TITLE
set color-scheme to only-light in table report

### DIFF
--- a/skrub/_reporting/_data/templates/base.css
+++ b/skrub/_reporting/_data/templates/base.css
@@ -64,7 +64,7 @@
 #report {
     background: white;
     color: black;
-    color-scheme: light;
+    color-scheme: only light;
     border-radius: var(--radius, 0);
     max-width: max-content;
 }


### PR DESCRIPTION
this is a small adjustment while we do not yet have a dark theme, it tells the browser to always use light-theme colors for the system ui elements (scrollbar etc). the reports are already usable regardless of the color scheme of the page and OS settings, this is just a cosmetic detail to avoid having a dark scrollbar on a light background eg in macos which looks weird