### PR TITLE
enh: vscode theme detection

### DIFF
--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -777,11 +777,15 @@ if (customElements.get('skrub-table-report') === undefined) {
     function detectTheme() {
         const shadowRootBody = document.querySelector('body');
 
+        const themeKind = shadowRootBody.getAttribute('data-vscode-theme-kind').toLowerCase();
+        const themeName = shadowRootBody.getAttribute('data-vscode-theme-name').toLowerCase();
+
         // Check VSCode theme
-        if (shadowRootBody.getAttribute('data-vscode-theme-kind') === 'vscode-dark') {
-            return 'dark';
-        } else if (shadowRootBody.getAttribute('data-vscode-theme-kind') === 'vscode-light') {
-            return 'light';
+        if (themeKind.includes("dark") || themeName.includes("dark")) {
+            return "dark";
+        }
+        if (themeKind.includes("light") || themeName.includes("light")) {
+            return "light";
         }
 
         // Check Jupyter theme

--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -777,15 +777,20 @@ if (customElements.get('skrub-table-report') === undefined) {
     function detectTheme() {
         const shadowRootBody = document.querySelector('body');
 
-        const themeKind = shadowRootBody.getAttribute('data-vscode-theme-kind').toLowerCase();
-        const themeName = shadowRootBody.getAttribute('data-vscode-theme-name').toLowerCase();
+        const themeKindAttr = shadowRootBody.getAttribute('data-vscode-theme-kind');
+        const themeNameAttr = shadowRootBody.getAttribute('data-vscode-theme-name');
 
-        // Check VSCode theme
-        if (themeKind.includes("dark") || themeName.includes("dark")) {
-            return "dark";
-        }
-        if (themeKind.includes("light") || themeName.includes("light")) {
-            return "light";
+        if (themeKindAttr && themeNameAttr) {
+            const themeKind = themeKindAttr.toLowerCase();
+            const themeName = themeNameAttr.toLowerCase();
+
+            // Check VSCode theme
+            if (themeKind.includes("dark") || themeName.includes("dark")) {
+                return "dark";
+            }
+            if (themeKind.includes("light") || themeName.includes("light")) {
+                return "light";
+            }
         }
 
         // Check Jupyter theme


### PR DESCRIPTION
This PR tries to enhance how the report detects vscode theme.
It should address the issue with high contrast theme discovered [here](https://github.com/skrub-data/skrub/pull/1228#issuecomment-2630589233).

Here is what I get now in high contrast:

<img width="1463" alt="Screenshot 2025-02-04 at 11 20 44" src="https://github.com/user-attachments/assets/7491d01b-e01e-47ec-a922-890d1d444832" />
