### PR TITLE
Small typo in `skb.get_randomized_search` docstring

### DIFF
--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -1288,12 +1288,12 @@ class SkrubNamespace:
         return search.fit(self.get_data())
 
     def get_randomized_search(self, *, fitted=False, **kwargs):
-        """Find the best parameters with grid search.
+        """Find the best parameters with randomized search.
 
         This function returns a :class:`ParamSearch`, an object similar to
-        scikit-learn's ``RandomizedSearchCV``. The main difference is that
-        methods such as ``fit()`` and ``predict()`` accept a dictionary of
-        inputs rather than ``X`` and ``y``. Please refer to the examples
+        scikit-learn's :class:`~sklearn.model_selection.RandomizedSearchCV`. The main
+        difference is that methods such as ``fit()`` and ``predict()`` accept a
+        dictionary of inputs rather than ``X`` and ``y``. Please refer to the examples
         gallery for an in-depth explanation.
 
         Parameters
@@ -1305,7 +1305,7 @@ class SkrubNamespace:
 
         kwargs : dict
             All other named arguments are forwarded to
-            ``sklearn.search.RandomizedSearchCV``.
+            :class:`~sklearn.search.RandomizedSearchCV`.
 
         Returns
         -------


### PR DESCRIPTION
Small typo fix + cross link to sklearn