### PR TITLE
ENH add periodic encoding in tabular learner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,11 @@ Changes
 - Optimize the :class:`StringEncoder`: significant memory reduction and 1.5x speed-up.
   :pr:`1248` by :user:`Gaël Varoquaux <gaelvaroquaux>`
 
+- The estimator returned by :func:`tabular_learner` now uses spline encoding of
+  datetime features when the supervised learner is not a model based on decision
+  trees such as random forests or gradient boosting. :pr:`1264` by
+  :user:`Guillaume Lemaitre <glemaitre>`.
+
 Bug fixes
 ---------
 

--- a/doc/end_to_end_pipeline.rst
+++ b/doc/end_to_end_pipeline.rst
@@ -49,7 +49,7 @@ based on the type of the final estimator.
    * - Date preprocessor
      - :class:`DatetimeEncoder`
      - :class:`DatetimeEncoder`
-     - :class:`DatetimeEncoder`
+     - :class:`DatetimeEncoder` with spline encoding
    * - Missing value strategy
      - Native support :sup:`(2)`
      - Native support

--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -184,7 +184,7 @@ def tabular_learner(estimator, *, n_jobs=None):
                     ('logisticregression', LogisticRegression())])
 
     We see that for the :obj:`~sklearn.linear_model.LogisticRegression` we get
-    the default configuration of the :obj:`TableVectorizer` which is intended
+    a configuration of the :obj:`TableVectorizer` which is intended
     to work well for a wide variety of downstream estimators. Moreover, as the
     :obj:`~sklearn.linear_model.LogisticRegression` cannot handle missing
     values, an imputation step is added. Finally, as many models require the
@@ -217,6 +217,8 @@ def tabular_learner(estimator, *, n_jobs=None):
       makes sure that those features have a categorical dtype so that the
       :obj:`~sklearn.ensemble.HistGradientBoostingClassifier` recognizes them
       as such.
+
+    - There is no spline encoding of datetimes.
 
     - There is no missing-value imputation because the classifier has its own
       (better) mechanism for dealing with missing values.

--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -162,7 +162,8 @@ def tabular_learner(estimator, *, n_jobs=None):
     >>> from sklearn.linear_model import LogisticRegression
     >>> model = tabular_learner(LogisticRegression())
     >>> model.fit(X, y)
-    Pipeline(steps=[('tablevectorizer', TableVectorizer()),
+    Pipeline(steps=[('tablevectorizer',
+                    TableVectorizer(datetime=DatetimeEncoder(periodic_encoding='spline'))),
                     ('simpleimputer', SimpleImputer(add_indicator=True)),
                     ('standardscaler', StandardScaler()),
                     ('logisticregression', LogisticRegression())])
@@ -181,7 +182,8 @@ def tabular_learner(estimator, *, n_jobs=None):
     The parameters of the :obj:`TableVectorizer` depend on the provided ``estimator``.
 
     >>> tabular_learner(LogisticRegression())
-    Pipeline(steps=[('tablevectorizer', TableVectorizer()),
+    Pipeline(steps=[('tablevectorizer',
+                    TableVectorizer(datetime=DatetimeEncoder(periodic_encoding='spline'))),
                     ('simpleimputer', SimpleImputer(add_indicator=True)),
                     ('standardscaler', StandardScaler()),
                     ('logisticregression', LogisticRegression())])

--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -2,7 +2,6 @@ import sklearn
 from sklearn import ensemble
 from sklearn.base import BaseEstimator
 from sklearn.impute import SimpleImputer
-from sklearn.linear_model._base import LinearClassifierMixin, LinearModel
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 from sklearn.utils.fixes import parse_version
@@ -22,10 +21,6 @@ _TREE_ENSEMBLE_CLASSES = (
     ensemble.HistGradientBoostingRegressor,
     ensemble.RandomForestClassifier,
     ensemble.RandomForestRegressor,
-)
-_LINEAR_MODEL_CLASSES = (
-    LinearClassifierMixin,
-    LinearModel,
 )
 
 
@@ -278,7 +273,7 @@ def tabular_learner(estimator, *, n_jobs=None):
             ),
             high_cardinality=MinHashEncoder(),
         )
-    elif isinstance(estimator, _LINEAR_MODEL_CLASSES):
+    else:
         vectorizer.set_params(datetime=DatetimeEncoder(periodic_encoding="spline"))
     steps = [vectorizer]
     if not get_tags(estimator).input_tags.allow_nan:

--- a/skrub/_tabular_learner.py
+++ b/skrub/_tabular_learner.py
@@ -2,10 +2,12 @@ import sklearn
 from sklearn import ensemble
 from sklearn.base import BaseEstimator
 from sklearn.impute import SimpleImputer
+from sklearn.linear_model._base import LinearClassifierMixin, LinearModel
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 from sklearn.utils.fixes import parse_version
 
+from ._datetime_encoder import DatetimeEncoder
 from ._minhash_encoder import MinHashEncoder
 from ._sklearn_compat import get_tags
 from ._table_vectorizer import TableVectorizer
@@ -20,6 +22,10 @@ _TREE_ENSEMBLE_CLASSES = (
     ensemble.HistGradientBoostingRegressor,
     ensemble.RandomForestClassifier,
     ensemble.RandomForestRegressor,
+)
+_LINEAR_MODEL_CLASSES = (
+    LinearClassifierMixin,
+    LinearModel,
 )
 
 
@@ -270,6 +276,8 @@ def tabular_learner(estimator, *, n_jobs=None):
             ),
             high_cardinality=MinHashEncoder(),
         )
+    elif isinstance(estimator, _LINEAR_MODEL_CLASSES):
+        vectorizer.set_params(datetime=DatetimeEncoder(periodic_encoding="spline"))
     steps = [vectorizer]
     if not get_tags(estimator).input_tags.allow_nan:
         steps.append(SimpleImputer(add_indicator=True))

--- a/skrub/tests/test_tabular_learner.py
+++ b/skrub/tests/test_tabular_learner.py
@@ -57,6 +57,7 @@ def test_linear_learner():
     assert isinstance(tv.low_cardinality, OneHotEncoder)
     assert isinstance(imputer, SimpleImputer)
     assert isinstance(scaler, StandardScaler)
+    assert tv.datetime.periodic_encoding == "spline"
 
 
 def test_tree_learner():
@@ -70,6 +71,7 @@ def test_tree_learner():
     assert learner is original_learner
     assert isinstance(tv.high_cardinality, MinHashEncoder)
     assert isinstance(tv.low_cardinality, OrdinalEncoder)
+    assert tv.datetime.periodic_encoding is None
 
 
 def test_from_dtype():


### PR DESCRIPTION
This PR adds periodic encoding by default when the estimator is a linear model

#### TODO

- [x] add tests
- [x] update the docstring of the `tabular_learner`
- [x] update the user guide
- [x] update the potential example impacted