### PR TITLE
[DOC] Remove API change banner on landing page

### DIFF
--- a/doc/announcement.html
+++ b/doc/announcement.html
@@ -1,3 +1,0 @@
-<div class="sidebar-message">
-    We are releasing <code>skrub</code> to gather early feedback, but <strong>the API is subject to change without notice</strong>.
-</div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,9 +199,6 @@ html_theme_options = {
     "navbar_align": "left",
     # "navbar_center": ["version-switcher", "navbar-nav"],
     "navbar_center": ["navbar-nav"],
-    "announcement": (
-        "https://raw.githubusercontent.com/skrub-data/skrub/main/doc/announcement.html"
-    ),
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],


### PR DESCRIPTION
As discussed, removing the banner mentioning that the API is subject to change without notice