### PR TITLE
Add  a `default` parameter to choices

### DIFF
--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -160,7 +160,7 @@ search.plot_results()
 # :func:`choose_int`, :func:`choose_float` and :func:`choose_bool`, we can use
 # the ``default`` parameter. For :func:`choose_from`, the default is the first
 # item from the list or dict of outcomes we provide. For :func:`optional`, we
-# can pass ``none_by_default=True`` to force the default to be the alternative
+# can pass ``default=None`` to force the default to be the alternative
 # outcome, ``None``.
 #
 # When we do not set an explicit default, skrub picks one for depending on the

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -153,15 +153,18 @@ search.plot_results()
 # example in previews or to get a quick first result before spending the
 # computation time to run the search. When we use :meth:`.skb.get_pipeline()
 # <Expr.skb.get_pipeline>`, we get a pipeline that does not perform any tuning
-# and uses those default values.
+# and uses those default values. That default pipeline is the one used for
+# :meth:`.skb.eval() <Expr.skb.eval>`.
 #
-# We can control what should be the default value in this case. For
-# :func:`choose_int`, :func:`choose_float` and :func:`choose_bool`, we can
-# provide an explicit ``default``. For :func:`choose_from`, the default is the
-# first item from the list or dict of outcomes we provide. For
-# :func:`optional`, we can pass ``none_by_default`` to force the default to be
-# the alternative outcome, ``None``. If we do not set an explicit default,
-# skrub picks one for depending on the kind of choice:
+# We can control what should be the default value for each choice. For
+# :func:`choose_int`, :func:`choose_float` and :func:`choose_bool`, we can use
+# the ``default`` parameter. For :func:`choose_from`, the default is the first
+# item from the list or dict of outcomes we provide. For :func:`optional`, we
+# can pass ``none_by_default=True`` to force the default to be the alternative
+# outcome, ``None``.
+#
+# When we do not set an explicit default, skrub picks one for depending on the
+# kind of choice:
 #
 # .. list-table:: default choice outcomes
 #    :header-rows: 1
@@ -199,7 +202,7 @@ search.plot_results()
 #
 
 # %%
-# Of course if we set the default that is used instead:
+# As mentioned we can control the default value:
 
 # %%
 skrub.choose_float(1.0, 100.0, default=12.0).default()

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -1,4 +1,6 @@
 """
+.. currentmodule:: skrub
+
 .. _example_tuning_pipelines:
 
 Tuning pipelines
@@ -140,6 +142,64 @@ search.results_
 
 # %%
 search.plot_results()
+
+# %%
+# Default choice values
+# ---------------------
+#
+# The goal of using the different ``choose_*`` functions is to tune choices on
+# validation metrics with randomized or grid search. However, even when our
+# expression contains such choices we can still use it without tuning, for
+# example in previews or to get a quick first result before spending the
+# computation time to run the search. When we use :meth:`.skb.get_pipeline()
+# <Expr.skb.get_pipeline>`, we get a pipeline that does not perform any tuning
+# and uses those default values.
+#
+# We can explicitly choose what should be the default value in this case, with
+# the ``default`` parameter of the different choice functions.
+# If we do not set an explicit default, skrub picks one for depending on the
+# kind of choice:
+#
+# .. list-table:: default choice outcomes
+#    :header-rows: 1
+#
+#    * - choosing function
+#      - default outcome
+#    * - :func:`choose_from([10, 20]) <choose_from>`
+#      - first outcome in the list: ``10``
+#    * - :func:`choose_from({"a_name": 10, "b_name": 20}) <choose_from>`
+#      - first outcome in the dict: ``10``
+#    * - :func:`optional(10) <optional>`
+#      - the provided ``value``: ``10``
+#    * - :func:`choose_bool() <choose_bool>`
+#      - ``True``
+#    * - :func:`choose_float(1.0, 100.0) <choose_float>`
+#      - the middle of the range: ``50.5``
+#    * - :func:`choose_int(1, 100) <choose_int>`
+#      - the int closest to the middle of the range: ``50``
+#    * - :func:`choose_float(1.0, 100.0, log=True) <choose_float>`
+#      - the middle of the range on a log scale: ``10.0``
+#    * - :func:`choose_int(1, 100, log=True) <choose_int>`
+#      - the int closest to the middle of the range on a log scale: ``10``
+#    * - :func:`choose_float(1.0, 100.0, n_steps=4) <choose_float>`
+#      - the step closest to the middle of the range: ``34.0`` (here steps are
+#        ``[1.0, 34.0, 67.0, 100.0]``)
+#    * - :func:`choose_int(1, 100, n_steps=4) <choose_int>`
+#      - the (integer) step closest to the middle of the range: ``34`` (here steps are
+#        ``[1, 34, 67, 100]``)
+#    * - :func:`choose_float(1.0, 100.0, log=True, n_steps=4) <choose_float>`
+#      - the step closest to the middle of the range on a log scale: ``4.64``
+#        (here steps are ``[1.0, 4.64, 21.54, 100.0]``)
+#    * - :func:`choose_float(1.0, 100.0, log=True) <choose_int>`
+#      - the (integer) step closest to the middle of the range on a log scale: ``5``
+#        (here steps are ``[1, 5, 22, 100]``)
+#
+
+# %%
+# Of course if we set the default that is used instead:
+
+# %%
+skrub.choose_from([10, 20], default=20).default()
 
 # %%
 # Choices can appear in many places

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -155,10 +155,13 @@ search.plot_results()
 # <Expr.skb.get_pipeline>`, we get a pipeline that does not perform any tuning
 # and uses those default values.
 #
-# We can explicitly choose what should be the default value in this case, with
-# the ``default`` parameter of the different choice functions.
-# If we do not set an explicit default, skrub picks one for depending on the
-# kind of choice:
+# We can control what should be the default value in this case. For
+# :func:`choose_int`, :func:`choose_float` and :func:`choose_bool`, we can
+# provide an explicit ``default``. For :func:`choose_from`, the default is the
+# first item from the list or dict of outcomes we provide. For
+# :func:`optional`, we can pass ``none_by_default`` to force the default to be
+# the alternative outcome, ``None``. If we do not set an explicit default,
+# skrub picks one for depending on the kind of choice:
 #
 # .. list-table:: default choice outcomes
 #    :header-rows: 1
@@ -199,7 +202,7 @@ search.plot_results()
 # Of course if we set the default that is used instead:
 
 # %%
-skrub.choose_from([10, 20], default=20).default()
+skrub.choose_float(1.0, 100.0, default=12.0).default()
 
 # %%
 # Choices can appear in many places

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -399,12 +399,12 @@ def choose_from(outcomes, *, name=None, default=NULL):
 
     Normally the default value is the first item:
 
-    >>> choose_from([1, 2, 3]).as_expr().skb.eval()
+    >>> choose_from([1, 2, 3]).default()
     1
 
     But we can override it with a different value:
 
-    >>> choose_from([1, 2, 3], default=2).as_expr().skb.eval()
+    >>> choose_from([1, 2, 3], default=2).default()
     2
     """
     if isinstance(outcomes, typing.Mapping):
@@ -517,13 +517,13 @@ def optional(value, *, name=None, default=NULL):
     When a pipeline containing an ``optional`` step is used *without
     hyperparameter tuning*, the default outcome is the provided ``value``.
 
-    >>> print(optional(PCA()).as_expr().skb.eval())
+    >>> print(optional(PCA()).default())
     PCA()
 
     This can be overridden with the ``default`` parameter. For example if we
     want the alternative (``None``) by default:
 
-    >>> print(optional(PCA(), default=None).as_expr().skb.eval())
+    >>> print(optional(PCA(), default=None).default())
     None
     """
     return Optional(
@@ -607,12 +607,12 @@ def choose_bool(*, name=None, default=NULL):
     >>> import skrub
     >>> print(skrub.choose_bool().as_expr().skb.describe_param_grid())
     - choose_bool(): [True, False]
-    >>> skrub.choose_bool().as_expr().skb.eval()
+    >>> skrub.choose_bool().default()
     True
 
     We can set the default to make it ``False``:
 
-    >>> skrub.choose_bool(default=False).as_expr().skb.eval()
+    >>> skrub.choose_bool(default=False).default()
     False
     """
     return BoolChoice(

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -70,12 +70,12 @@ class BaseChoice:
         raise TypeError(f"key must be {self.keys()[0]!r}")
 
 
-def _check_match_keys(outcome_values, default_outcome, mapping_keys, has_default):
+def _check_match_keys(outcomes, default_outcome, match_keys, match_has_default):
     if default_outcome is not NULL:
-        outcome_values = [*outcome_values, default_outcome]
+        outcomes = [*outcomes, default_outcome]
     try:
-        extra_keys = set(mapping_keys).difference(outcome_values)
-        extra_outcomes = set(outcome_values).difference(mapping_keys)
+        extra_keys = set(match_keys).difference(outcomes)
+        extra_outcomes = set(outcomes).difference(match_keys)
     except TypeError as e:
         raise TypeError(f"To use `match()`, all choice outcomes must be hashable. {e}")
     if extra_keys:
@@ -83,7 +83,7 @@ def _check_match_keys(outcome_values, default_outcome, mapping_keys, has_default
             "The following keys were found in the mapping provided to `match()` but"
             f" are not possible choice outcomes: {extra_keys!r}"
         )
-    if has_default:
+    if match_has_default:
         return
     if extra_outcomes:
         raise ValueError(
@@ -237,10 +237,10 @@ class Choice(BaseChoice):
         {'logistic': 'linear', 'hgb': 'unknown'}
         """  # noqa : E501
         _check_match_keys(
-            self.outcomes,
-            self.default_outcome,
-            outcome_mapping.keys(),
-            default is not NULL,
+            outcomes=self.outcomes,
+            default_outcome=self.default_outcome,
+            match_keys=outcome_mapping.keys(),
+            match_has_default=default is not NULL,
         )
         if default is NULL:
             complete_mapping = outcome_mapping
@@ -324,10 +324,10 @@ class Match:
         {'logistic': StandardScaler(), 'random_forest': 'passthrough', 'hgb': 'passthrough'}
         """  # noqa: E501
         _check_match_keys(
-            self.outcome_mapping.values(),
-            NULL,
-            outcome_mapping.keys(),
-            default is not NULL,
+            outcomes=self.outcome_mapping.values(),
+            default_outcome=NULL,
+            match_keys=outcome_mapping.keys(),
+            match_has_default=default is not NULL,
         )
         mapping = {
             k: outcome_mapping.get(v, default) for k, v in self.outcome_mapping.items()

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -473,7 +473,7 @@ def optional(value, *, name=None, default=OPTIONAL_VALUE):
         ``None``. Normally, the default outcome when a pipeline is used
         *without hyperparameter tuning* is the provided ``value``. Pass
         ``default=None`` to make the alternative outcome, ``None``, the
-        default. `None` is the only allowed value for this parameter.
+        default. ``None`` is the only allowed value for this parameter.
 
     Returns
     -------

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -439,6 +439,7 @@ class Optional(Choice):
 
     def __repr__(self):
         if self.outcomes[0] is not None or self.outcomes[1] is None:
+            # note when `value` is None, `none_by_default` makes no difference
             value, none_by_default = self.outcomes[0], False
         else:
             value, none_by_default = self.outcomes[1], True

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -423,7 +423,7 @@ class Optional(Choice):
 
     def __repr__(self):
         args = _utils.repr_args(
-            (self.outcomes[0]),
+            (self.outcomes[0],),
             {"name": self.name, "default": self.default_outcome},
             defaults={"name": None, "default": NULL},
         )

--- a/skrub/_expressions/_choosing.py
+++ b/skrub/_expressions/_choosing.py
@@ -153,8 +153,7 @@ class Choice(BaseChoice):
             Maps possible outcome to the desired result. The keys must all be
             one of the possible outcomes for the choice. If no ``default`` is
             provided, there must be an entry in ``outcome_mapping`` for each
-            possible choice outcome (including the choice's default outcome if
-            that has been set).
+            possible choice outcome.
 
         default : object, optional
             The value to use for outcomes not found in ``outcome_mapping``.
@@ -439,8 +438,9 @@ class Optional(Choice):
     """A choice between something and nothing."""
 
     def __repr__(self):
-        value, none_by_default = self.outcomes[0], False
-        if value is None:
+        if self.outcomes[0] is not None or self.outcomes[1] is None:
+            value, none_by_default = self.outcomes[0], False
+        else:
             value, none_by_default = self.outcomes[1], True
         args = _utils.repr_args(
             (value,),

--- a/skrub/_expressions/_evaluation.py
+++ b/skrub/_expressions/_evaluation.py
@@ -125,14 +125,11 @@ class _ExprTraversal:
         return estimator
 
     def handle_choice(self, choice):
-        new_default = yield choice.default_outcome
         if not isinstance(choice, _choosing.Choice):
             # choice is a BaseNumericChoice
-            return _choosing._with_fields(choice, default_outcome=new_default)
+            return _choosing._with_fields(choice)
         new_outcomes = yield choice.outcomes
-        return _choosing._with_fields(
-            choice, outcomes=new_outcomes, default_outcome=new_default
-        )
+        return _choosing._with_fields(choice, outcomes=new_outcomes)
 
     def handle_choice_match(self, choice_match):
         choice = yield choice_match.choice

--- a/skrub/_expressions/_evaluation.py
+++ b/skrub/_expressions/_evaluation.py
@@ -125,11 +125,14 @@ class _ExprTraversal:
         return estimator
 
     def handle_choice(self, choice):
+        new_default = yield choice.default_outcome
         if not isinstance(choice, _choosing.Choice):
             # choice is a BaseNumericChoice
-            return choice
+            return _choosing._with_fields(choice, default_outcome=new_default)
         new_outcomes = yield choice.outcomes
-        return _choosing._with_fields(choice, outcomes=new_outcomes)
+        return _choosing._with_fields(
+            choice, outcomes=new_outcomes, default_outcome=new_default
+        )
 
     def handle_choice_match(self, choice_match):
         choice = yield choice_match.choice
@@ -390,8 +393,6 @@ class _Cloner(_ExprTraversal):
         if id(choice) in self._replace:
             return self._replace[id(choice)]
         new_choice = yield from super().handle_choice(choice)
-        if not isinstance(new_choice, _choosing.Choice):
-            new_choice = _choosing._with_fields(choice)
         self._replace[id(choice)] = new_choice
         return new_choice
 

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -1096,6 +1096,14 @@ class SkrubNamespace:
         provided as the values in ``skrub.var("name", value=...)`` and
         ``skrub.X(value)``.
 
+        .. warning::
+
+           If the expression contains choices (e.g. ``choose_from(...)``), this
+           pipeline uses the default value of each choice. To actually pick the
+           best value with hyperparameter tuning, use
+           :meth:`Expr.skb.get_randomized_search` or
+           :meth:`Expr.skb.get_grid_search` instead.
+
         Parameters
         ----------
         fitted : bool (default=False)

--- a/skrub/_expressions/_utils.py
+++ b/skrub/_expressions/_utils.py
@@ -10,16 +10,18 @@ Y_NAME = "_skrub_y"
 
 
 class Sentinels(enum.Enum):
-    NULL = enum.auto()
+    NULL = "NULL"
+    OPTIONAL_VALUE = "value"
 
     def __repr__(self):
-        return self.name
+        return self.value
 
     def __str__(self):
-        return self.name
+        return self.value
 
 
 NULL = Sentinels.NULL
+OPTIONAL_VALUE = Sentinels.OPTIONAL_VALUE
 
 
 def simple_repr(expr):

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -76,6 +76,14 @@ def test_bad_bounds():
         skrub.choose_float(0.0, 10.0, log=True, name="c")
 
 
+def test_bad_numeric_default():
+    with pytest.raises(TypeError, match=".*must be an integer"):
+        skrub.choose_int(0, 10, default=5.5)
+    with pytest.raises(TypeError, match=".*must be a float"):
+        skrub.choose_float(0, 10, default=skrub.as_expr(5.5))
+    assert skrub.choose_float(0, 10, default=5).default() == 5
+
+
 def test_as_expr():
     c = skrub.choose_from([10, 20, 30], name="c")
     m = c.match({10: "ten", 20: "twenty"}, default="?")
@@ -244,6 +252,12 @@ def test_choice_repr():
     choose_bool(name='a')
     >>> skrub.choose_float(1, 10, n_steps=2, name="i")
     choose_float(1, 10, n_steps=2, name='i')
+    >>> skrub.optional('value')
+    optional('value')
+    >>> skrub.optional('value', none_by_default=True)
+    optional('value', none_by_default=True)
+    >>> skrub.optional(None, none_by_default=True)
+    optional(None)
     """
 
 

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -110,10 +110,52 @@ def test_get_chosen_or_default():
     assert _choosing.get_chosen_or_default(c) == 12.0
     assert _choosing.get_default(c) == 15.0
 
+    c = skrub.choose_int(100, 200, name="c", n_steps=4)
+    assert _choosing.get_chosen_or_default(c) == 133
+    assert _choosing.get_default(c) == 133
+    c.chosen_outcome = 167
+    assert _choosing.get_chosen_or_default(c) == 167
+    assert _choosing.get_default(c) == 133
 
-def test_match():
+
+def test_get_chosen_or_default_explicit_default():
+    c = skrub.choose_from([10, 20], name="c", default=100)
+    assert _choosing.get_chosen_or_default(c) == 100
+    assert _choosing.get_default(c) == 100
+    c.chosen_outcome_idx = 1
+    assert _choosing.get_chosen_or_default(c) == 20
+    assert _choosing.get_default(c) == 100
+
+    c = skrub.choose_from([10, 20], name="c", default=100)
+    m = c.match({10: "ten", 20: "twenty", 100: "one hundred"})
+    assert _choosing.get_chosen_or_default(m) == "one hundred"
+    assert _choosing.get_default(m) == "one hundred"
+    c.chosen_outcome_idx = 1
+    assert _choosing.get_chosen_or_default(m) == "twenty"
+    assert _choosing.get_default(m) == "one hundred"
+
+    c = skrub.choose_float(10.0, 20.0, name="c", default=13.0)
+    assert _choosing.get_chosen_or_default(c) == 13.0
+    assert _choosing.get_default(c) == 13.0
+    c.chosen_outcome = 12.0
+    assert _choosing.get_chosen_or_default(c) == 12.0
+    assert _choosing.get_default(c) == 13.0
+
+    c = skrub.choose_int(100, 200, name="c", n_steps=4, default=72)
+    assert _choosing.get_chosen_or_default(c) == 72
+    assert _choosing.get_default(c) == 72
+    c.chosen_outcome = 167
+    assert _choosing.get_chosen_or_default(c) == 167
+    assert _choosing.get_default(c) == 72
+
+
+@pytest.mark.parametrize("choice_has_default", [False, True])
+def test_match(choice_has_default):
     assert not hasattr(skrub.choose_int(0, 10, n_steps=6, name="N"), "match")
-    c = skrub.choose_from(["a", "b", "c"], name="c")
+    if choice_has_default:
+        c = skrub.choose_from(["a", "b"], name="c", default="c")
+    else:
+        c = skrub.choose_from(["a", "b", "c"], name="c")
 
     # m and mm without default
     m = c.match({"a": 10, "b": 20, "c": 30})
@@ -144,9 +186,14 @@ def test_match():
     assert mm.outcome_mapping == {"a": "ten", "b": "twenty", "c": "??"}
 
 
+@pytest.mark.parametrize("choice_has_default", [False, True])
 @pytest.mark.parametrize("test_class", ["choice", "match"])
-def test_bad_match_mappings(test_class):
-    c = skrub.choose_from(["a", "b", "c"], name="c")
+def test_bad_match_mappings(choice_has_default, test_class):
+    if choice_has_default:
+        c = skrub.choose_from(["a", "b"], name="c", default="c")
+    else:
+        c = skrub.choose_from(["a", "b", "c"], name="c")
+
     if test_class == "match":
         c = c.match({"a": "a", "b": "b", "c": "c"})
     with pytest.raises(

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -268,3 +268,20 @@ def test_choice_repr():
     >>> skrub.choose_float(1, 10, n_steps=2, name="i")
     choose_float(1, 10, n_steps=2, name='i')
     """
+
+
+def test_defaults_shown_in_doc_table():
+    assert skrub.choose_from([10, 20]).default() == 10
+    assert skrub.choose_from({"a_name": 10, "b_name": 20}).default() == 10
+    assert skrub.optional(10).default() == 10
+    assert skrub.choose_bool().default() is True
+    assert skrub.choose_float(1.0, 100.0).default() == 50.5
+    assert skrub.choose_int(1, 100).default() == 50
+    assert skrub.choose_float(1.0, 100.0, log=True).default() == pytest.approx(10.0)
+    assert skrub.choose_int(1, 100, log=True).default() == 10
+    assert skrub.choose_float(1.0, 100.0, n_steps=4).default() == 34.0
+    assert skrub.choose_int(1, 100, n_steps=4).default() == 34
+    assert skrub.choose_float(
+        1.0, 100.0, log=True, n_steps=4
+    ).default() == pytest.approx(4.641588833612779)
+    assert skrub.choose_int(1, 100, log=True, n_steps=4).default() == 5

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -142,6 +142,11 @@ def test_get_chosen_or_default_explicit_default():
     assert _choosing.get_default(c) == 72
 
 
+def test_bad_optional_default():
+    with pytest.raises(TypeError, match=".*must be `None`"):
+        skrub.optional(10, default=10)
+
+
 def test_match():
     assert not hasattr(skrub.choose_int(0, 10, n_steps=6, name="N"), "match")
     c = skrub.choose_from(["a", "b", "c"], name="c")
@@ -254,9 +259,9 @@ def test_choice_repr():
     choose_float(1, 10, n_steps=2, name='i')
     >>> skrub.optional('value')
     optional('value')
-    >>> skrub.optional('value', none_by_default=True)
-    optional('value', none_by_default=True)
-    >>> skrub.optional(None, none_by_default=True)
+    >>> skrub.optional('value', default=None)
+    optional('value', default=None)
+    >>> skrub.optional(None, default=None)
     optional(None)
     """
 

--- a/skrub/_expressions/tests/test_choosing.py
+++ b/skrub/_expressions/tests/test_choosing.py
@@ -119,21 +119,6 @@ def test_get_chosen_or_default():
 
 
 def test_get_chosen_or_default_explicit_default():
-    c = skrub.choose_from([10, 20], name="c", default=100)
-    assert _choosing.get_chosen_or_default(c) == 100
-    assert _choosing.get_default(c) == 100
-    c.chosen_outcome_idx = 1
-    assert _choosing.get_chosen_or_default(c) == 20
-    assert _choosing.get_default(c) == 100
-
-    c = skrub.choose_from([10, 20], name="c", default=100)
-    m = c.match({10: "ten", 20: "twenty", 100: "one hundred"})
-    assert _choosing.get_chosen_or_default(m) == "one hundred"
-    assert _choosing.get_default(m) == "one hundred"
-    c.chosen_outcome_idx = 1
-    assert _choosing.get_chosen_or_default(m) == "twenty"
-    assert _choosing.get_default(m) == "one hundred"
-
     c = skrub.choose_float(10.0, 20.0, name="c", default=13.0)
     assert _choosing.get_chosen_or_default(c) == 13.0
     assert _choosing.get_default(c) == 13.0
@@ -149,13 +134,9 @@ def test_get_chosen_or_default_explicit_default():
     assert _choosing.get_default(c) == 72
 
 
-@pytest.mark.parametrize("choice_has_default", [False, True])
-def test_match(choice_has_default):
+def test_match():
     assert not hasattr(skrub.choose_int(0, 10, n_steps=6, name="N"), "match")
-    if choice_has_default:
-        c = skrub.choose_from(["a", "b"], name="c", default="c")
-    else:
-        c = skrub.choose_from(["a", "b", "c"], name="c")
+    c = skrub.choose_from(["a", "b", "c"], name="c")
 
     # m and mm without default
     m = c.match({"a": 10, "b": 20, "c": 30})
@@ -186,13 +167,9 @@ def test_match(choice_has_default):
     assert mm.outcome_mapping == {"a": "ten", "b": "twenty", "c": "??"}
 
 
-@pytest.mark.parametrize("choice_has_default", [False, True])
 @pytest.mark.parametrize("test_class", ["choice", "match"])
-def test_bad_match_mappings(choice_has_default, test_class):
-    if choice_has_default:
-        c = skrub.choose_from(["a", "b"], name="c", default="c")
-    else:
-        c = skrub.choose_from(["a", "b", "c"], name="c")
+def test_bad_match_mappings(test_class):
+    c = skrub.choose_from(["a", "b", "c"], name="c")
 
     if test_class == "match":
         c = c.match({"a": "a", "b": "b", "c": "c"})

--- a/skrub/_expressions/tests/test_inspection.py
+++ b/skrub/_expressions/tests/test_inspection.py
@@ -137,7 +137,7 @@ def test_describe_param_grid():
     >>> X = skrub.X()
     >>> y = skrub.y()
 
-    >>> imputed = X.skb.apply(skrub.optional(SimpleImputer, name="impute"))
+    >>> imputed = X.skb.apply(skrub.optional(SimpleImputer(), name="impute"))
     >>> dim_reduction = skrub.choose_from(
     ...     {
     ...         "PCA": PCA(),
@@ -182,38 +182,38 @@ def test_describe_param_grid():
     subgrids.
 
     >>> print(pred.skb.describe_param_grid())
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'robust'
       robust_scaler__with_centering: [True, False]
       classifier: 'logreg'
       C: choose_float(0.001, 100, log=True, name='C')
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'robust'
       robust_scaler__with_centering: [True, False]
       classifier: 'rf'
       N 🌴: choose_int(20, 400, name='N 🌴')
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'standard'
       classifier: 'logreg'
       C: choose_float(0.001, 100, log=True, name='C')
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: True
       scaling_kind: 'standard'
       classifier: 'rf'
       N 🌴: choose_int(20, 400, name='N 🌴')
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: False
       classifier: 'logreg'
       C: choose_float(0.001, 100, log=True, name='C')
-    - impute: ['true', 'false']
+    - impute: [SimpleImputer(), None]
       dim_reduction: ['PCA', 'SelectKBest']
       scaling: False
       classifier: 'rf'


### PR DESCRIPTION
~Not sure if we want this~, but we discussed it once or twice with @Vincent-Maladiere : allowing to specify an explicit default value for the choices.

This PR adds a new parameter `default`. If provided, it is used in the default pipeline. It does not affect the parameter grid so for example it has no effect on the behavior of `.skb.get_randomized_search()` and `.skb.get_grid_search()`.

```
>>> import skrub

Normally the default is the middle of the range

>>> skrub.choose_float(0.0, 10.0).as_expr().skb.eval()
np.float64(5.0)

But we can provide our own default value instead

>>> e = skrub.choose_float(0.0, 10.0, name='c', default=2.0).as_expr()
>>> e.skb.eval()
2.0
>>> e.skb.get_pipeline().fit_transform({})
2.0

The param grid and hyperparameter search don't change

>>> print(e.skb.describe_param_grid())
- c: choose_float(0.0, 10.0, name='c', default=2.0)
```

