### PR TITLE
Faster svg viewbox computation in tablereport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,8 @@ Minor changes
   Moreover, when the text contains line breaks it now appears all on one line.
   Note this only affects the labels in the plots; the rest of the report did not
   have these problems.
-  :pr:`1097` by :user:`Jérôme Dockès <jeromedockes>`.
+  :pr:`1097` by :user:`Jérôme Dockès <jeromedockes>`
+  and :pr:`1138` by :user:`Jérôme Dockès <jeromedockes>`.
 
 * In the TableReport it is now possible, before clicking any of the cells, to
   reach the dataframe sample table and activate a cell with tab key navigation.

--- a/examples/08_join_aggregation.py
+++ b/examples/08_join_aggregation.py
@@ -6,6 +6,7 @@ Many problems involve tables whose entities have a one-to-many relationship.
 To simplify aggregate-then-join operations for machine learning, we can include
 the |AggJoiner| in our pipeline.
 
+
 In this example, we are tackling a fraudulent loan detection use case.
 Because fraud is rare, this dataset is extremely imbalanced, with a prevalence of around
 1.4%.

--- a/skrub/_reporting/_data/templates/buttons.html
+++ b/skrub/_reporting/_data/templates/buttons.html
@@ -1,8 +1,8 @@
 {% macro copybutton(target) %}
 <button
     class="copybutton copybutton-left"
+    data-manager="CopyButton"
     type="button"
-    onclick="copyButtonClick(event)"
     data-target-id="{{ target }}">
     {% include "icons/copy.svg" %}
     {% include "icons/check-lg.svg" %}

--- a/skrub/_reporting/_data/templates/column-summary.html
+++ b/skrub/_reporting/_data/templates/column-summary.html
@@ -79,7 +79,7 @@
 
         {% for plot_name in column.plot_names %}
         <div>
-            <div class="margin-t-m" data-manager="SvgAdjustedViewBox">
+            <div class="margin-t-m" data-svg-needs-adjust-viewbox>
                 {{ column[plot_name] | safe }}
             </div>
             {% if plot_name == "value_counts_plot" %}

--- a/skrub/_reporting/_data/templates/report.html
+++ b/skrub/_reporting/_data/templates/report.html
@@ -23,11 +23,8 @@
     <skrub-table-report class="report" id="{{ report_id }}">
     </skrub-table-report>
 
-    <script>
+    <script type="module">
      {% include "report.js" %}
-    </script>
-    <script>
-     setTimeout(() => {initReport("{{ report_id }}");});
     </script>
 </div>
 


### PR DESCRIPTION
The way the computation of the correct viewbox for the plots is done currently is slow when there are many columns.
This makes all the bounding box computation in one go with no changes to the document in between to avoid unnecessary recomputations of the styles and layout

also as it adds a few functions to the report code, now is a good time to put it in a module to avoid polluting the global namespace so this PR adds that too