### PR TITLE
better handling of timedelta in tablereport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Minor changes
 * Added a `DropColumnIfNull` transformer that drops columns that contain only null
   values. :pr:`1115` by :user: `Riccardo Cappuzzo <riccardocappuzzo>`
 
+* The :class:`TableReport` now provides more helpful output for columns of dtype
+  TimeDelta / Duration. :pr:`1152` by :user:`Jérôme Dockès <jeromedockes>`.
+
 Bug fixes
 ---------
 

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -106,7 +106,9 @@ def _onehot_encode(df, n_bins):
     output = np.zeros((n_cols, n_bins, n_rows), dtype=bool)
     for col_idx in range(n_cols):
         col = sbd.col_by_idx(df, col_idx)
-        if sbd.is_numeric(col):
+        if sbd.is_duration(col):
+            col = sbd.total_seconds(col)
+        if sbd.is_numeric(col) or sbd.is_any_date(col):
             col = sbd.to_float32(col)
             if _CATEGORICAL_THRESHOLD <= sbd.n_unique(col):
                 _onehot_encode_numbers(sbd.to_numpy(col), n_bins, output[col_idx])

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -72,6 +72,7 @@ __all__ = [
     "is_pandas_object",
     "is_any_date",
     "to_datetime",
+    "is_duration",
     "is_categorical",
     "to_categorical",
     "is_all_null",
@@ -101,6 +102,8 @@ __all__ = [
     "slice",
     "replace",
     "with_columns",
+    "abs",
+    "total_seconds",
 ]
 
 #
@@ -810,6 +813,21 @@ def _to_datetime_polars(col, format, strict=True):
 
 
 @dispatch
+def is_duration(col):
+    raise NotImplementedError()
+
+
+@is_duration.specialize("pandas", argument_type="Column")
+def _is_duration_pandas(col):
+    return pd.api.types.is_timedelta64_dtype(col)
+
+
+@is_duration.specialize("polars", argument_type="Column")
+def _is_duration_polars(col):
+    return col.dtype == pl.Duration
+
+
+@dispatch
 def is_categorical(col):
     raise NotImplementedError()
 
@@ -1226,3 +1244,33 @@ def with_columns(df, **new_cols):
     cols = {col_name: col(df, col_name) for col_name in column_names(df)}
     cols.update({n: make_column_like(df, c, n) for n, c in new_cols.items()})
     return make_dataframe_like(df, cols)
+
+
+@dispatch
+def abs(col):
+    raise NotImplementedError()
+
+
+@abs.specialize("pandas", argument_type="Column")
+def _abs_pandas(col):
+    return col.abs()
+
+
+@abs.specialize("polars", argument_type="Column")
+def _abs_polars(col):
+    return col.abs()
+
+
+@dispatch
+def total_seconds(col):
+    raise NotImplementedError()
+
+
+@total_seconds.specialize("pandas")
+def _total_seconds_pandas(col):
+    return col.dt.total_seconds()
+
+
+@total_seconds.specialize("polars")
+def _total_seconds_polars(col):
+    return col.dt.total_seconds()

--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -1273,4 +1273,4 @@ def _total_seconds_pandas(col):
 
 @total_seconds.specialize("polars")
 def _total_seconds_polars(col):
-    return col.dt.total_seconds()
+    return col.dt.total_microseconds().cast(float) * 1e-6

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -6,7 +6,7 @@ in ``skrub.conftest``. See the corresponding docstrings for details.
 import inspect
 import re
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 
 import numpy as np
@@ -515,6 +515,14 @@ def test_to_datetime(df_module):
     assert str(dt[0]) == "2020-01-01 02:00:00+00:00"
 
 
+def test_is_duration(df_module):
+    df = df_module.make_dataframe(
+        {"a": [timedelta(days=1)], "b": [datetime(2020, 3, 4)]}
+    )
+    assert ns.is_duration(ns.col(df, "a"))
+    assert not ns.is_duration(ns.col(df, "b"))
+
+
 def test_is_categorical(df_module):
     if df_module.name == "pandas":
         import pandas as pd
@@ -845,3 +853,15 @@ def test_with_columns(df_module):
         out = ns.pandas_convert_dtypes(out)
     expected = df_module.make_dataframe({"a": [5, 6], "b": [3, 4]})
     df_module.assert_frame_equal(out, expected)
+
+
+def test_abs(df_module):
+    s = df_module.make_column("", [-1.0, 2.0, None])
+    df_module.assert_column_equal(
+        ns.abs(s), df_module.make_column("", [1.0, 2.0, None])
+    )
+
+
+def test_total_seconds(df_module):
+    s = df_module.make_column("", [timedelta(seconds=20), timedelta(hours=1)])
+    assert ns.to_list(ns.total_seconds(s)) == [20, 3600]

--- a/skrub/_reporting/_data/templates/column-summary.html
+++ b/skrub/_reporting/_data/templates/column-summary.html
@@ -31,28 +31,39 @@
                 <dt>Unique values</dt>
                 <dd>{{ column.n_unique | format_number }} ({{ column.unique_proportion | format_percent }})</dd>
                 {% endif %}
+
+                {% if column["duration_unit"] %}
+                {% set unit = " {}s".format(column['duration_unit']) %}
+                {% else %}
+                {% set unit = "" %}
+                {% endif %}
+
                 {% if "mean" in column %}
                 <dt>Mean ± Std</dt>
                 <dd>{{ column["mean"] | format_number }} ±
                     {{ column["standard_deviation"] | format_number }}
+                    {{ unit }}
                 </dd>
                 {% endif %}
                 {% if column.quantiles %}
                 <dt>Median ± IQR</dt>
                 <dd>{{ column.quantiles[0.5] | format_number }} ±
                     {{ column["inter_quartile_range"] | format_number}}
+                    {{ unit }}
                 </dd>
 
                 <dt>Min | Max</dt>
                 <dd>
                     {{ column.quantiles[0.0] | format_number }} |
                     {{ column.quantiles[1.0] | format_number }}
+                    {{ unit }}
                 </dd>
                 {% elif "min" in column %}
                 <dt>Min | Max</dt>
                 <dd>
                     {{ column.min | format_number }} |
                     {{ column.max | format_number }}
+                    {{ unit }}
                 </dd>
                 {% endif %}
                 {% endif %}
@@ -70,7 +81,8 @@
             <strong>Constant value:</strong>
             <div class="copybutton-grid">
                 <div class="box">
-                    <pre id="{{ val_id }}">{{ column.constant_value }}</pre>
+                    <pre id="{{ val_id }}"
+                         data-copy-text="{{ column.constant_value.__repr__() }}">{{ column.constant_value }}</pre>
                     {{ buttons.copybutton(val_id) }}
                 </div>
             </div>

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -115,13 +115,15 @@ def _adjust_fig_size(fig, ax, target_w, target_h):
 
 
 @_plot
-def histogram(col, color=COLOR_0):
+def histogram(col, duration_unit=None, color=COLOR_0):
     """Histogram for a numeric column."""
     col = sbd.drop_nulls(col)
     values = sbd.to_numpy(col)
     fig, ax = plt.subplots()
     _despine(ax)
     ax.hist(values, color=color)
+    if duration_unit is not None:
+        ax.set_xlabel(f"{duration_unit.capitalize()}s")
     if sbd.is_any_date(col):
         _rotate_ticklabels(ax)
     _adjust_fig_size(fig, ax, 2.0, 1.0)

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -208,6 +208,7 @@ def _add_numeric_summary(
     summary, column, dataframe_summary, with_plots, order_by_column
 ):
     del dataframe_summary
+    assert len(column)  # _add_numeric_summary is not called if the column is empty
     first_value = sbd.to_list(sbd.head(column, 1))[0]
     if sbd.is_duration(column):
         summary["is_duration"] = True

--- a/skrub/_reporting/_utils.py
+++ b/skrub/_reporting/_utils.py
@@ -112,3 +112,22 @@ class JSONEncoder(json.JSONEncoder):
             if isinstance(value, np.floating):
                 return float(value)
             raise
+
+
+def duration_to_numeric(col):
+    seconds = sbd.total_seconds(col)
+    q = sbd.quantile(sbd.abs(seconds), 0.9)
+    HOUR = 3600
+    DAY = HOUR * 24
+    YEAR = DAY * 365.2425
+    if q < 1e-3:
+        return seconds * 1e6, "microsecond"
+    if q < 1.0:
+        return seconds * 1e3, "millisecond"
+    if q < HOUR:
+        return seconds, "second"
+    if q < DAY:
+        return seconds / HOUR, "hour"
+    if q < YEAR:
+        return seconds / DAY, "day"
+    return seconds / YEAR, "year"

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -62,6 +62,7 @@ def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
         "value_counts": [("Paris", 9), ("London", 8)],
         "most_frequent_values": ["Paris", "London"],
         "value_is_constant": False,
+        "is_duration": False,
     }
 
     assert summary["columns"][4]["constant_value"] == "no2"

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import re
 import warnings
@@ -113,3 +114,8 @@ def test_infinite_values(df_module):
         )
 
     TableReport(df).html()
+
+
+def test_duration(df_module):
+    df = df_module.make_dataframe({"a": [datetime.timedelta(days=2)]})
+    assert re.search(r"2(\.0)?\s+days", TableReport(df).html())

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -117,5 +117,7 @@ def test_infinite_values(df_module):
 
 
 def test_duration(df_module):
-    df = df_module.make_dataframe({"a": [datetime.timedelta(days=2)]})
+    df = df_module.make_dataframe(
+        {"a": [datetime.timedelta(days=2), datetime.timedelta(days=3)]}
+    )
     assert re.search(r"2(\.0)?\s+days", TableReport(df).html())

--- a/skrub/_reporting/tests/test_utils.py
+++ b/skrub/_reporting/tests/test_utils.py
@@ -1,8 +1,10 @@
+import datetime
 import json
 
 import numpy as np
 import pytest
 
+from skrub import _dataframe as sbd
 from skrub._reporting import _utils
 
 
@@ -112,3 +114,20 @@ def test_svg_to_img_src():
         "DAgMCAxIDAgLjcwOGwtNCA0YS41LjUgMCAwIDEtLjcwOC0uNzA4TDE"
         "zLjI5MyA4LjVIMS41QS41LjUgMCAwIDEgMSA4Ii8+PC9zdmc+"
     )
+
+
+@pytest.mark.parametrize(
+    "kwargs,value,unit",
+    [
+        ({"seconds": 0.5}, 500, "millisecond"),
+        ({"seconds": 5}, 5, "second"),
+        ({"hours": 5}, 5, "hour"),
+        ({"days": 5}, 5, "day"),
+        ({"days": 500}, 1.3689, "year"),
+    ],
+)
+def test_duration_to_numeric(df_module, kwargs, value, unit):
+    s = df_module.make_column("", [datetime.timedelta(**kwargs)])
+    chosen_value, chosen_unit = _utils.duration_to_numeric(s)
+    assert sbd.to_list(chosen_value)[0] == pytest.approx(value, 0.001)
+    assert chosen_unit == unit

--- a/skrub/_reporting/tests/test_utils.py
+++ b/skrub/_reporting/tests/test_utils.py
@@ -119,6 +119,7 @@ def test_svg_to_img_src():
 @pytest.mark.parametrize(
     "kwargs,value,unit",
     [
+        ({"seconds": 2e-6}, 2, "microsecond"),
         ({"seconds": 0.5}, 500, "millisecond"),
         ({"seconds": 5}, 5, "second"),
         ({"hours": 5}, 5, "hour"),


### PR DESCRIPTION
fixes #1132 

this converts the duration/timedelta columns to numeric so we get a histogram & summary statistics rather than a bar plot

durations and datetimes are also converted to numeric for the column associations detection

the choice of time unit & conversion could probably be improved but this is already better than treating them as categorical

![screenshot_2024-11-21T17:16:03+01:00](https://github.com/user-attachments/assets/21205588-e532-46e6-87fa-c43742e6003f)
