### PR TITLE
fix missing return

### DIFF
--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -317,6 +317,7 @@ def _check_return_value(f):
             "their argument unchanged and return a new object."
         )
         warnings.warn(msg)
+        return expr
 
     return check_call_return_value
 

--- a/skrub/_expressions/tests/test_errors.py
+++ b/skrub/_expressions/tests/test_errors.py
@@ -65,7 +65,8 @@ def test_setattr():
 def test_func_returning_none():
     a = skrub.var("a", [])
     with pytest.warns(UserWarning, match=r"Calling '\.append\(\)' returned None"):
-        a.append(0)
+        out = a.append(0)
+    assert out.skb.eval() is None
 
 
 #


### PR DESCRIPTION
There is a check that sees if a function called in an expression returns None as this probably indicates it modifies its input in-place instead of returning a new value. When it was decided it should emit a warning rather than raise an exception I forgot to add the return statement after removing the raise statement