### PR TITLE
DOC: Add patch_display to the API docs

### DIFF
--- a/doc/reference/generating_a_report.rst
+++ b/doc/reference/generating_a_report.rst
@@ -19,4 +19,3 @@ Generating an HTML report
 
    patch_display
    unpatch_display
-

--- a/doc/reference/generating_a_report.rst
+++ b/doc/reference/generating_a_report.rst
@@ -11,3 +11,12 @@ Generating an HTML report
    :nosignatures:
 
    TableReport
+
+.. autosummary::
+   :toctree: generated/
+   :template: base.rst
+   :nosignatures:
+
+   patch_display
+   unpatch_display
+


### PR DESCRIPTION
As well as the corresponding function unpatch_display

This is important also to get to work all the ":func:" references (including those added automatically to the docs)