### PR TITLE
fix: Correct typo in TableReport docstring

### DIFF
--- a/skrub/_reporting/README.rst
+++ b/skrub/_reporting/README.rst
@@ -102,7 +102,7 @@ Distributing non-Python files
 The html templates, javascript and CSS files are not python files so some special
 steps must be taken in the build configuration to make sure they are included in
 the source distribution and the wheel. At the moment (see ``pyproject.toml``)
-skrub's ``build-system`` requires the ``setuptools_scm`` plugin, which pacakges
+skrub's ``build-system`` requires the ``setuptools_scm`` plugin, which packages
 all files that are tracked by git. If the build backend is replaced by a
 different one, refer to the new build backend's documentation on handling
 "package data" (non-python files).

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -65,7 +65,7 @@ class TableReport:
     >>> report
     <TableReport: use .open() to display>
 
-    (Note that above we only see the string represention, not the report itself,
+    (Note that above we only see the string representation, not the report itself,
     because we are not in a notebook.)
 
     Whether you are using a notebook or not, you can always open the report as a


### PR DESCRIPTION
_represention_ is now _representation_.

_pacakges_ is now _packages_.