### PR TITLE
small tablereport display adjustments

### DIFF
--- a/skrub/_reporting/_data/templates/column-filter.css
+++ b/skrub/_reporting/_data/templates/column-filter.css
@@ -9,7 +9,7 @@
 }
 
 .column-filter > select {
-    max-width: 15ch;
+    max-width: 17ch;
     text-overflow: ellipsis;
     padding: 0 var(--border-s) 0 var(--space-s);
     font-size: var(--text-s);

--- a/skrub/_reporting/_data/templates/dataframe-sample.css
+++ b/skrub/_reporting/_data/templates/dataframe-sample.css
@@ -136,15 +136,25 @@ table:not(:focus-within):not(:has(:active)) .table-cell[data-is-active] {
     padding-top: var(--space-s);
 }
 
+.table-footer > * {
+    flex-shrink: 1;
+}
+
 .keyboard-hints  {
     display: none;
-    flex-basis: max(0px, min(50%, calc((50% - 30ch) * 99999)));
-    flex-shrink: 0;
+    flex-basis: max(0px, min(50%, calc((50% - 25ch) * 99999)));
     min-width: 0px;
     height: 2em;
-    margin-bottom: calc(-1 * var(--space-l));
+    margin-bottom: calc(-1 * var(--space-m));
     margin-right: var(--space-s);
     overflow: hidden;
+    flex-shrink: 10000;
+}
+
+.keyboard-hints > div {
+    display: flex;
+    flex-wrap: wrap;
+    row-gap: 2em;
 }
 
 :has(.table-with-selectable-cells:focus-within) ~ .table-footer .keyboard-hints {
@@ -165,5 +175,6 @@ table:not(:focus-within):not(:has(:active)) .table-cell[data-is-active] {
     text-align: center;
     margin: var(--space-xs);
     display: inline-block;
-    vertical-align: center;
+    text-wrap: nowrap;
+    flex-shrink: 0;
 }


### PR DESCRIPTION
ATM the keyboard shortcut hints are a bit too eager to disappear when horizontal space is tight; this adjusts a bit the threshold while improving a bit the display in the off chance that it has to wrap before it disappears

also makes the column filter very slightly wider to avoid the default option being ellided in rare cases