### PR TITLE
add column_associations public function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,11 @@ Minor changes
   is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
   Dockès <jeromedockes>`.
 
+* The :func:`column_associations` function has been added. It computes a
+  pairwise measure of statistical dependence between all columns in a dataframe
+  (the same as shown in the :class:`TableReport`). :pr:`1109` by :user:`Jérôme
+  Dockès <jeromedockes>`.
+
 Release 0.3.1
 =============
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,14 @@ Ongoing development
 Skrub is a very recent package.
 It is currently undergoing fast development and backward compatibility is not ensured.
 
+New features
+------------
+
+* The :func:`column_associations` function has been added. It computes a
+  pairwise measure of statistical dependence between all columns in a dataframe
+  (the same as shown in the :class:`TableReport`). :pr:`1109` by :user:`Jérôme
+  Dockès <jeromedockes>`.
+
 Major changes
 -------------
 
@@ -46,11 +54,6 @@ Minor changes
 
 * The "Column name" column of the "summary statistics" table in the TableReport
   is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
-  Dockès <jeromedockes>`.
-
-* The :func:`column_associations` function has been added. It computes a
-  pairwise measure of statistical dependence between all columns in a dataframe
-  (the same as shown in the :class:`TableReport`). :pr:`1109` by :user:`Jérôme
   Dockès <jeromedockes>`.
 
 Release 0.3.1

--- a/doc/reference/generating_a_report.rst
+++ b/doc/reference/generating_a_report.rst
@@ -19,3 +19,4 @@ Generating an HTML report
 
    patch_display
    unpatch_display
+   column_associations

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path as _Path
 
 from ._agg_joiner import AggJoiner, AggTarget
 from ._check_dependencies import check_dependencies
+from ._column_associations import column_associations
 from ._datetime_encoder import DatetimeEncoder
 from ._deduplicate import compute_ngram_distance, deduplicate
 from ._fuzzy_join import fuzzy_join
@@ -48,4 +49,5 @@ __all__ = [
     "AggTarget",
     "SelectCols",
     "DropCols",
+    "column_associations",
 ]

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -6,15 +6,16 @@ import pandas as pd
 import pytest
 import zoneinfo
 
+from skrub import _column_associations
 from skrub import _dataframe as sbd
-from skrub._reporting import _associations, _sample_table
+from skrub._reporting import _sample_table
 from skrub._reporting._summarize import summarize_dataframe
 
 
 @pytest.mark.parametrize("order_by", [None, "date.utc", "value"])
 @pytest.mark.parametrize("with_plots", [False, True])
 def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
-    monkeypatch.setattr(_associations, "_CATEGORICAL_THRESHOLD", 10)
+    monkeypatch.setattr(_column_associations, "_CATEGORICAL_THRESHOLD", 10)
     summary = summarize_dataframe(
         air_quality, with_plots=with_plots, order_by=order_by, title="the title"
     )

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
 from skrub import column_associations
 
 
@@ -13,19 +12,10 @@ def test_column_associations(df_module):
     df = df_module.make_dataframe(dict(x=x, y=y, z=z))
     asso = column_associations(df)
     asso = sbd.pandas_convert_dtypes(asso)
-    df_module.assert_frame_equal(
-        s.select(asso, sbd.column_names(asso)[:-1]),
-        sbd.pandas_convert_dtypes(
-            df_module.make_dataframe(
-                {
-                    "left_column_name": ["x", "y", "x"],
-                    "left_column_idx": [0, 1, 0],
-                    "right_column_name": ["y", "z", "z"],
-                    "right_column_idx": [1, 2, 2],
-                }
-            )
-        ),
-    )
+    assert sbd.to_list(sbd.col(asso, "left_column_name")) == ["x", "y", "x"]
+    assert sbd.to_list(sbd.col(asso, "left_column_idx")) == [0, 1, 0]
+    assert sbd.to_list(sbd.col(asso, "right_column_name")) == ["y", "z", "z"]
+    assert sbd.to_list(sbd.col(asso, "right_column_idx")) == [1, 2, 2]
     assert sbd.to_list(sbd.col(asso, "cramer_v")) == pytest.approx(
         [1.0, 0.6546536, 0.6546536]
     )

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from skrub import _dataframe as sbd
+from skrub import _selectors as s
+from skrub import column_associations
+
+
+def test_column_associations(df_module):
+    x = (np.ones((7, 3)) * np.arange(3)).ravel()
+    y = 2 - 3 * x
+    z = np.arange(len(x))
+    df = df_module.make_dataframe(dict(x=x, y=y, z=z))
+    asso = column_associations(df)
+    asso = sbd.pandas_convert_dtypes(asso)
+    df_module.assert_frame_equal(
+        s.select(asso, sbd.column_names(asso)[:-1]),
+        sbd.pandas_convert_dtypes(
+            df_module.make_dataframe(
+                {
+                    "left_column_name": ["x", "y", "x"],
+                    "left_column_idx": [0, 1, 0],
+                    "right_column_name": ["y", "z", "z"],
+                    "right_column_idx": [1, 2, 2],
+                }
+            )
+        ),
+    )
+    assert sbd.to_list(sbd.col(asso, "cramer_v")) == pytest.approx(
+        [1.0, 0.6546536, 0.6546536]
+    )


### PR DESCRIPTION
adds `column_associations` (the function that computes the pairwise cramer v stats shown in the tablereport) as a function accessible in the public api