### PR TITLE
make column filter select smaller in tablereport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Major changes
 Minor changes
 -------------
 
+* The column filter selection dropdown in the tablereport is smaller and its
+  label has been removed to save space. :pr:`1107` by :user:`Jérôme Dockès
+  <jeromedockes>`.
+
 * The TableReport now uses the font size of its parent element when inserted
   into another page. This makes it smaller in pages that use a smaller font size
   than the browser default such as VSCode in some configurations. It also makes

--- a/skrub/_reporting/_data/templates/column-filter.css
+++ b/skrub/_reporting/_data/templates/column-filter.css
@@ -4,11 +4,13 @@
     gap: var(--space-m);
     align-items: flex-end;
     margin-bottom: var(--space-s);
-    margin-left: var(--space-l);
+    margin-left: var(--space-m);
     margin-right: var(--space-s);
 }
 
-.column-filter > label {
-    padding: 0;
-    margin: 0;
+.column-filter > select {
+    max-width: 15ch;
+    text-overflow: ellipsis;
+    padding: 0 var(--border-s) 0 var(--space-s);
+    font-size: var(--text-s);
 }

--- a/skrub/_reporting/_data/templates/column-filter.html
+++ b/skrub/_reporting/_data/templates/column-filter.html
@@ -1,12 +1,14 @@
 <div class="column-filter" data-manager="InvisibleInAssociationsTabPanel">
-    <label for="column-filter-select">Show: </label>
     <select data-manager="ColumnFilter"
             data-all-filters-base64="{{ base64_column_filters | safe }}"
             data-test="column-filter-select"
             autocomplete="off">
+        <optgroup label="Select columns to show:">
+        <option value="all()" selected disabled hidden>Filter columns</option>
         {% for filter_name in column_filters %}
-        <option value="{{ filter_name }}" {{ "selected" if filter_name == "all()" }}>
+        <option value="{{ filter_name }}">
             {{ column_filters[filter_name]["display_name"] }}</option>
         {% endfor %}
+        </optgroup>
     </select>
 </div>

--- a/skrub/_reporting/_data/templates/tabs.css
+++ b/skrub/_reporting/_data/templates/tabs.css
@@ -8,7 +8,7 @@
 .tab-list-wrapper {
     align-items: flex-start;
     border-bottom: var(--border-s) solid var(--darkg);
-    column-gap: calc(2 * var(--base-size));
+    column-gap: calc(var(--space-xs));
     row-gap: var(--space-s);
 }
 

--- a/skrub/_reporting/_html.py
+++ b/skrub/_reporting/_html.py
@@ -17,19 +17,19 @@ from . import _utils
 _HIGH_ASSOCIATION_THRESHOLD = 0.9
 
 _FILTER_NAMES = {
-    "first_10": "First 10 columns",
-    "high_association": "Columns with high similarity",
+    "first_10": "First 10",
+    "high_association": "High similarity",
     "all()": "All columns",
-    "has_nulls()": "Columns with null values",
-    "(~has_nulls())": "Columns without null values",
-    "numeric()": "Numeric columns",
-    "(~numeric())": "Non-numeric columns",
-    "string()": "String columns",
-    "(~string())": "Non-string columns",
-    "categorical()": "Categorical columns",
-    "(~categorical())": "Non-categorical columns",
-    "any_date()": "Datetime columns",
-    "(~any_date())": "Non-datetime columns",
+    "has_nulls()": "With nulls",
+    "(~has_nulls())": "Without nulls",
+    "numeric()": "Numeric",
+    "(~numeric())": "Non-numeric",
+    "string()": "String",
+    "(~string())": "Non-string",
+    "categorical()": "Categorical",
+    "(~categorical())": "Non-categorical",
+    "any_date()": "Datetime",
+    "(~any_date())": "Non-datetime",
 }
 
 

--- a/skrub/_reporting/js_tests/cypress/e2e/column-filter.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/column-filter.cy.js
@@ -6,7 +6,7 @@ describe('test filtering visible columns', () => {
         cy.get('@report').find('[data-test="summaries-tab"]').as(
             'summariesTab').click();
         cy.get('@report').find('[data-test="column-filter-select"]')
-            .select('Numeric columns');
+            .select('Numeric');
         cy.get('@report').find('#col_7').should('be.visible');
         cy.get('@report').find('#col_0').should('not.be.visible');
         cy.get('@report').find('[data-test="sample-tab"]').as(
@@ -18,7 +18,7 @@ describe('test filtering visible columns', () => {
         cy.get('@nColumns').should('have.text', '1');
 
         cy.get('@report').find('[data-test="column-filter-select"]')
-            .select('Non-numeric columns');
+            .select('Non-numeric');
         cy.get('@cell7').should('not.be.visible');
         cy.get('@cell0').should('be.visible');
         cy.get('@nColumns').should('have.text', '7');
@@ -27,7 +27,7 @@ describe('test filtering visible columns', () => {
         cy.get('@report').find('#col_0').should('be.visible');
 
         cy.get('@report').find('[data-test="column-filter-select"]')
-            .select('Datetime columns');
+            .select('Datetime');
         cy.get('@report').find('[data-test="summaries-panel"]').find(
             '[data-test="show-all-columns-button"]').should(
             'be.visible');

--- a/skrub/_reporting/js_tests/cypress/e2e/column-summaries.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/column-summaries.cy.js
@@ -13,7 +13,7 @@ describe('test the column summaries', () => {
             "['department']");
 
         cy.get('@report').find('[data-test="column-filter-select"]')
-            .select('Numeric columns');
+            .select('Numeric');
         cy.get('@selectedColumns').should('have.text',
             "['department']");
         cy.get('@report').find('[data-test="select-all-columns"]')

--- a/skrub/_reporting/js_tests/cypress/e2e/dataframe-sample.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/dataframe-sample.cy.js
@@ -37,12 +37,12 @@ describe('test the dataframe sample tab', () => {
 
         cy.get('@report').find('[data-test="column-filter-select"]').as(
                 "filter")
-            .select('String columns');
+            .select('String');
         cy.get('@bar').should('be.visible');
         cy.get('@announcement').should('not.be.visible');
         cy.get('@bar').should('have.text', "department");
 
-        cy.get('@filter').select('Numeric columns');
+        cy.get('@filter').select('Numeric');
         cy.get('@bar').should('not.be.visible');
         cy.get('@announcement').should('be.visible');
         cy.get('@bar').should('have.text', "");
@@ -55,7 +55,7 @@ describe('test the dataframe sample tab', () => {
         // hide the numeric columns
         cy.get('@report').find('[data-test="column-filter-select"]').as(
                 "filter")
-            .select('String columns');
+            .select('String');
 
         // type arrow down on the first header should move to first cell
         cy.get('@report').find('th').contains('c 1').as('c1').click();

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -19,8 +19,8 @@ def test_report(air_quality):
     report = TableReport(air_quality, title="the title", column_filters=col_filt)
     html = report.html()
     assert "the title" in html
-    assert "Columns with null values" in html
-    assert "First 10 columns" in html
+    assert "With nulls" in html
+    assert "First 10" in html
     assert "First 2" in html
     for col_name in sbd.column_names(air_quality):
         assert col_name in html


### PR DESCRIPTION
reduces the width and height of the column filter in the tablereport. it is a little less obvious what it does now but the upside is there is a smaller chance that it needs to wrap to a different line than the tabs