### PR TITLE
compute n_unique for all columns in tablereport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Minor changes
 * Added a `DropColumnIfNull` transformer that drops columns that contain only null
   values. :pr:`1115` by :user: `Riccardo Cappuzzo <riccardocappuzzo>`
 
+* The :class:`TableReport` now also reports the number of unique values for
+  numeric columns. :pr:`1154` by :user:`Jérôme Dockès <jeromedockes>`.
+
 Bug fixes
 ---------
 

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -4,7 +4,6 @@ from .. import _column_associations
 from .. import _dataframe as sbd
 from . import _plotting, _sample_table, _utils
 
-_HIGH_CARDINALITY_THRESHOLD = 10
 _SUBSAMPLE_SIZE = 3000
 _N_TOP_ASSOCIATIONS = 20
 
@@ -130,6 +129,15 @@ def _summarize_column(
     if summary["null_count"] == dataframe_summary["n_rows"]:
         summary["plot_names"] = []
         return summary
+    try:
+        summary["n_unique"] = sbd.n_unique(column)
+        summary["unique_proportion"] = summary["n_unique"] / max(
+            1, dataframe_summary["n_rows"]
+        )
+    except Exception:
+        # for some dtypes n_unique can fail eg with a typeerror for
+        # non-hashable types in pandas.
+        pass
     _add_value_counts(
         summary, column, dataframe_summary=dataframe_summary, with_plots=with_plots
     )
@@ -160,15 +168,17 @@ def _add_nulls_summary(summary, column, dataframe_summary):
 
 def _add_value_counts(summary, column, *, dataframe_summary, with_plots):
     if sbd.is_numeric(column) or sbd.is_any_date(column):
-        summary["high_cardinality"] = True
         return
     n_unique, value_counts = _utils.top_k_value_counts(column, k=10)
     # if the column contains all nulls, _add_value_counts does not get called
     assert n_unique > 0
 
+    # value_counts may be able to find the number of unique values in cases
+    # where n_unique() fails (eg non-hashable column content in pandas) so we
+    # update n_unique and unique_proportion
     summary["n_unique"] = n_unique
     summary["unique_proportion"] = n_unique / max(1, dataframe_summary["n_rows"])
-    summary["high_cardinality"] = n_unique >= _HIGH_CARDINALITY_THRESHOLD
+
     summary["value_counts"] = value_counts
     summary["most_frequent_values"] = [v for v, _ in value_counts]
 

--- a/skrub/_reporting/js_tests/cypress/e2e/summary-statistics.cy.js
+++ b/skrub/_reporting/js_tests/cypress/e2e/summary-statistics.cy.js
@@ -18,12 +18,12 @@ describe('test sorting the summary stats columns', () => {
         cy.get('@table').find('tbody tr').first().should('have.attr',
             'data-column-name', 'gender');
         cy.get('@table').find('tbody tr').last().should('have.attr',
-            'data-column-name', 'year_first_hired');
+            'data-column-name', 'date_first_hired');
         cy.get('@unique').parent().find('button').first().next()
     .click();
         cy.get('@table').find('tbody tr').first().should('have.attr',
             'data-column-name', 'date_first_hired');
         cy.get('@table').find('tbody tr').last().should('have.attr',
-            'data-column-name', 'year_first_hired');
+            'data-column-name', 'assignment_category');
     });
 });

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -50,7 +50,6 @@ def test_summarize(monkeypatch, df_module, air_quality, order_by, with_plots):
     assert c == {
         "idx": 0,
         "dtype": "string",
-        "high_cardinality": False,
         "n_unique": 2,
         "name": "city",
         "null_count": 0,


### PR DESCRIPTION
fixes #1070 

ATM the tablereport only computes the number of unique values for categorical columns.
with this pr it does it for all columns