### PR TITLE
drop nulls before plotting histogram

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,10 @@ Minor changes
   is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
   Dockès <jeromedockes>`.
 
+* The :class:`TableReport` could raise an exception when one of the columns
+  contained datetimes with time zones and missing values; this has been fixed in
+  :pr:`1114` by :user:`Jérôme Dockès <jeromedockes>`.
+
 Release 0.3.1
 =============
 

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -117,6 +117,7 @@ def _adjust_fig_size(fig, ax, target_w, target_h):
 @_plot
 def histogram(col, color=COLOR_0):
     """Histogram for a numeric column."""
+    col = sbd.drop_nulls(col)
     values = sbd.to_numpy(col)
     fig, ax = plt.subplots()
     _despine(ax)

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -1,7 +1,7 @@
 import json
 import re
 
-from skrub import TableReport
+from skrub import TableReport, ToDatetime
 from skrub import _dataframe as sbd
 
 
@@ -81,3 +81,15 @@ def test_non_hashable_values(df_module):
     df = df_module.make_dataframe(dict(a=[[1, 2, 3], None, [4]]))
     html = TableReport(df).html()
     assert "[1, 2, 3]" in html
+
+
+def test_nat(df_module):
+    # non-regression for:
+    # https://github.com/skrub-data/skrub/issues/1111
+    # NaT used to cause exception when plotting histogram
+    col = df_module.make_column(
+        "a", ["2020-01-01T01:00:00 UTC", "2020-01-02T01:00:00 UTC", None]
+    )
+    col = ToDatetime().fit_transform(col)
+    df = df_module.make_dataframe({"a": col})
+    TableReport(df).html()


### PR DESCRIPTION
fixes #1111 

all nulls are dropped before building the histogram, they are never useful for this plot anyway