### PR TITLE
Small refactoring in expressions evaluation

### DIFF
--- a/skrub/_expressions/_evaluation.py
+++ b/skrub/_expressions/_evaluation.py
@@ -14,8 +14,6 @@ from . import _choosing
 from ._expressions import (
     Apply,
     Expr,
-    IfElse,
-    Match,
     Value,
     Var,
 )
@@ -109,12 +107,10 @@ class _ExprTraversal:
                 stack.pop()
         return last_result
 
-    def handle_expr(self, expr, attributes_to_evaluate=None):
+    def handle_expr(self, expr):
         impl = expr._skrub_impl
         evaluated_attributes = {}
-        if attributes_to_evaluate is None:
-            attributes_to_evaluate = impl._fields
-        for name in attributes_to_evaluate:
+        for name in impl._fields:
             attr = getattr(impl, name)
             evaluated_attributes[name] = yield attr
         return self.compute_result(expr, evaluated_attributes)
@@ -216,41 +212,17 @@ class _Evaluator(_ExprTraversal):
             return self._fetch(expr)
         except KeyError:
             pass
-        impl = expr._skrub_impl
-        if isinstance(impl, IfElse):
-            result = yield from self._handle_if_else(expr)
-        elif isinstance(impl, Match):
-            result = yield from self._handle_match(expr)
-        else:
-            result = yield from self._handle_expr_default(expr)
+        result = yield from self._eval_expr(expr)
         self._store(expr, result)
         for cb in self.callbacks:
             cb(expr, result)
         return result
 
-    def _handle_if_else(self, expr):
+    def _eval_expr(self, expr):
         impl = expr._skrub_impl
-        cond = yield impl.condition
-        if cond:
-            return (yield impl.value_if_true)
-        else:
-            return (yield impl.value_if_false)
-
-    def _handle_match(self, expr):
-        impl = expr._skrub_impl
-        query = yield impl.query
-        if impl.has_default():
-            target = impl.targets.get(query, impl.default)
-        else:
-            target = impl.targets[query]
-        return (yield target)
-
-    def _handle_expr_default(self, expr):
-        return (
-            yield from super().handle_expr(
-                expr, expr._skrub_impl.fields_required_for_eval(self.mode)
-            )
-        )
+        if hasattr(impl, "eval"):
+            return (yield from impl.eval(mode=self.mode, environment=self.environment))
+        return (yield from super().handle_expr(expr))
 
     def handle_choice(self, choice):
         if choice.name is not None and choice.name in self.environment:
@@ -715,10 +687,10 @@ class _FindNode(_ExprTraversal):
     def __init__(self, predicate=None):
         self.predicate = predicate
 
-    def handle_expr(self, e, *args, **kwargs):
+    def handle_expr(self, e):
         if self.predicate is None or self.predicate(e):
             raise _Found(e)
-        yield from super().handle_expr(e, *args, **kwargs)
+        yield from super().handle_expr(e)
 
     def handle_choice(self, choice):
         if self.predicate is None or self.predicate(choice):
@@ -770,14 +742,14 @@ class _FindConflicts(_ExprTraversal):
         self._x = {}
         self._y = {}
 
-    def handle_expr(self, e, *args, **kwargs):
+    def handle_expr(self, e):
         self._add(
             e,
             getattr(e._skrub_impl, "name", None),
             e._skrub_impl.is_X,
             e._skrub_impl.is_y,
         )
-        yield from super().handle_expr(e, *args, **kwargs)
+        yield from super().handle_expr(e)
 
     def handle_choice(self, choice):
         self._add(choice, getattr(choice, "name", None), False, False)
@@ -856,10 +828,10 @@ class _FindArg(_ExprTraversal):
         self.predicate = predicate
         self.skip_types = skip_types
 
-    def handle_expr(self, expr, **kwargs):
+    def handle_expr(self, expr):
         if isinstance(expr._skrub_impl, self.skip_types):
             return expr
-        return (yield from super().handle_expr(expr, **kwargs))
+        return (yield from super().handle_expr(expr))
 
     def handle_value(self, value):
         if self.predicate(value):
@@ -879,10 +851,10 @@ class _FindFirstApply(_ExprTraversal):
     def handle_choice(self, choice):
         return (yield choice.chosen_outcome_or_default())
 
-    def handle_expr(self, expr, **kwargs):
+    def handle_expr(self, expr):
         if isinstance(expr._skrub_impl, Apply):
             raise _Found(expr)
-        return (yield from super().handle_expr(expr, **kwargs))
+        return (yield from super().handle_expr(expr))
 
 
 def find_first_apply(expr):

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -988,7 +988,8 @@ class Apply(ExprImpl):
     _fields = ["X", "estimator", "y", "cols", "how", "allow_reject", "unsupervised"]
 
     # TODO can we avoid the need for an explicit unsupervised parameter by
-    # inspecting sklearn tags?
+    # inspecting the estimator? eg in recent versions we can look at
+    # tags.target_tags.required
 
     def eval(self, *, mode, environment):
         if mode not in self.supported_modes():

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -209,9 +209,6 @@ class ExprImpl:
     def preview_if_available(self):
         return self.results.get("preview", NULL)
 
-    def fields_required_for_eval(self, mode):
-        return self._fields
-
     def __repr__(self):
         return f"<{self.__class__.__name__}>"
 
@@ -936,6 +933,13 @@ def as_expr(value):
 class IfElse(ExprImpl):
     _fields = ["condition", "value_if_true", "value_if_false"]
 
+    def eval(self, *, environment, mode):
+        cond = yield self.condition
+        if cond:
+            return (yield self.value_if_true)
+        else:
+            return (yield self.value_if_false)
+
     def __repr__(self):
         cond, if_true, if_false = map(
             short_repr, (self.condition, self.value_if_true, self.value_if_false)
@@ -945,6 +949,14 @@ class IfElse(ExprImpl):
 
 class Match(ExprImpl):
     _fields = ["query", "targets", "default"]
+
+    def eval(self, *, environment, mode):
+        query = yield self.query
+        if self.has_default():
+            target = self.targets.get(query, self.default)
+        else:
+            target = self.targets[query]
+        return (yield target)
 
     def has_default(self):
         return self.default is not NULL
@@ -956,14 +968,9 @@ class Match(ExprImpl):
 class FreezeAfterFit(ExprImpl):
     _fields = ["target"]
 
-    def fields_required_for_eval(self, mode):
-        if "fit" in mode or mode == "preview":
-            return self._fields
-        return []
-
-    def compute(self, e, mode, environment):
+    def eval(self, *, mode, environment):
         if mode == "preview" or "fit" in mode:
-            self.value_ = e.target
+            self.value_ = yield self.target
         return self.value_
 
 
@@ -983,38 +990,39 @@ class Apply(ExprImpl):
     # TODO can we avoid the need for an explicit unsupervised parameter by
     # inspecting sklearn tags?
 
-    def fields_required_for_eval(self, mode):
-        if "fit" in mode or mode == "preview":
-            if not self.unsupervised:
-                return self._fields
-            return [f for f in self._fields if f != "y"]
-        if mode == "score":
-            return ["X", "y"]
-        return ["X"]
-
-    def compute(self, e, mode, environment):
+    def eval(self, *, mode, environment):
         if mode not in self.supported_modes():
             mode = "fit_transform" if "fit" in mode else "transform"
         method_name = "fit_transform" if mode == "preview" else mode
 
-        X = _check_column_names(e.X)
+        X = yield self.X
+        if ("fit" in method_name and not self.unsupervised) or method_name == "score":
+            y = yield self.y
+        else:
+            y = None
+
+        X = _check_column_names(X)
 
         if "fit" in method_name:
+            estimator = yield self.estimator
+            cols = yield self.cols
+            how = yield self.how
+            allow_reject = yield self.allow_reject
             self.estimator_ = _wrap_estimator(
-                estimator=e.estimator,
-                cols=e.cols,
-                how=e.how,
-                allow_reject=e.allow_reject,
+                estimator=estimator,
+                cols=cols,
+                how=how,
+                allow_reject=allow_reject,
                 X=X,
             )
 
         if "transform" in method_name and not hasattr(self.estimator_, "transform"):
             if "fit" in method_name:
-                self.estimator_.fit(X, e.y)
-                if sbd.is_column(e.y):
-                    self._all_outputs = [sbd.name(e.y)]
-                elif sbd.is_dataframe(e.y):
-                    self._all_outputs = sbd.column_names(e.y)
+                self.estimator_.fit(X, y)
+                if sbd.is_column(y):
+                    self._all_outputs = [sbd.name(y)]
+                elif sbd.is_dataframe(y):
+                    self._all_outputs = sbd.column_names(y)
                 else:
                     self._all_outputs = None
             pred = self.estimator_.predict(X)
@@ -1033,12 +1041,12 @@ class Apply(ExprImpl):
             return sbd.copy_index(X, result)
 
         if "fit" in method_name:
-            y = () if self.unsupervised else (e.y,)
+            y_arg = () if self.unsupervised else (y,)
         elif method_name == "score":
-            y = (e.y,)
+            y_arg = (y,)
         else:
-            y = ()
-        return getattr(self.estimator_, method_name)(X, *y)
+            y_arg = ()
+        return getattr(self.estimator_, method_name)(X, *y_arg)
 
     def supported_modes(self):
         modes = ["preview", "fit_transform", "transform"]


### PR DESCRIPTION
this allows ExprImpl subclasses to define `eval` to override how they are evaluated. it simplifies things a bit by not needing to special case expressions that may not need all their children to be evaluated (eg an applied estimator does not need y for predict, if_else needs only one of the branches to be evaluated, ...)