### PR TITLE
Make the selectors module public

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,7 @@ New features
 - The :mod:`selectors` module provides utilities for selecting columns to which
   a transformer should be applied in a flexible way. The module was created in
   :pr:`895` by :user:`Jérôme Dockès <jeromedockes>` and added to the public API
-  in :pr:`TODO` by :user:`Jérôme Dockès <jeromedockes>`.
+  in :pr:`1341` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Changes
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,20 +12,25 @@ Ongoing development
 New features
 ------------
 
-The skrub expressions are new mechanism for building machine-learning pipelines
-that handle multiple tables and easily describing their hyperparameter spaces.
-See :ref:`the examples <expressions_examples_ref>` for an introduction.
-:pr:`1233` by :user:`Jérôme Dockès <jeromedockes>`. A lot of work from other
-contributors is not directly visible on the pull request page: :user:`Vincent
-Maladiere <Vincent-Maladiere>` provided very important help by trying the
-expressions on many use-cases and datasets, providing feedback and suggesting
-improvements, improving the examples (including creating all the figures in the
-examples) and adding jitter to the parallel coordinate plots, :user:`Riccardo
-Cappuzzo<rcap107>` experimented with the expressions, suggested improvements and
-improved the examples, :user:`Gaël Varoquaux <gaelvaroquaux>` , :user:`Guillaume
-Lemaitre <glemaitre>`, :user:`Adrin Jalali <adrinjalali>`, :user:`Olivier Grisel
-<ogrisel>` and others participated through many discussions in defining the
-requirements and the public API.
+- The skrub expressions are new mechanism for building machine-learning
+  pipelines that handle multiple tables and easily describing their
+  hyperparameter spaces. See :ref:`the examples <expressions_examples_ref>` for
+  an introduction. :pr:`1233` by :user:`Jérôme Dockès <jeromedockes>`. A lot of
+  work from other contributors is not directly visible on the pull request page:
+  :user:`Vincent Maladiere <Vincent-Maladiere>` provided very important help by
+  trying the expressions on many use-cases and datasets, providing feedback and
+  suggesting improvements, improving the examples (including creating all the
+  figures in the examples) and adding jitter to the parallel coordinate plots,
+  :user:`Riccardo Cappuzzo<rcap107>` experimented with the expressions,
+  suggested improvements and improved the examples, :user:`Gaël Varoquaux
+  <gaelvaroquaux>` , :user:`Guillaume Lemaitre <glemaitre>`, :user:`Adrin Jalali
+  <adrinjalali>`, :user:`Olivier Grisel <ogrisel>` and others participated
+  through many discussions in defining the requirements and the public API.
+
+- The :mod:`selectors` module provides utilities for selecting columns to which
+  a transformer should be applied in a flexible way. The module was created in
+  :pr:`895` by :user:`Jérôme Dockès <jeromedockes>` and added to the public API
+  in :pr:`TODO` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Changes
 -------

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -177,6 +177,43 @@ For more control or in order to build pipelines for more datasets, use the skrub
    ExprEstimator
    ParamSearch
 
+.. _selectors_ref:
+
+Selecting columns in a DataFrame
+================================
+
+The srkub selectors provide a flexible way to specify the columns on which a
+transformation should be applied. They are meant to be used for the ``cols``
+argument of :meth:`Expr.skb.apply`, :meth:`Expr.skb.select`,
+:meth:`Expr.skb.drop`, :class:`SelectCols` or :class:`DropCols`.
+
+.. autosummary::
+   :toctree: generated/
+   :template: base.rst
+   :nosignatures:
+
+   selectors.all
+   selectors.any_date
+   selectors.boolean
+   selectors.cardinality_below
+   selectors.categorical
+   selectors.cols
+   selectors.Filter
+   selectors.filter
+   selectors.filter_names
+   selectors.float
+   selectors.glob
+   selectors.has_nulls
+   selectors.integer
+   selectors.inv
+   selectors.make_selector
+   selectors.NameFilter
+   selectors.numeric
+   selectors.regex
+   selectors.select
+   selectors.Selector
+   selectors.string
+
 .. _generating_a_report_ref:
 
 Generating an HTML report

--- a/examples/08_join_aggregation.py
+++ b/examples/08_join_aggregation.py
@@ -195,7 +195,7 @@ TableReport(products_transformed)
 # |MinHashEncoder|, for reasons that are out of the scope of this notebook.
 #
 from skrub import AggJoiner
-from skrub import _selectors as s
+from skrub import selectors as s
 
 # Skrub selectors allow us to select columns using regexes, which reduces
 # the boilerplate.

--- a/examples/FIXME/08_join_aggregation_full.py
+++ b/examples/FIXME/08_join_aggregation_full.py
@@ -470,7 +470,7 @@ TableReport(products_transformed)
 from sklearn.pipeline import make_pipeline
 
 from skrub import AggJoiner
-from skrub import _selectors as s
+from skrub import selectors as s
 
 minhash_cols = "ID" | s.glob("item_*") | s.glob("model_*") | s.glob("make_*")
 single_cols = ["ID", "goods_code", "Nbr_of_prod_purchas", "cash_price"]

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -4,7 +4,7 @@ skrub: Prepping tables for machine learning.
 
 from pathlib import Path as _Path
 
-from . import _selectors as selectors
+from . import selectors
 from ._agg_joiner import AggJoiner, AggTarget
 from ._column_associations import column_associations
 from ._datetime_encoder import DatetimeEncoder

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -15,7 +15,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from skrub import _dataframe as sbd
 from skrub import _join_utils, _utils
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._dispatch import dispatch
 
 from ._check_input import CheckInputDataFrame

--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -15,7 +15,7 @@ import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._dataframe import _common as ns
 
 

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -14,7 +14,7 @@ import warnings
 from sklearn.base import BaseEstimator
 
 from .. import _dataframe as sbd
-from .. import _selectors as s
+from .. import selectors as s
 from .._check_input import cast_column_names_to_strings
 from .._reporting._utils import strip_xml_declaration
 from .._utils import PassThrough, short_repr

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from . import _dataframe as sbd
 from . import _join_utils
-from . import _selectors as s
+from . import selectors as s
 from ._joiner import DEFAULT_REF_DIST, DEFAULT_STRING_ENCODER, Joiner
 
 

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -10,7 +10,7 @@ from sklearn.ensemble import (
 
 from . import _dataframe as sbd
 from . import _join_utils, _utils
-from . import _selectors as s
+from . import selectors as s
 from ._minhash_encoder import MinHashEncoder
 from ._sklearn_compat import get_tags
 from ._table_vectorizer import TableVectorizer

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -4,8 +4,8 @@ import inspect
 import re
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
 from skrub import _utils
+from skrub import selectors as s
 from skrub._dispatch import dispatch
 
 

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -16,7 +16,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
 from . import _join_utils, _matching, _utils
-from . import _selectors as s
+from . import selectors as s
 from ._check_input import CheckInputDataFrame
 from ._datetime_encoder import DatetimeEncoder
 from ._table_vectorizer import TableVectorizer

--- a/skrub/_on_each_column.py
+++ b/skrub/_on_each_column.py
@@ -8,7 +8,7 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
-from . import _selectors, _utils
+from . import _utils, selectors
 from ._join_utils import pick_column_names
 
 __all__ = ["OnEachColumn", "SingleColumnTransformer", "RejectColumn"]
@@ -425,7 +425,7 @@ class OnEachColumn(TransformerMixin, BaseEstimator):
     def __init__(
         self,
         transformer,
-        cols=_selectors.all(),
+        cols=selectors.all(),
         allow_reject=False,
         keep_original=False,
         rename_columns="{}",
@@ -443,7 +443,7 @@ class OnEachColumn(TransformerMixin, BaseEstimator):
         return self
 
     def fit_transform(self, X, y=None):
-        self._columns = _selectors.make_selector(self.cols).expand(X)
+        self._columns = selectors.make_selector(self.cols).expand(X)
         results = []
         all_columns = sbd.column_names(X)
         parallel = Parallel(n_jobs=self.n_jobs)

--- a/skrub/_on_subframe.py
+++ b/skrub/_on_subframe.py
@@ -2,7 +2,7 @@ from sklearn.base import BaseEstimator, TransformerMixin, clone
 from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
-from . import _selectors, _utils
+from . import _utils, selectors
 from ._join_utils import pick_column_names
 
 __all__ = ["OnSubFrame"]
@@ -128,7 +128,7 @@ class OnSubFrame(TransformerMixin, BaseEstimator):
     def __init__(
         self,
         transformer,
-        cols=_selectors.all(),
+        cols=selectors.all(),
         keep_original=False,
         rename_columns="{}",
     ):
@@ -143,12 +143,12 @@ class OnSubFrame(TransformerMixin, BaseEstimator):
 
     def fit_transform(self, X, y=None):
         self.all_inputs_ = sbd.column_names(X)
-        self._columns = _selectors.make_selector(self.cols).expand(X)
-        to_transform = _selectors.select(X, self._columns)
+        self._columns = selectors.make_selector(self.cols).expand(X)
+        to_transform = selectors.select(X, self._columns)
         if self.keep_original:
             passthrough = X
         else:
-            passthrough = _selectors.select(X, _selectors.inv(self._columns))
+            passthrough = selectors.select(X, selectors.inv(self._columns))
         passthrough_names = sbd.column_names(passthrough)
         if self._columns:
             self.transformer_ = clone(self.transformer)
@@ -187,11 +187,11 @@ class OnSubFrame(TransformerMixin, BaseEstimator):
 
         # do the selection even if self._columns is empty to raise if X doesn't
         # have the right columns
-        to_transform = _selectors.select(X, self._columns)
+        to_transform = selectors.select(X, self._columns)
         if self.keep_original:
             passthrough = X
         else:
-            passthrough = _selectors.select(X, _selectors.inv(self._columns))
+            passthrough = selectors.select(X, selectors.inv(self._columns))
         if not self._columns:
             return passthrough
         transformed = self.transformer_.transform(to_transform)

--- a/skrub/_reporting/_html.py
+++ b/skrub/_reporting/_html.py
@@ -9,7 +9,7 @@ import jinja2
 import pandas as pd
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
 
 from .._utils import random_string
 from . import _utils

--- a/skrub/_select_cols.py
+++ b/skrub/_select_cols.py
@@ -1,6 +1,6 @@
 from sklearn.base import BaseEstimator, TransformerMixin
 
-from . import _selectors as s
+from . import selectors as s
 from ._on_each_column import SingleColumnTransformer
 
 

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -11,8 +11,8 @@ from sklearn.utils._estimator_html_repr import _VisualBlock
 from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
-from . import _selectors as s
 from . import _utils
+from . import selectors as s
 from ._check_input import CheckInputDataFrame
 from ._clean_categories import CleanCategories
 from ._clean_null_strings import CleanNullStrings
@@ -91,7 +91,7 @@ def _created_by(*transformers):
         attribute) ``_pipeline`` which is constructed and fitted during
         ``TableVectorizer.fit``, and is never cloned. ``_created_by`` is a
         private helper of ``TableVectorizer``, not meant to be generally useful
-        and it should not be moved to the ``skrub._selectors`` module.
+        and it should not be moved to the ``skrub.selectors`` module.
     """
     return s.Filter(
         _created_by_predicate,

--- a/skrub/_to_datetime.py
+++ b/skrub/_to_datetime.py
@@ -6,7 +6,7 @@ from pandas._libs.tslibs.parsing import (
 from sklearn.utils.validation import check_is_fitted
 
 from . import _dataframe as sbd
-from . import _selectors as s
+from . import selectors as s
 from ._dispatch import dispatch
 from ._on_each_column import RejectColumn, SingleColumnTransformer
 from ._wrap_transformer import wrap_transformer

--- a/skrub/_wrap_transformer.py
+++ b/skrub/_wrap_transformer.py
@@ -1,6 +1,6 @@
 from ._on_each_column import OnEachColumn
 from ._on_subframe import OnSubFrame
-from ._selectors import make_selector
+from .selectors import make_selector
 
 __all__ = ["wrap_transformer"]
 
@@ -74,7 +74,7 @@ def wrap_transformer(
     --------
     >>> from skrub._wrap_transformer import wrap_transformer
     >>> from skrub._to_datetime import ToDatetime
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> from sklearn.preprocessing import OrdinalEncoder
 
     >>> wrap_transformer(ToDatetime(), s.all())

--- a/skrub/selectors/__init__.py
+++ b/skrub/selectors/__init__.py
@@ -33,7 +33,7 @@ Here is an example dataframe:
 A simple kind of selector selects a fixed list of column names. Such selectors
 are created with the ``cols()`` function.
 
->>> from skrub import _selectors as s
+>>> from skrub import selectors as s
 >>> mm_cols = s.cols("height_mm", "width_mm")
 >>> mm_cols
 cols('height_mm', 'width_mm')
@@ -134,9 +134,8 @@ client code. Rather, users would create selectors and pass them instead of a
 column list to skrub objects that operate on a subset of columns. This could
 be, for example, the cols parameter of SelectCols: SelectCols(s.glob("*_mm")).
 
-This is not yet the case for SelectCols, as _selectors is still a completely
-private module. One example of a (private) function that consumes selectors is
-the ``select`` function provided in this module.
+One example of a (private) function that consumes selectors is the ``select``
+function provided in this module.
 
 >>> s.select(df, ["ID", "kind"])
    ID kind
@@ -224,7 +223,7 @@ Directly instantiating a Filter or FilterNames object allows passing the name
 argument and thus controlling the repr of the resulting selector, so an
 slightly improved version could be:
 
->>> from skrub._selectors._base import NameFilter
+>>> from skrub.selectors._base import NameFilter
 
 >>> def ends_with(suffix):
 ...     return NameFilter(str.endswith, args=(suffix,), name='ends_with')

--- a/skrub/selectors/_base.py
+++ b/skrub/selectors/_base.py
@@ -8,7 +8,7 @@ def all():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -37,7 +37,7 @@ def cols(*columns):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -97,7 +97,7 @@ def inv(obj):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -136,7 +136,7 @@ def make_selector(obj):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
 
     >>> s.make_selector('ID')
     cols('ID')
@@ -180,7 +180,7 @@ def select(df, selector):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -408,7 +408,7 @@ def filter(predicate, *args, **kwargs):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -471,7 +471,7 @@ def filter_names(predicate, *args, **kwargs):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {

--- a/skrub/selectors/_selectors.py
+++ b/skrub/selectors/_selectors.py
@@ -35,7 +35,7 @@ def glob(pattern):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -78,7 +78,7 @@ def regex(pattern, flags=0):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     {
@@ -148,7 +148,7 @@ def numeric():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> import numpy as np
     >>> df = pd.DataFrame(
@@ -200,7 +200,7 @@ def integer():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> import numpy as np
     >>> df = pd.DataFrame(
@@ -249,7 +249,7 @@ def float():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> import numpy as np
     >>> df = pd.DataFrame(
@@ -295,7 +295,7 @@ def any_date():
     Examples
     --------
     >>> import datetime
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
 
     >>> df = pd.DataFrame(
@@ -331,7 +331,7 @@ def categorical():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     dict(
@@ -368,7 +368,7 @@ def string():
     Examples
     --------
 
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     dict(
@@ -410,7 +410,7 @@ def boolean():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> import numpy as np
     >>> df = pd.DataFrame(
@@ -461,7 +461,7 @@ def cardinality_below(threshold):
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(
     ...     dict(
@@ -502,7 +502,7 @@ def has_nulls():
 
     Examples
     --------
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> import pandas as pd
     >>> df = pd.DataFrame(dict(a=[0, 1, 2], b=[0, None, 20], c=['a', 'b', None]))
     >>> s.select(df, s.has_nulls())

--- a/skrub/selectors/_selectors.py
+++ b/skrub/selectors/_selectors.py
@@ -26,7 +26,7 @@ __all__ = [
 def glob(pattern):
     """Select columns by name with Unix shell style 'glob' pattern.
 
-    pattern is interpreted as described in ``fnmatch.fnmatchcase``:
+    pattern is interpreted as described in ``fnmatch.fnmatchcase``::
 
         *       matches everything
         ?       matches any single character

--- a/skrub/selectors/tests/test_base.py
+++ b/skrub/selectors/tests/test_base.py
@@ -1,12 +1,19 @@
 import pytest
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
+
+
+def test_import_selectors():
+    # selectors used to be called _selectors but now this should work
+    import skrub.selectors
+
+    assert "numeric" in skrub.selectors.__all__
 
 
 def test_repr():
     """
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> s.all()
     all()
     >>> s.all() - ["ID", "Name"]

--- a/skrub/selectors/tests/test_selectors.py
+++ b/skrub/selectors/tests/test_selectors.py
@@ -5,12 +5,12 @@ import types
 import pytest
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
 
 
 def test_repr():
     """
-    >>> from skrub import _selectors as s
+    >>> from skrub import selectors as s
     >>> s.numeric() - s.boolean()
     (numeric() - boolean())
     >>> s.numeric() | s.glob("*_mm") - s.regex(r"^[ 0-9]+_mm$")

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -4,7 +4,7 @@ import pytest
 
 from skrub import DatetimeEncoder
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._datetime_encoder import _CircularEncoder, _SplineEncoder
 from skrub._on_each_column import OnEachColumn
 from skrub._to_float32 import ToFloat32

--- a/skrub/tests/test_fuzzy_join.py
+++ b/skrub/tests/test_fuzzy_join.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_array_equal
 from sklearn.feature_extraction.text import HashingVectorizer
 
 from skrub import ToDatetime, _join_utils, fuzzy_join
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._dataframe import _common as ns
 
 

--- a/skrub/tests/test_on_each_column.py
+++ b/skrub/tests/test_on_each_column.py
@@ -9,7 +9,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OneHotEncoder
 
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._on_each_column import OnEachColumn, RejectColumn, SingleColumnTransformer
 from skrub._select_cols import Drop
 

--- a/skrub/tests/test_on_subframe.py
+++ b/skrub/tests/test_on_subframe.py
@@ -9,7 +9,7 @@ from sklearn.preprocessing import FunctionTransformer
 
 from skrub import SelectCols
 from skrub import _dataframe as sbd
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._on_subframe import OnSubFrame
 
 

--- a/skrub/tests/test_wrap_transformer.py
+++ b/skrub/tests/test_wrap_transformer.py
@@ -1,6 +1,6 @@
 from sklearn.preprocessing import OrdinalEncoder
 
-from skrub import _selectors as s
+from skrub import selectors as s
 from skrub._on_each_column import OnEachColumn
 from skrub._on_subframe import OnSubFrame
 from skrub._to_datetime import ToDatetime


### PR DESCRIPTION
closes #1146 

It is already exposed as a public attribute of skrub as they can be used with expressions so 

```python
from skrub import selectors as s
```

already works on the main branch

however the actual module is called `_selectors` so 

```python
import skrub.selectors
```

raises an importerror

this pr renames it to `selectors`