### PR TITLE
FIX accept input_features parameter in TableVectorizer.get_feature_names_out

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -676,8 +676,13 @@ class TableVectorizer(TransformerMixin, BaseEstimator):
         tags.input_tags.allow_nan = True
         return tags
 
-    def get_feature_names_out(self):
+    def get_feature_names_out(self, input_features=None):
         """Return the column names of the output of ``transform`` as a list of strings.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored.
 
         Returns
         -------


### PR DESCRIPTION
closes #1256 

This PR makes sure to expose an `input_features` parameter in the `get_feature_names_out` to be compatible with scikit-learn.

Right now, the parameter is ignored. One question would be: do we want to allow overwriting the column names. In this case, we would need to change more code because we would need to overwrite the name of the columns of the output dataframe in `transform` to have a consistency between `get_feature_names_out()` and the `feature_names_in_` of the subsequent steps in a scikit-learn pipeline.