### PR TITLE
revert gif in the readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,7 @@ The goal of skrub is to bridge the gap between tabular data sources and machine-
 
 skrub provides high-level tools for joining dataframes (``Joiner``, ``AggJoiner``, ...),
 encoding columns (``MinHashEncoder``, ``ToCategorical``, ...), building a pipeline
-(``TableVectorizer``, ``tabular_learner``, ...), and explore interactively your data (``TableReport``).
-
-.. figure::
-   https://github.com/rcap107/skrub-datasets/blob/master/data/output.gif?raw=true
-   :alt: An animation showing how TableReport works
-
-   An animation showing how TableReport works
+(``TableVectorizer``, ``tabular_learner``, ...), and exploring interactively your data (``TableReport``).
 
 
 >>> from skrub.datasets import fetch_employee_salaries


### PR DESCRIPTION
While I like the idea of showcasing the tablereport as soon as possible because it is one of the more visual and immediatly understood features, I think we were too quick in adding that gif to the readme:

- I'm not sure if it is due to the large size (most likely) or how the link is generated from markdown but it does not display on PyPI's "description" page
- the `figure` directive renders as a link so clicking on the image downloads the gif which nobody wants to do
- having a largish animation that moves a lot and we cannot stop can be distracting or even disagreeable for some

this is a quick fix to revert the change and then we can discuss some more what should be in the readme and maybe reduce it further to drive everyone to the home page instead