### PR TITLE
add missing changelog entry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,14 @@ Major changes
 Minor changes
 -------------
 
+* The TableReport now uses the font size of its parent element when inserted
+  into another page. This makes it smaller in pages that use a smaller font size
+  than the browser default such as VSCode in some configurations. It also makes
+  it easier to control its size when inserting it in a web page by setting the
+  font size of its parent element. A few other small adjustments have also been
+  made to make it a bit more compact. :pr:`1098` by :user:`Jérôme Dockès
+  <jeromedockes>`.
+
 * In the TableReport it is now possible, before clicking any of the cells, to
   reach the dataframe sample table and activate a cell with tab key navigation.
   :pr:`1101` by :user:`Jérôme Dockès <jeromedockes>`.


### PR DESCRIPTION
as mentioned in this [comment](https://github.com/skrub-data/skrub/pull/1098#issuecomment-2387959764) a previous pr was missing a changelog entry


ATM the bot only complaines about the changelog if some tests have been modified, which causes a few false negatives. shall we make it check the changelog for all PRs, given that silencing false positives is easy with the "changelog not needed" label?