### PR TITLE
Add `.venv` and `env_skrub` in the `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,6 @@ jupyterlite_contents
 .pixi/
 
 # python virtual environment
+.venv
 venv
+env_skrub


### PR DESCRIPTION
Fix #1209 

This small PR adds `.venv` and `env_skrub` in the `.gitignore`, as `env_skrub` is the env name suggested in the contributing guide and `.venv` is often used IMO