### PR TITLE
Fix error bars plotting in encoding example

### DIFF
--- a/examples/01_encodings.py
+++ b/examples/01_encodings.py
@@ -329,8 +329,10 @@ plt.figure(figsize=(12, 9))
 plt.barh(
     y=labels,
     width=avg_importances[top_indices],
-    yerr=std_importances[top_indices],
+    xerr=std_importances[top_indices],
+    ecolor="k",
     color="b",
+    alpha=0.5,
 )
 plt.yticks(fontsize=15)
 plt.title("Feature importances")


### PR DESCRIPTION
This PR addresses Issue #1268 by correcting the `xerr` parameter in the horizontal bar plot within the "Encoding: from a dataframe to a numerical matrix for machine learning" example. The standard deviations of feature importances are now properly assigned to `xerr`, ensuring accurate representation of error bars.
