### PR TITLE
Removing distributions and associations tabs from TableReport in some cases

### DIFF
--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -576,7 +576,7 @@ class Expr:
             f"{graph}<br /><br />\n</details>\n"
             "<strong><samp>Result:</samp></strong>"
         )
-        report = node_report(self)
+        report = node_report(self, max_plot_columns=0, max_association_columns=0)
         if hasattr(report, "_repr_html_"):
             report = report._repr_html_()
         return f"<div>\n{prefix}\n{report}\n</div>"


### PR DESCRIPTION
Addressing #1329 

After discussing with @jeromedockes, the objective of this PR is removing the "Distributions" and "Associations" tabs, as well as the associated computations, from the TableReport.

We also need to find a different place for the message informing the user that no plots are being made, and suppress the message when the TableReport is generated for an expression. 