### PR TITLE
add functions to patch the _repr_html_ of pandas & polars dataframes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,16 +12,19 @@ Ongoing development
 Skrub is a very recent package.
 It is currently undergoing fast development and backward compatibility is not ensured.
 
-Major changes
--------------
-
-Minor changes
--------------
+New features
+------------
 
 * The :func:`patch_display` function has been added. It changes the display of
   pandas and polars dataframes in jupyter notebooks to replace them with a
   :class:`TableReport`. This can be undone with :func:`unpatch_display`.
   :pr:`1108` by :user:`Jérôme Dockès <jeromedockes>`
+
+Major changes
+-------------
+
+Minor changes
+-------------
 
 * The column filter selection dropdown in the tablereport is smaller and its
   label has been removed to save space. :pr:`1107` by :user:`Jérôme Dockès

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Major changes
 Minor changes
 -------------
 
+* The :func:`patch_display` function has been added. It changes the display of
+  pandas and polars dataframes in jupyter notebooks to replace them with a
+  :class:`TableReport`. This can be undone with :func:`unpatch_display`.
+  :pr:`1108` by :user:`Jérôme Dockès <jeromedockes>`
+
 * The column filter selection dropdown in the tablereport is smaller and its
   label has been removed to save space. :pr:`1107` by :user:`Jérôme Dockès
   <jeromedockes>`.

--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -53,6 +53,18 @@ TableReport(employees_df)
 #    .. _example reports: https://skrub-data.org/skrub-reports/examples/
 #    .. _demo: https://skrub-data.org/skrub-reports/
 
+# %%
+# It is also possible to tell skrub to replace the default pandas & polars
+# displays with ``TableReport``.
+
+from skrub import patch_display
+
+patch_display()
+
+employees_df
+
+# %%
+# The effect of ``patch_display`` can be undone with ``skrub.unpatch_display()``
 
 # %%
 # Easily building a strong baseline for tabular machine learning

--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -57,7 +57,7 @@ TableReport(employees_df)
 # It is also possible to tell skrub to replace the default pandas & polars
 # displays with ``TableReport``.
 
-from skrub import patch_display
+from skrub import patch_display, unpatch_display
 
 patch_display()
 
@@ -65,6 +65,8 @@ employees_df
 
 # %%
 # The effect of ``patch_display`` can be undone with ``skrub.unpatch_display()``
+
+unpatch_display()
 
 # %%
 # Easily building a strong baseline for tabular machine learning

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -13,7 +13,7 @@ from ._interpolation_joiner import InterpolationJoiner
 from ._joiner import Joiner
 from ._minhash_encoder import MinHashEncoder
 from ._multi_agg_joiner import MultiAggJoiner
-from ._reporting import TableReport
+from ._reporting import TableReport, patch_display, unpatch_display
 from ._select_cols import DropCols, SelectCols
 from ._similarity_encoder import SimilarityEncoder
 from ._table_vectorizer import TableVectorizer
@@ -29,6 +29,8 @@ with open(_Path(__file__).parent / "VERSION.txt") as _fh:
 
 __all__ = [
     "TableReport",
+    "patch_display",
+    "unpatch_display",
     "tabular_learner",
     "DatetimeEncoder",
     "ToDatetime",

--- a/skrub/_reporting/__init__.py
+++ b/skrub/_reporting/__init__.py
@@ -1,5 +1,6 @@
 """Summarize the contents of a dataframe and generate an HTML report."""
 
+from ._patching import patch_display, unpatch_display
 from ._table_report import TableReport
 
-__all__ = ["TableReport"]
+__all__ = ["TableReport", "patch_display", "unpatch_display"]

--- a/skrub/_reporting/_patching.py
+++ b/skrub/_reporting/_patching.py
@@ -1,0 +1,83 @@
+import importlib
+
+from . import TableReport
+
+__all__ = ["patch_display", "unpatch_display"]
+
+_METHODS_TO_PATCH = ["_repr_mimebundle_", "_repr_html_"]
+
+
+def _stashed_name(method_name):
+    return f"_skrub_{method_name}"
+
+
+def _patch(cls, method_name):
+    if (original_method := getattr(cls, method_name, None)) is None:
+        return
+    stashed_name = _stashed_name(method_name)
+    if not hasattr(cls, stashed_name):
+        setattr(cls, stashed_name, original_method)
+    setattr(cls, method_name, lambda df: getattr(TableReport(df), method_name)())
+
+
+def _unpatch(cls, method_name):
+    stashed_name = _stashed_name(method_name)
+    if (original_method := getattr(cls, stashed_name, None)) is None:
+        return
+    setattr(cls, method_name, original_method)
+
+
+def _change_display(transform, to_patch):
+    for module_name, class_names in to_patch:
+        try:
+            mod = importlib.import_module(module_name)
+        except ImportError:
+            continue
+        for cls_name in class_names:
+            cls = getattr(mod, cls_name)
+            for method_name in _METHODS_TO_PATCH:
+                transform(cls, method_name)
+
+
+def _get_to_patch(pandas, polars):
+    to_patch = []
+    if pandas:
+        to_patch.append(("pandas", ["DataFrame"]))
+    if polars:
+        to_patch.append(("polars", ["DataFrame"]))
+    return to_patch
+
+
+def patch_display(pandas=True, polars=True):
+    """Replace the default DataFrame HTML displays with ``skrub.TableReport``.
+
+    This function replaces the HTML displays (what is shown when an object is
+    the output of a jupyter notebook cell) of pandas and polars DataFrames
+    with a TableReport.
+
+    It can be undone with ``skrub.unpatch_display()``.
+
+    Parameters
+    ----------
+    pandas: bool, optional (default=True)
+        If False, do not override the displays for pandas dataframes.
+    polars: bool, optional (default=True)
+        If False, do not override the displays for polars dataframes.
+    """
+    _change_display(_patch, _get_to_patch(pandas=pandas, polars=polars))
+
+
+def unpatch_display(pandas=True, polars=True):
+    """Undo the effect of ``skrub.patch_display()``.
+
+    This function restores the default HTML displays of pandas and polars
+    DataFrames.
+
+    Parameters
+    ----------
+    pandas: bool, optional (default=True)
+        If False, do not restore the displays for pandas dataframes.
+    polars: bool, optional (default=True)
+        If False, do not restore the displays for polars dataframes.
+    """
+    _change_display(_unpatch, _get_to_patch(pandas=pandas, polars=polars))

--- a/skrub/_reporting/_patching.py
+++ b/skrub/_reporting/_patching.py
@@ -1,6 +1,6 @@
 import importlib
 
-from . import TableReport
+from ._table_report import TableReport
 
 __all__ = ["patch_display", "unpatch_display"]
 

--- a/skrub/_reporting/_patching.py
+++ b/skrub/_reporting/_patching.py
@@ -63,6 +63,14 @@ def patch_display(pandas=True, polars=True):
         If False, do not override the displays for pandas dataframes.
     polars : bool, optional (default=True)
         If False, do not override the displays for polars dataframes.
+
+    See Also
+    --------
+    unpatch_display :
+        Undo the change made by this function.
+
+    TableReport :
+        Directly create a report from a dataframe.
     """
     _change_display(_patch, _get_to_patch(pandas=pandas, polars=polars))
 
@@ -79,5 +87,13 @@ def unpatch_display(pandas=True, polars=True):
         If False, do not restore the displays for pandas dataframes.
     polars : bool, optional (default=True)
         If False, do not restore the displays for polars dataframes.
+
+    See Also
+    --------
+    patch_display :
+        Replace the default dataframe display with a TableReport.
+
+    TableReport :
+        Directly create a report from a dataframe.
     """
     _change_display(_unpatch, _get_to_patch(pandas=pandas, polars=polars))

--- a/skrub/_reporting/_patching.py
+++ b/skrub/_reporting/_patching.py
@@ -59,9 +59,9 @@ def patch_display(pandas=True, polars=True):
 
     Parameters
     ----------
-    pandas: bool, optional (default=True)
+    pandas : bool, optional (default=True)
         If False, do not override the displays for pandas dataframes.
-    polars: bool, optional (default=True)
+    polars : bool, optional (default=True)
         If False, do not override the displays for polars dataframes.
     """
     _change_display(_patch, _get_to_patch(pandas=pandas, polars=polars))
@@ -75,9 +75,9 @@ def unpatch_display(pandas=True, polars=True):
 
     Parameters
     ----------
-    pandas: bool, optional (default=True)
+    pandas : bool, optional (default=True)
         If False, do not restore the displays for pandas dataframes.
-    polars: bool, optional (default=True)
+    polars : bool, optional (default=True)
         If False, do not restore the displays for polars dataframes.
     """
     _change_display(_unpatch, _get_to_patch(pandas=pandas, polars=polars))

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -45,6 +45,12 @@ class TableReport:
     .. _example reports: https://skrub-data.org/skrub-reports/examples/
     .. _demo: https://skrub-data.org/skrub-reports/
 
+    See Also
+    --------
+    patch_display :
+        Replace the default DataFrame HTML displays in the output of notebook
+        cells with a TableReport.
+
     Examples
     --------
     >>> import pandas as pd

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -36,6 +36,12 @@ class TableReport:
         e.g. ``"First 10 columns"``) and ``columns`` (a list of column names).
         See the end of the "Examples" section below for details.
 
+    See Also
+    --------
+    patch_display :
+        Replace the default DataFrame HTML displays in the output of notebook
+        cells with a TableReport.
+
     Notes
     -----
     You can see some `example reports`_ for a few datasets online. We also
@@ -44,12 +50,6 @@ class TableReport:
 
     .. _example reports: https://skrub-data.org/skrub-reports/examples/
     .. _demo: https://skrub-data.org/skrub-reports/
-
-    See Also
-    --------
-    patch_display :
-        Replace the default DataFrame HTML displays in the output of notebook
-        cells with a TableReport.
 
     Examples
     --------

--- a/skrub/_reporting/tests/test_patch_display.py
+++ b/skrub/_reporting/tests/test_patch_display.py
@@ -1,17 +1,27 @@
+import pickle
+
+import pytest
+
 from skrub import patch_display, unpatch_display
 
 
-def test_patch_display(df_module):
+@pytest.mark.parametrize("repeat_patch", [1, 2])
+@pytest.mark.parametrize("repeat_unpatch", [1, 2])
+def test_patch_display(df_module, repeat_patch, repeat_unpatch):
     df = df_module.example_dataframe
     assert "<table" in df._repr_html_()
     assert "<skrub-table-report" not in df._repr_html_()
     patch_display(pandas=False, polars=False)
     assert "<table" in df._repr_html_()
     assert "<skrub-table-report" not in df._repr_html_()
-    patch_display()
+    for _ in range(repeat_patch):
+        patch_display()
     try:
         assert "<skrub-table-report" in df._repr_html_()
+        pickle.loads(pickle.dumps(df))
     finally:
-        unpatch_display()
+        for _ in range(repeat_unpatch):
+            unpatch_display()
+    pickle.loads(pickle.dumps(df))
     assert "<table" in df._repr_html_()
     assert "<skrub-table-report" not in df._repr_html_()

--- a/skrub/_reporting/tests/test_patch_display.py
+++ b/skrub/_reporting/tests/test_patch_display.py
@@ -1,0 +1,17 @@
+from skrub import patch_display, unpatch_display
+
+
+def test_patch_display(df_module):
+    df = df_module.example_dataframe
+    assert "<table" in df._repr_html_()
+    assert "<skrub-table-report" not in df._repr_html_()
+    patch_display(pandas=False, polars=False)
+    assert "<table" in df._repr_html_()
+    assert "<skrub-table-report" not in df._repr_html_()
+    patch_display()
+    try:
+        assert "<skrub-table-report" in df._repr_html_()
+    finally:
+        unpatch_display()
+    assert "<table" in df._repr_html_()
+    assert "<skrub-table-report" not in df._repr_html_()


### PR DESCRIPTION
With 

```python
skrub.patch_display()
```

the default HTML representations of pandas & polars dataframes are replaced with TableReports

it can be undone with

```python
skrub.unpatch_display()
```

`patch_display` can be called before or after importing the libraries (it will import them if they are installed but not imported yet. as this is only useful for interactive work I don't think it is a problem)

still need to add tests & an example but first I would like opinions on whether we actually want something like this or not

TODO:
- [x] changelog
- [x] tests
- [ ] use in more examples?
- [x] mention in tablereport docstring
- [ ] the drawback is it is slower than the default displays. Limit the number of columns for which we create plots?



[Example](https://output.circle-artifacts.com/output/job/88bb3835-6978-4982-b198-bafef2e78783/artifacts/0/doc/auto_examples/00_getting_started.html#generating-an-interactive-report-for-a-dataframe)