### PR TITLE
Do no reuse the same variable name for different nodes in expression graph

### DIFF
--- a/examples/expressions/10_expressions_intro.py
+++ b/examples/expressions/10_expressions_intro.py
@@ -208,9 +208,9 @@ vectorized_products = products.skb.apply(vectorizer, exclude_cols="basket_ID")
 
 # %%
 aggregated_products = vectorized_products.groupby("basket_ID").agg("mean").reset_index()
-baskets = baskets.merge(aggregated_products, left_on="ID", right_on="basket_ID").drop(
-    columns=["ID", "basket_ID"]
-)
+augmented_baskets = baskets.merge(
+    aggregated_products, left_on="ID", right_on="basket_ID"
+).drop(columns=["ID", "basket_ID"])
 
 # %%
 # Finally, we add a supervised estimator and our pipeline is complete.
@@ -221,7 +221,7 @@ from sklearn.ensemble import HistGradientBoostingClassifier
 hgb = HistGradientBoostingClassifier(
     learning_rate=skrub.choose_float(0.01, 0.9, log=True, name="learning_rate")
 )
-predictions = baskets.skb.apply(hgb, y=fraud_flags)
+predictions = augmented_baskets.skb.apply(hgb, y=fraud_flags)
 predictions
 
 # %%


### PR DESCRIPTION
Workaround for: #1306.

This also fix another UX problem (traditional when working with jupyter):

- execute all the cells once in order until the cell with `baskets = baskets.merge(...)`;
- then scroll back up to re-execute the cell with `products = products[products["basket_ID"].isin(baskets["ID"])]`
- then we would get the following nested exception:

```python
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File ~/miniforge3/envs/dev/lib/python3.12/site-packages/pandas/core/indexes/base.py:3805, in Index.get_loc(self, key)
   3804 try:
-> 3805     return self._engine.get_loc(casted_key)
   3806 except KeyError as err:

File index.pyx:167, in pandas._libs.index.IndexEngine.get_loc()

File index.pyx:196, in pandas._libs.index.IndexEngine.get_loc()

File pandas/_libs/hashtable_class_helper.pxi:7081, in pandas._libs.hashtable.PyObjectHashTable.get_item()

File pandas/_libs/hashtable_class_helper.pxi:7089, in pandas._libs.hashtable.PyObjectHashTable.get_item()

KeyError: 'ID'

The above exception was the direct cause of the following exception:

KeyError                                  Traceback (most recent call last)
File ~/code/skrub/skrub/_expressions/_expressions.py:290, in check_expr.<locals>.checked_call(*args, **kwargs)
    289 try:
--> 290     evaluate(expr, mode="preview", environment=None)
    291 except UninitializedVariable:

File ~/code/skrub/skrub/_expressions/_evaluation.py:349, in evaluate(expr, mode, environment, clear, callbacks)
    346 try:
    347     result = _Evaluator(
    348         mode=mode, environment=environment, callbacks=callbacks
--> 349     ).run(expr)
    350     return expr if requested_mode == "fit" else result

File ~/code/skrub/skrub/_expressions/_evaluation.py:187, in _Evaluator.run(self, expr)
    186 self._expr = expr
--> 187 return super().run(expr)

File ~/code/skrub/skrub/_expressions/_evaluation.py:81, in _ExprTraversal.run(self, expr)
     80 if isinstance(top, _Computation):
---> 81     new_top = top.generator.send(last_result)
     82     if id(new_top) in {
     83         c.target_id for c in stack if isinstance(c, _Computation)
     84     }:

File ~/code/skrub/skrub/_expressions/_evaluation.py:225, in _Evaluator.handle_expr(self, expr)
    224 else:
--> 225     result = yield from self._handle_expr_default(expr)
    226 self._store(expr, result)

File ~/code/skrub/skrub/_expressions/_evaluation.py:250, in _Evaluator._handle_expr_default(self, expr)
    248 def _handle_expr_default(self, expr):
    249     return (
--> 250         yield from super().handle_expr(
    251             expr, expr._skrub_impl.fields_required_for_eval(self.mode)
    252         )
    253     )

File ~/code/skrub/skrub/_expressions/_evaluation.py:120, in _ExprTraversal.handle_expr(self, expr, attributes_to_evaluate)
    119     evaluated_attributes[name] = yield attr
--> 120 return self.compute_result(expr, evaluated_attributes)

File ~/code/skrub/skrub/_expressions/_evaluation.py:269, in _Evaluator.compute_result(self, expr, evaluated_attributes)
    268 try:
--> 269     return expr._skrub_impl.compute(
    270         SimpleNamespace(**evaluated_attributes),
    271         mode=self.mode,
    272         environment=self.environment,
    273     )
    274 except Exception as e:

File ~/code/skrub/skrub/_expressions/_expressions.py:1128, in GetItem.compute(self, e, mode, environment)
   1127 def compute(self, e, mode, environment):
-> 1128     return e.container[e.key]

File ~/miniforge3/envs/dev/lib/python3.12/site-packages/pandas/core/frame.py:4102, in DataFrame.__getitem__(self, key)
   4101     return self._getitem_multilevel(key)
-> 4102 indexer = self.columns.get_loc(key)
   4103 if is_integer(indexer):

File ~/miniforge3/envs/dev/lib/python3.12/site-packages/pandas/core/indexes/base.py:3812, in Index.get_loc(self, key)
   3811         raise InvalidIndexError(key)
-> 3812     raise KeyError(key) from err
   3813 except TypeError:
   3814     # If we have a listlike key, _check_indexing_error will raise
   3815     #  InvalidIndexError. Otherwise we fall through and re-raise
   3816     #  the TypeError.

KeyError: 'ID'

The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
Cell In[19], line 2
      1 # %%
----> 2 products = products[products["basket_ID"].isin(baskets["ID"])]
      3 products = products.assign(
      4     total_price=products["Nbr_of_prod_purchas"] * products["cash_price"]
      5 )
      6 products

File ~/code/skrub/skrub/_expressions/_expressions.py:295, in check_expr.<locals>.checked_call(*args, **kwargs)
    293 except Exception as e:
    294     msg = "\n".join(_utils.format_exception_only(e)).rstrip("\n")
--> 295     raise RuntimeError(
    296         f"Evaluation of {func_name!r} failed.\n"
    297         f"You can see the full traceback above. The error message was:\n{msg}"
    298     ) from e
    300 return expr

RuntimeError: Evaluation of "['ID']" failed.
You can see the full traceback above. The error message was:
KeyError: 'ID'
```