### PR TITLE
remove use of matplotlib.rc_context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,11 @@ Changes
 
 Bug fixes
 ---------
+* Generating a ``TableReport`` could have an effect on the matplotib
+  configuration which could cause plots not to display inline in jupyter
+  notebooks any more. This has been fixed in skrub in :pr:`1172` by
+  :user:`Jérôme Dockès <jeromedockes>` and the matplotlib issue can be tracked
+  [here](https://github.com/matplotlib/matplotlib/issues/25041).
 
 
 Release 0.4.0

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -8,7 +8,6 @@ import io
 import re
 import warnings
 
-import matplotlib
 import numpy as np
 from matplotlib import pyplot as plt
 
@@ -51,9 +50,16 @@ def _plot(plotting_fun):
 
     @functools.wraps(plotting_fun)
     def plot_with_config(*args, **kwargs):
-        # This causes matplotlib to insert labels etc as text in the svg rather
-        # than drawing the glyphs.
-        with matplotlib.rc_context({"svg.fonttype": "none"}):
+        #
+        # TODO once this is fixed: https://github.com/matplotlib/matplotlib/issues/25041
+        # use the context manager:
+        # with matplotlib.rc_context({"svg.fonttype": "none"}):
+        #
+        svg_font_type = plt.rcParams["svg.fonttype"]
+        try:
+            # This causes matplotlib to insert labels etc as text in the svg rather
+            # than drawing the glyphs.
+            plt.rcParams["svg.fonttype"] = "none"
             with warnings.catch_warnings():
                 # We do not care about missing glyphs because the text is
                 # rendered & the viewbox is recomputed in the browser.
@@ -62,6 +68,8 @@ def _plot(plotting_fun):
                     "ignore", "Matplotlib currently does not support Arabic natively"
                 )
                 return plotting_fun(*args, **kwargs)
+        finally:
+            plt.rcParams["svg.fonttype"] = svg_font_type
 
     return plot_with_config
 

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -51,7 +51,7 @@ def _plot(plotting_fun):
     @functools.wraps(plotting_fun)
     def plot_with_config(*args, **kwargs):
         #
-        # Note: we do use `matplotlib.rc_context` because it can prevent the
+        # Note: we do not use `matplotlib.rc_context` because it can prevent the
         # inline display of plots in jupyter notebooks:
         #
         # https://github.com/matplotlib/matplotlib/issues/25041

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -51,11 +51,18 @@ def _plot(plotting_fun):
     @functools.wraps(plotting_fun)
     def plot_with_config(*args, **kwargs):
         #
-        # TODO once this is fixed: https://github.com/matplotlib/matplotlib/issues/25041
-        # use the context manager:
+        # Note: we do use `matplotlib.rc_context` because it can prevent the
+        # inline display of plots in jupyter notebooks:
+        #
+        # https://github.com/matplotlib/matplotlib/issues/25041
+        # https://github.com/matplotlib/matplotlib/issues/26716
+        #
+        # otherwise we could write
         # with matplotlib.rc_context({"svg.fonttype": "none"}):
         #
-        svg_font_type = plt.rcParams["svg.fonttype"]
+        # See https://github.com/skrub-data/skrub/pull/1172
+        #
+        original_font_type = plt.rcParams["svg.fonttype"]
         try:
             # This causes matplotlib to insert labels etc as text in the svg rather
             # than drawing the glyphs.
@@ -69,7 +76,7 @@ def _plot(plotting_fun):
                 )
                 return plotting_fun(*args, **kwargs)
         finally:
-            plt.rcParams["svg.fonttype"] = svg_font_type
+            plt.rcParams["svg.fonttype"] = original_font_type
 
     return plot_with_config
 


### PR DESCRIPTION
fixes #1171

matplotlib.rc_context seems to prevent the inline display of plots in jupyter notebooks in some cases
this removes the use of this context manager

the context manager does not seem to do anything fancier than the try/finally statement in this PR, but the difference is here we only set the key we are interested in `svg.fonttype` whereas upon exit `rc_context` updates all params except the backend:

https://github.com/matplotlib/matplotlib/blob/v3.9.3/lib/matplotlib/__init__.py#L1142-L1196