### PR TITLE
make the choice name optional

### DIFF
--- a/examples/expressions/13_choices.py
+++ b/examples/expressions/13_choices.py
@@ -97,7 +97,7 @@ pred.skb.cross_validate(n_jobs=4)["test_score"]
 #   ``X.skb.apply(skrub.optional(StandardScaler()))``
 #
 # Choices can be given a name which is used to display hyperparameter search
-# results and plots or to override their outcome.
+# results and plots or to override their outcome. The name is optional.
 #
 # Note that ``skrub.choose_float()`` and ``skrub.choose_int()`` can be given a
 # ``log`` argument to sample in log scale.

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -1001,7 +1001,7 @@ def _check_column_names(X):
 
 
 class Apply(ExprImpl):
-    _fields = ["estimator", "cols", "X", "y", "how", "allow_reject", "unsupervised"]
+    _fields = ["X", "estimator", "y", "cols", "how", "allow_reject", "unsupervised"]
 
     # TODO can we avoid the need for an explicit unsupervised parameter by
     # inspecting sklearn tags?

--- a/skrub/_expressions/_inspection.py
+++ b/skrub/_expressions/_inspection.py
@@ -16,7 +16,7 @@ from .._reporting._serve import open_in_browser
 from .._utils import Repr, random_string, short_repr
 from . import _utils
 from ._choosing import BaseNumericChoice
-from ._evaluation import choices, clear_results, evaluate, graph, param_grid
+from ._evaluation import choice_graph, clear_results, evaluate, graph, param_grid
 from ._expressions import Apply, Value, Var
 
 # TODO after merging the expressions do some refactoring and move this stuff to
@@ -342,15 +342,15 @@ def draw_expr_graph(expr, url=None, direction="TB"):
 
 def describe_param_grid(expr):
     grid = param_grid(expr)
-    expr_choices = choices(expr)
+    expr_choices = choice_graph(expr)
 
     buf = io.StringIO()
     for subgrid in grid:
         prefix = "- "
         for k, v in subgrid.items():
             assert isinstance(v, (BaseNumericChoice, list))
-            choice = expr_choices[k]
-            name = choice.name
+            choice = expr_choices["choices"][k]
+            name = expr_choices["choice_display_names"][k]
             buf.write(f"{prefix}{name}: ")
             if isinstance(choice, BaseNumericChoice):
                 buf.write(f"{v}\n")

--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -19,7 +19,8 @@ def plot_parallel_coord(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
                 metadata,
                 colorscale=colorscale,
             )
-        )
+        ),
+        layout=go.Layout(font=dict(size=18)),
     )
 
 

--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -19,8 +19,7 @@ def plot_parallel_coord(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
                 metadata,
                 colorscale=colorscale,
             )
-        ),
-        layout=go.Layout(font=dict(size=18)),
+        )
     )
 
 
@@ -41,7 +40,8 @@ def get_parallel_coord_data(cv_results, metadata, colorscale=DEFAULT_COLORSCALE)
             colorbar=dict(title=dict(text="score")),
         ),
         dimensions=prepared_columns,
-        labelangle=45,
+        labelangle=15,
+        labelside="top",
     )
 
 

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -906,22 +906,22 @@ class SkrubNamespace:
         ... )
         >>> pred = selected.skb.apply(classifier, y=y)
         >>> print(pred.skb.describe_param_grid())
-        - classifier: 'logreg'
-          C: choose_float(0.001, 100, log=True, name='C')
-          dim_reduction: 'PCA'
+        - dim_reduction: 'PCA'
           n_components: choose_int(5, 100, log=True, name='n_components')
-        - classifier: 'logreg'
+          classifier: 'logreg'
           C: choose_float(0.001, 100, log=True, name='C')
-          dim_reduction: 'SelectKBest'
-          k: choose_int(5, 100, log=True, name='k')
-        - classifier: 'rf'
-          N 🌴: choose_int(20, 400, name='N 🌴')
-          dim_reduction: 'PCA'
+        - dim_reduction: 'PCA'
           n_components: choose_int(5, 100, log=True, name='n_components')
-        - classifier: 'rf'
+          classifier: 'rf'
           N 🌴: choose_int(20, 400, name='N 🌴')
-          dim_reduction: 'SelectKBest'
+        - dim_reduction: 'SelectKBest'
           k: choose_int(5, 100, log=True, name='k')
+          classifier: 'logreg'
+          C: choose_float(0.001, 100, log=True, name='C')
+        - dim_reduction: 'SelectKBest'
+          k: choose_int(5, 100, log=True, name='k')
+          classifier: 'rf'
+          N 🌴: choose_int(20, 400, name='N 🌴')
 
         Sampling a configuration for this pipeline starts by selecting an entry
         (marked by ``-``) in the list above, then a value for each of the
@@ -1241,12 +1241,12 @@ class SkrubNamespace:
 
         >>> search = pred.skb.get_grid_search(fitted=True)
         >>> search.results_
-           mean_test_score classifier     C   N 🌴
-        0             0.89         rf   NaN  30.0
-        1             0.84   logistic   0.1   NaN
-        2             0.80   logistic  10.0   NaN
-        3             0.65         rf   NaN   3.0
-        4             0.50      dummy   NaN   NaN
+           mean_test_score     C   N 🌴 classifier
+        0             0.89   NaN  30.0         rf
+        1             0.84   0.1   NaN   logistic
+        2             0.80  10.0   NaN   logistic
+        3             0.65   NaN   3.0         rf
+        4             0.50   NaN   NaN      dummy
         """  # noqa: E501
         for c in choices(self._expr).values():
             if hasattr(c, "rvs") and not isinstance(c, typing.Sequence):
@@ -1323,17 +1323,17 @@ class SkrubNamespace:
 
         >>> search = pred.skb.get_randomized_search(fitted=True, random_state=0)
         >>> search.results_
-           mean_test_score classifier         C   k   N 🌴
-        0             0.93         rf       NaN   6  20.0
-        1             0.92         rf       NaN   4  18.0
-        2             0.90         rf       NaN   7  12.0
-        3             0.84   logistic  0.109758  15   NaN
-        4             0.82   logistic  0.584633  14   NaN
-        5             0.82   logistic  9.062263  14   NaN
-        6             0.80   logistic  1.533519  15   NaN
-        7             0.50      dummy       NaN   4   NaN
-        8             0.50      dummy       NaN   9   NaN
-        9             0.50      dummy       NaN   5   NaN
+           mean_test_score   k         C  N 🌴 classifier
+        0             0.92   4  4.626363  NaN   logistic
+        1             0.89  10       NaN  7.0         rf
+        2             0.87   7  3.832217  NaN   logistic
+        3             0.86  15       NaN  6.0         rf
+        4             0.85  10  4.881255  NaN   logistic
+        5             0.80  19  3.965675  NaN   logistic
+        6             0.77  14       NaN  3.0         rf
+        7             0.50   4       NaN  NaN      dummy
+        8             0.50   9       NaN  NaN      dummy
+        9             0.50   5       NaN  NaN      dummy
         """  # noqa: E501
 
         search = ParamSearch(

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -23,7 +23,7 @@ def test_choice_unpacking(name):
         skrub.choose_from([10, 20], name=name)[0]
 
 
-@pytest.mark.parametrize("name", [None, 0, skrub.var("name", "the_name")])
+@pytest.mark.parametrize("name", [0, skrub.var("name", "the_name")])
 def test_bad_name(name):
     with pytest.raises(TypeError, match=".*must be a `str`"):
         skrub.choose_from({"a": 0}, name=name)
@@ -168,3 +168,56 @@ def test_bad_match_mappings(test_class):
         "unhashable type: 'Expr'",
     ):
         c.match({1: "one", 11: "eleven"})
+
+
+def test_get_display_name():
+    c = skrub.choose_from([1, 2])
+    assert _choosing.get_display_name(c) == "choose_from([1, 2])"
+    c = skrub.choose_from([1, 2], name="c")
+    assert _choosing.get_display_name(c) == "c"
+
+
+def test_choice_repr():
+    """
+    >>> import numpy as np
+    >>> import skrub
+
+    >>> n_components = skrub.choose_int(10, 30, name="n")
+    >>> n_components
+    choose_int(10, 30, name='n')
+    >>> skrub.choose_from(
+    ...     [
+    ...         skrub.StringEncoder(n_components=n_components),
+    ...         skrub.TextEncoder(n_components=n_components),
+    ...     ]
+    ... )
+    choose_from([StringEncoder(...), TextEncoder(...)])
+    >>> skrub.choose_from(
+    ...     {
+    ...         "string": skrub.StringEncoder(n_components=n_components),
+    ...         "text": skrub.TextEncoder(n_components=n_components),
+    ...     }
+    ... )
+    choose_from({'string': StringEncoder(...), 'text': TextEncoder(...)})
+
+    >>> skrub.choose_from([np.eye(3)])
+    choose_from([ndarray(...)])
+    >>> skrub.choose_from([1, 2])
+    choose_from([1, 2])
+    >>> skrub.as_expr([skrub.choose_from([1, 2]), skrub.optional(np.eye(3))])
+    <Value list>
+    Result:
+    ―――――――
+    [choose_from([1, 2]), optional(ndarray(...))]
+
+    >>> skrub.optional(0, name='a')
+    optional(0, name='a')
+    >>> skrub.optional(0)
+    optional(0)
+    >>> skrub.choose_bool()
+    choose_bool()
+    >>> skrub.choose_bool(name='a')
+    choose_bool(name='a')
+    >>> skrub.choose_float(1, 10, n_steps=2, name="i")
+    choose_float(1, 10, n_steps=2, name='i')
+    """

--- a/skrub/_expressions/tests/test_estimators.py
+++ b/skrub/_expressions/tests/test_estimators.py
@@ -191,6 +191,23 @@ def test_grid_search(expression, data, n_jobs):
     assert train_score == pytest.approx(0.94)
 
 
+def test_no_names():
+    X, y = make_classification(random_state=0, n_samples=20)
+    e = (
+        skrub.X(X)
+        .skb.apply(StandardScaler(with_mean=skrub.choose_bool()))
+        .skb.apply(StandardScaler(with_mean=skrub.choose_bool()))
+        .skb.apply(StandardScaler(with_mean=skrub.choose_bool(name="m")))
+        .skb.apply(LogisticRegression(), y=skrub.y(y))
+    ).skb.get_grid_search(fitted=True, cv=2)
+    assert list(e.results_.columns) == [
+        "mean_test_score",
+        "choose_bool()",
+        "choose_bool()_1",
+        "m",
+    ]
+
+
 def test_nested_cv(expression, data, data_kind, n_jobs, monkeypatch):
     search = expression.skb.get_randomized_search(
         n_iter=3, n_jobs=n_jobs, random_state=0

--- a/skrub/_expressions/tests/test_evaluation.py
+++ b/skrub/_expressions/tests/test_evaluation.py
@@ -160,22 +160,22 @@ def test_empty_param_grid():
 
 
 def test_param_grid_nested_choices():
-    c0 = skrub.choose_from([10, 20], name="c0")
-    c1 = skrub.choose_from([11, 21], name="c1")
-    c2 = skrub.choose_from([12, 22], name="c2")
-    c3 = skrub.choose_from([{"C": c0}, {"C": c1}], name="c3")
-    e = skrub.as_expr([c3, c2])
+    c0 = skrub.choose_from([10, 20, 30], name="c0")
+    c1 = skrub.choose_from([11, 21, 22, 24], name="c1")
+    c2 = skrub.choose_from([{"C": c0}, {"C": c1}], name="c2")
+    c3 = skrub.choose_from([12, 22, 40, 50, 60], name="c3")
+    e = skrub.as_expr([c2, c3])
     assert e.skb.describe_param_grid() == """\
-- c2: [12, 22]
-  c3: {'C': choose_from([10, 20], name='c0')}
-  c0: [10, 20]
-- c2: [12, 22]
-  c3: {'C': choose_from([11, 21], name='c1')}
-  c1: [11, 21]
+- c3: [12, 22, 40, 50, 60]
+  c2: {'C': choose_from([10, 20, 30], name='c0')}
+  c0: [10, 20, 30]
+- c3: [12, 22, 40, 50, 60]
+  c2: {'C': choose_from([11, 21, 22, 24], name='c1')}
+  c1: [11, 21, 22, 24]
 """
     assert _evaluation.param_grid(e) == [
-        {3: [0, 1], 0: [0], 1: [0, 1]},
-        {3: [0, 1], 0: [1], 2: [0, 1]},
+        {2: [0], 0: [0, 1, 2], 3: [0, 1, 2, 3, 4]},
+        {2: [1], 1: [0, 1, 2, 3], 3: [0, 1, 2, 3, 4]},
     ]
 
 
@@ -221,6 +221,38 @@ def test_param_grid_choice_before_X():
   c1: [0.5]
   c2: [12, 22]
 """
+
+
+def test_unnamed_choices():
+    """
+    >>> import skrub
+
+    >>> a = skrub.choose_bool()
+    >>> b = skrub.choose_bool()
+    >>> c = skrub.choose_bool()
+    >>> d = skrub.choose_from({'a': a, 'b': b, 'c': c})
+    >>> x = skrub.as_expr([a, b, c, d])
+    >>> print(x.skb.describe_param_grid())
+    - choose_bool(): [True, False]
+      choose_bool()_1: [True, False]
+      choose_bool()_2: [True, False]
+      choose_from({'a': …, 'b': …, 'c': …}): 'a'
+    - choose_bool(): [True, False]
+      choose_bool()_1: [True, False]
+      choose_bool()_2: [True, False]
+      choose_from({'a': …, 'b': …, 'c': …}): 'b'
+    - choose_bool(): [True, False]
+      choose_bool()_1: [True, False]
+      choose_bool()_2: [True, False]
+      choose_from({'a': …, 'b': …, 'c': …}): 'c'
+    """
+    a = skrub.choose_int(1, 5)
+    b = skrub.choose_int(1, 5)
+    c = skrub.choose_int(1, 5, name="c")
+    e = a.as_expr() + b + c
+    assert e.skb.eval() == 9
+    assert e.skb.eval({"c": 5}) == 11
+    assert _evaluation.param_grid(e) == [{0: a, 1: b, 2: c}]
 
 
 #

--- a/skrub/_expressions/tests/test_inspection.py
+++ b/skrub/_expressions/tests/test_inspection.py
@@ -182,40 +182,40 @@ def test_describe_param_grid():
     subgrids.
 
     >>> print(pred.skb.describe_param_grid())
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
-      classifier: 'logreg'
-      C: choose_float(0.001, 100, log=True, name='C')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'robust'
       robust_scaler__with_centering: [True, False]
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
       classifier: 'logreg'
       C: choose_float(0.001, 100, log=True, name='C')
-      scaling: True
-      scaling_kind: 'standard'
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
-      classifier: 'logreg'
-      C: choose_float(0.001, 100, log=True, name='C')
-      scaling: False
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
-      classifier: 'rf'
-      N 🌴: choose_int(20, 400, name='N 🌴')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'robust'
       robust_scaler__with_centering: [True, False]
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
       classifier: 'rf'
       N 🌴: choose_int(20, 400, name='N 🌴')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'standard'
-    - dim_reduction: ['PCA', 'SelectKBest']
-      impute: ['true', 'false']
+      classifier: 'logreg'
+      C: choose_float(0.001, 100, log=True, name='C')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
+      scaling: True
+      scaling_kind: 'standard'
       classifier: 'rf'
       N 🌴: choose_int(20, 400, name='N 🌴')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
       scaling: False
+      classifier: 'logreg'
+      C: choose_float(0.001, 100, log=True, name='C')
+    - impute: ['true', 'false']
+      dim_reduction: ['PCA', 'SelectKBest']
+      scaling: False
+      classifier: 'rf'
+      N 🌴: choose_int(20, 400, name='N 🌴')
     """

--- a/skrub/_expressions/tests/test_parallel_coord.py
+++ b/skrub/_expressions/tests/test_parallel_coord.py
@@ -65,13 +65,13 @@ def test_parallel_coord():
     next(data)
     next(data)
     dim = next(data)
+    assert dim["label"] == "c4"
+    assert list(dim["ticktext"]) == ["Null", "A", "z"]
+    assert list(dim["tickvals"]) == [-1.0, 0, 1]
+    dim = next(data)
     assert dim["label"] == "c5"
     assert list(dim["ticktext"]) == ["Null", "False", "True"]
     assert list(dim["tickvals"]) == [-1.0, 0, 1]
     next(data)
-    dim = next(data)
-    assert dim["label"] == "c4"
-    assert list(dim["ticktext"]) == ["Null", "A", "z"]
-    assert list(dim["tickvals"]) == [-1.0, 0, 1]
     dim = next(data)
     assert dim["label"] == "fit time"


### PR DESCRIPTION
closes #1311 

The `name` parameter of all choices is now optional. When displaying results if there is no name the slightly shortened repr of the choice is used:

```
>>> from sklearn.datasets import make_classification
>>> from sklearn.preprocessing import StandardScaler
>>> from sklearn.linear_model import LogisticRegression
>>> from sklearn.ensemble import RandomForestClassifier

>>> import skrub

>>> X, y = make_classification()

>>> search = (
...     skrub.X(X)
...     .skb.apply(StandardScaler(with_mean=skrub.choose_bool()))
...     .skb.apply(
...         skrub.choose_from(
...             {
...                 "logistic": LogisticRegression(
...                     C=skrub.choose_float(0.1, 10.0, log=True),
...                     fit_intercept=skrub.choose_bool(),
...                 ),
...                 "rf": RandomForestClassifier(n_estimators=skrub.choose_int(5, 100)),
...             }
...         ),
...         y=skrub.y(y),
...     )
...     .skb.get_randomized_search(fitted=True)
... )
>>> search.results_.iloc[0]
mean_test_score                          0.98
choose_bool()                            True
choose_float(0.1, 10.0, log=True)         NaN
choose_bool()_1                           NaN
choose_int(5, 100)                       36.0
choose_from({'logistic': …, 'rf': …})      rf
Name: 0, dtype: object
```

I noticed plotly does not adjust the space it needs for the tick labels in the parallel coordinate plots, so the names are truncated. However that is also the case for long user-chosen names

![screenshot_2025-04-15T11:19:11+02:00](https://github.com/user-attachments/assets/24dd9df9-c1d5-4967-ae8d-d500a9b92f00)

reducing the labelangle helps

![screenshot_2025-04-15T11:33:57+02:00](https://github.com/user-attachments/assets/2422d56a-8fcb-449c-97c4-0109969f2899)
