### PR TITLE
fix histogram plot failure on float('inf')

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,7 +96,7 @@ Bug fixes
 
 * The :class:`TableReport` would raise an exception when a column contained
   infinite values. This has been fixed in :pr:`1150` by :user:`Jérôme Dockès
-  <jeromedockes>`.
+  <jeromedockes>` and :pr:`1151` by Jérôme Dockès.
 
 Release 0.3.1
 =============

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -9,6 +9,7 @@ import re
 import warnings
 
 import matplotlib
+import numpy as np
 from matplotlib import pyplot as plt
 
 from skrub import _dataframe as sbd
@@ -119,6 +120,7 @@ def histogram(col, color=COLOR_0):
     """Histogram for a numeric column."""
     col = sbd.drop_nulls(col)
     values = sbd.to_numpy(col)
+    values = values[np.isfinite(values)]
     fig, ax = plt.subplots()
     _despine(ax)
     ax.hist(values, color=color)

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -119,6 +119,11 @@ def _adjust_fig_size(fig, ax, target_w, target_h):
 def histogram(col, color=COLOR_0):
     """Histogram for a numeric column."""
     col = sbd.drop_nulls(col)
+    if sbd.is_float(col):
+        # avoid any issues with pandas nullable dtypes
+        # (to_numpy can yield a numpy array with object dtype in old pandas
+        # version if there are inf or nan)
+        col = sbd.to_float32(col)
     values = sbd.to_numpy(col)
     if np.issubdtype(values.dtype, np.floating):
         values = values[np.isfinite(values)]

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -120,7 +120,8 @@ def histogram(col, color=COLOR_0):
     """Histogram for a numeric column."""
     col = sbd.drop_nulls(col)
     values = sbd.to_numpy(col)
-    values = values[np.isfinite(values)]
+    if np.issubdtype(values.dtype, np.floating):
+        values = values[np.isfinite(values)]
     fig, ax = plt.subplots()
     _despine(ax)
     ax.hist(values, color=color)

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -1,5 +1,6 @@
 import json
 import re
+import warnings
 
 from skrub import TableReport, ToDatetime
 from skrub import _dataframe as sbd
@@ -98,4 +99,17 @@ def test_nat(df_module):
 def test_duplicate_columns(pd_module):
     df = pd_module.make_dataframe({"a": [1, 2], "b": [3, 4]})
     df.columns = ["a", "a"]
+    TableReport(df).html()
+
+
+def test_infinite_values(df_module):
+    # Non-regression for https://github.com/skrub-data/skrub/issues/1134
+    # (histogram plot failing with infinite values)
+    with warnings.catch_warnings():
+        # convert_dtypes() emits spurious warning while deciding whether to cast to int
+        warnings.filterwarnings("ignore", message="invalid value encountered in cast")
+        df = df_module.make_dataframe(
+            dict(a=[float("inf"), 1.0, 2.0], b=[0.0, 1.0, 2.0])
+        )
+
     TableReport(df).html()


### PR DESCRIPTION
fixes #1134 

this is a quick fix for #1134 

later we can improve handling of infinite or very large values by

- excluding them from the computation of summary statistics (?)
- excluding them while setting the bounds of the shown histograms to avoid unhelpful histograms with only one bar

however this requires taking care to make sure that the user realizes those outliers have been discarded so may take a bit more discussion. So I suggest we avoid crashing for now so that the release 0.3.2 does not depend on solving these more subtle choices