### PR TITLE
try to guess the appropriate color theme based on parent element's color

### DIFF
--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -94,7 +94,7 @@ if (customElements.get('skrub-table-report') === undefined) {
             });
 
             const report = this.shadowRoot.getElementById("report");
-            report.classList.add(detectTheme());
+            report.classList.add(detectTheme(`${this.id}-wrapper`));
             adjustAllSvgViewBoxes(report);
         }
 
@@ -774,7 +774,7 @@ if (customElements.get('skrub-table-report') === undefined) {
     }
     SkrubTableReport.register(CopyButton);
 
-    function detectTheme() {
+    function detectTheme(parentId) {
         const shadowRootBody = document.querySelector('body');
 
         // Check VSCode theme
@@ -789,6 +789,16 @@ if (customElements.get('skrub-table-report') === undefined) {
             return 'dark';
         } else if (shadowRootBody.getAttribute('data-jp-theme-light') === 'true') {
             return 'light';
+        }
+
+        // Guess based on parent element's color
+        const parentElem = document.getElementById(parentId);
+        const color = window.getComputedStyle(parentElem, null).getPropertyValue('color');
+        const match = color.match(/^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/i);
+        if(match){
+            const [r, g, b] = [match[1], match[2], match[3]];
+            const value = Math.max(r, g, b);
+            return value > 127 ? 'dark' : 'light';
         }
 
         // Fallback to system preference


### PR DESCRIPTION
I wonder if looking at the text color on the report's parent element and trying to choose the most appropriate theme based on the result would be a good heuristic (when the other heuristics we have for vscode & jupyter notebook don't give a result), or if it is better to fall back on the system preference as we currently do...

this detects for example when the user set the theme in the skrub online documentation manually by clicking the button, to something different than their system or browser default. But I don't know if this is something that happens in practice; I guess dark theme users will have it set at the OS level?

@rouk1  WDYT?