### PR TITLE
fix regression with set_output in scikit-learn < 1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,9 +56,16 @@ Minor changes
   is now always visible when scrolling the table. :pr:`1102` by :user:`Jérôme
   Dockès <jeromedockes>`.
 
+Bug fixes
+---------
+
 * The :class:`TableReport` could raise an exception when one of the columns
   contained datetimes with time zones and missing values; this has been fixed in
   :pr:`1114` by :user:`Jérôme Dockès <jeromedockes>`.
+
+* In scikit-learn versions older than 1.4 the :class:`TableVectorizer` could
+  fail on polars dataframes when used with the default parameters. This has been
+  fixed in :pr:`1122` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Release 0.3.1
 =============

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -196,6 +196,8 @@ def set_output(transformer, X):
         "1.4"
     ):
         # TODO: remove when scikit-learn 1.3 support is dropped.
+        target_module = "pandas"
+    else:
         target_module = module_name
     try:
         transformer.set_output(transform=target_module)

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -191,7 +191,6 @@ def set_output(transformer, X):
     if not hasattr(transformer, "set_output"):
         return
     module_name = sbd.dataframe_module_name(X)
-    target_module = module_name
     if module_name == "polars" and parse_version(sklearn.__version__) < parse_version(
         "1.4"
     ):

--- a/skrub/tests/test_on_each_column.py
+++ b/skrub/tests/test_on_each_column.py
@@ -306,5 +306,6 @@ def test_output_index(cols):
 def test_set_output_polars(pl_module):
     # non-regression for an issue introduced in #973; set_output('polars')
     # would cause a failure in old scikit-learn versions.
+    # see #1122 for details
     df = pl_module.make_dataframe({"x": ["a", "b", "c"]})
     OnEachColumn(OneHotEncoder(sparse_output=False)).fit_transform(df)

--- a/skrub/tests/test_on_each_column.py
+++ b/skrub/tests/test_on_each_column.py
@@ -6,6 +6,7 @@ import pytest
 from pandas.testing import assert_index_equal
 from sklearn.base import BaseEstimator
 from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import OneHotEncoder
 
 from skrub import _dataframe as sbd
 from skrub import _selectors as s
@@ -300,3 +301,10 @@ def test_output_index(cols):
     assert_index_equal(transformer.fit_transform(df).index, df.index)
     df = pd.DataFrame({"a": [10, 20], "b": [1.1, 2.2]}, index=[-10, 20])
     assert_index_equal(transformer.transform(df).index, df.index)
+
+
+def test_set_output_polars(pl_module):
+    # non-regression for an issue introduced in #973; set_output('polars')
+    # would cause a failure in old scikit-learn versions.
+    df = pl_module.make_dataframe({"x": ["a", "b", "c"]})
+    OnEachColumn(OneHotEncoder(sparse_output=False)).fit_transform(df)


### PR DESCRIPTION
OnEachColumn, when its transformer is a scikit-learn transformer exposing set_output, calls set_output('pandas') or set_output('polars') to get the output in the correct dataframe.

in old scikit-learn versions, set_output('polars') is not supported, so OnEachColumn does set_output('pandas') and later does the conversion itself with `polars.from_pandas`.

or at least it's supposed to -- when doing a small change in #973 to handle possible exceptions raised by set_output I forgot to copy the "else" part of the "if scikit-learn < 1.4" block so now it is always using "polars" even in scikit-learn versions that don't support it.

this pr fixes the regression