### PR TITLE
Add user guide page on expressions validation & param search

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -43,4 +43,3 @@ essential to prevent data leakage and ensure generalization.
    skrub_pipeline_validation
    assembling
    cleaning
-   skrub_pipeline

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -39,6 +39,8 @@ essential to prevent data leakage and ensure generalization.
 
    end_to_end_pipeline
    encoding
+   skrub_pipeline
+   skrub_pipeline_validation
    assembling
    cleaning
    skrub_pipeline

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -114,9 +114,8 @@ And we can obtain predictions on the test part:
 Cross-validation
 ----------------
 
-Rather than a single split, we often want to run cross-validation. The same
-mechanism is used, except that several splits are done and the model fitting and
-scoring is done for us. This is done with
+We can increase our confidence in our score by using cross-validation instead of a single split.
+mechanism now fits and evaluates the model on several splits. This is done with
 :meth:`.skb.cross_validate() <Expr.skb.cross_validate>`.
 
 >>> pred.skb.cross_validate() # doctest: +SKIP

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -1,0 +1,205 @@
+.. currentmodule:: skrub
+
+.. _skrub_pipeline_validation:
+
+=====================================
+Tuning and validating Skrub Pipelines
+=====================================
+
+Typically, we want to evaluate the prediction performance of our pipeline. This
+is usually done by fitting it on a training dataset, then obtaining prediction
+on an unseen, test dataset.
+
+In scikit-learn, estimators and pipelines are given an ``X`` and a ``y`` matrix
+with one row per observation from the very start. Therefore splitting of these
+data into training and test set can be done independently from the pipeline.
+
+However, in many real-world scenarios, our data sources are not already
+organized into ``X`` and ``y`` matrices. Some transformations may be necessary to
+build those, and we want to keep those transformations inside the pipeline so
+that they can be reliably re-applied to new data.
+
+Therefore, we must start our pipeline by creating the design matrix and targets,
+then tell skrub which intermediate results in the pipeline constitute ``X`` and
+``y`` respectively.
+
+Let us consider a toy example where the only step needed to obtain ``X`` and
+``y`` is extracting them from a single table -- in the input to the pipeline,
+both are in the same dataframe. More complex transformations would be handled in
+the same way.
+
+>>> from sklearn.datasets import load_diabetes
+>>> from sklearn.linear_model import Ridge
+>>> import skrub
+
+>>> diabetes_df = load_diabetes(as_frame=True)['frame']
+
+In the original data, all features and the target are in the same dataframe.
+
+>>> data = skrub.var("data", diabetes_df)
+
+We build our design matrix by dropping the target. Note we use
+``errors="ignore"`` so that pandas does not raise an error if the column we want
+to drop is already missing. Indeed, if later we are asked to make actual useful
+predictions on unlabelled data, the "target" column will not be available.
+
+>>> X = data.drop(columns="target", errors="ignore").skb.mark_as_X()
+
+We use :meth:`.skb.mark_as_X() <Expr.skb.mark_as_X>` to indicate that this
+intermediate result (the dataframe obtained after dropping "target") is the
+``X`` design matrix. This is the dataframe that will be split into a training
+and a testing part when we split our dataset or perform cross-validation.
+
+Similarly for ``y``, we use :meth:`.skb.mark_as_y() <Expr.skb.mark_as_y>`:
+
+>>> y = data["target"].skb.mark_as_y()
+
+Now we can add our supervised estimator:
+
+>>> pred = X.skb.apply(Ridge(), y=y)
+>>> pred
+<Apply Ridge>
+Result:
+―――――――
+         target
+0    182.673354
+1     90.998607
+2    166.113476
+3    156.034880
+4    133.659575
+..          ...
+437  180.323365
+438  135.798908
+439  139.855630
+440  182.645829
+441   83.564413
+[442 rows x 1 columns]
+
+
+Once a pipeline is defined and the ``X`` and ``y`` nodes are identified, skrub
+is able to split the dataset and perform cross-validation.
+
+Splitting
+---------
+
+We can use :meth:`.skb.train_test_split() <Expr.skb.train_test_split>` to
+perform a single train-test split. Skrub first executes the first evaluates the
+expressions on which we used :meth:`.skb.mark_as_X() <Expr.skb.mark_as_X>` and
+:meth:`.skb.mark_as_y() <Expr.skb.mark_as_y>`: the first few steps of the
+pipeline are executed until we have a value for ``X`` and for ``y``. Then, those
+dataframes are split using the provided splitter function (by default
+scikit-learn's :func:`sklearn.model_selection.train_test_split`).
+
+>>> split = pred.skb.train_test_split(shuffle=False)
+>>> split.keys()
+dict_keys(['train', 'test', 'X_train', 'X_test', 'y_train', 'y_test'])
+
+We can now fit our pipeline on the training data:
+
+>>> pipeline = pred.skb.get_pipeline()
+>>> pipeline.fit(split['train'])
+SkrubPipeline(expr=<Apply Ridge>)
+
+Only the training part of ``X`` and ``y`` are used. The subsequent steps are
+evaluated, using this data, to fit the rest of the pipeline.
+
+And we can obtain predictions on the test part:
+
+>>> test_pred = pipeline.predict(split['test'])
+>>> test_y_true = split['y_test']
+
+>>> from sklearn.metrics import r2_score
+>>> r2_score(test_y_true, test_pred)
+0.440999149220359
+
+Cross-validation
+----------------
+
+Rather than a single split, we often want to run cross-validation. The same
+mechanism is used, except that several splits are done and the model fitting and
+scoring is done for us. This is done with
+:meth:`.skb.cross_validate() <Expr.skb.cross_validate>`.
+
+>>> pred.skb.cross_validate()
+   fit_time  score_time  test_score
+0  0.002816    0.001344    0.321665
+1  0.002685    0.001323    0.440485
+2  0.002468    0.001308    0.422104
+3  0.002748    0.001321    0.424661
+4  0.002649    0.001309    0.441961
+
+Tuning choices
+--------------
+
+Skrub provides a convenient way to declare ranges of possible values, and tune
+those choices to keep the values that give the best predictions on a validation
+set.
+
+Rather than specifying a grid of hyperparameters separately from the pipeline,
+we simply insert special skrub objects in place of the value. For example we
+replace the hyperparameter `alpha` (which should be a float) with a range
+created by :func:`skrub.choose_float`. Skrub can use it to select the best value
+for ``alpha``.
+
+>>> pred = X.skb.apply(Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True)), y=y)
+
+.. warning::
+
+   When we do :meth:`.skb.get_pipeline() <Expr.skb.get_pipeline>`, the pipeline
+   we obtain does not perform any hyperparameter tuning. The pipeline we obtain
+   uses default values for each of the choices. For numeric choices it is the
+   middle of the range, and for :func:`choose_from` it is the first option we
+   give it.
+
+   To get a pipeline that runs an internal cross-validation to select the best
+   hyperparameters, we must use :meth:`.skb.get_grid_search()
+   <Expr.skb.get_grid_search()>` or :meth:`.skb.get_randomized_search()
+   <Expr.skb.get_randomized_search>`.
+
+
+We can then find the best hyperparameters.
+
+>>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
+>>> search.results_
+   mean_test_score  choose_float(0.01, 10.0, log=True)
+0         0.478338                            0.141359
+1         0.476022                            0.186623
+2         0.474905                            0.205476
+3         0.457807                            0.431171
+4         0.456808                            0.443038
+5         0.439670                            0.643117
+6         0.420917                            0.866328
+7         0.380719                            1.398196
+8         0.233172                            4.734989
+9         0.168444                            7.780156
+
+
+Choices are not limited to scikit-learn hyperparameters. The choice of the
+estimator to use, any argument of an expression's method or deferred function
+call, etc. can be replaced with choices. We can also choose between several
+expressions to compare different pipelines. Choices can be nested arbitrarily.
+
+>>> from sklearn.ensemble import RandomForestRegressor
+>>> ridge = Ridge(alpha=skrub.choose_float(.01, 10.0, log=True, name="α"))
+>>> rf = RandomForestRegressor(n_estimators=skrub.choose_int(5, 50, name="N 🌴"))
+>>> regressor = skrub.choose_from({"ridge": ridge, "rf": rf}, name="regressor")
+>>> pred = X.skb.apply(regressor, y=y)
+>>> print(pred.skb.describe_param_grid())
+- regressor: 'ridge'
+  α: choose_float(0.01, 10.0, log=True, name='α')
+- regressor: 'rf'
+  N 🌴: choose_int(5, 50, name='N 🌴')
+
+>>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
+>>> search.results_
+   mean_test_score         α   N 🌴 regressor
+0         0.480425  0.078092   NaN     ridge
+1         0.477904  0.150784   NaN     ridge
+2         0.470507  0.271016   NaN     ridge
+3         0.443326  0.600529   NaN     ridge
+4         0.439670  0.643117   NaN     ridge
+5         0.423326       NaN  47.0        rf
+6         0.416455       NaN  31.0        rf
+7         0.403278       NaN  37.0        rf
+8         0.348517       NaN   8.0        rf
+9         0.168444  7.780156   NaN     ridge

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -120,7 +120,7 @@ mechanism is used, except that several splits are done and the model fitting and
 scoring is done for us. This is done with
 :meth:`.skb.cross_validate() <Expr.skb.cross_validate>`.
 
->>> pred.skb.cross_validate()
+>>> pred.skb.cross_validate() # doctest: +SKIP
    fit_time  score_time  test_score
 0  0.002816    0.001344    0.321665
 1  0.002685    0.001323    0.440485
@@ -160,7 +160,7 @@ for ``alpha``.
 We can then find the best hyperparameters.
 
 >>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
->>> search.results_
+>>> search.results_ # doctest: +SKIP
    mean_test_score  choose_float(0.01, 10.0, log=True)
 0         0.478338                            0.141359
 1         0.476022                            0.186623
@@ -191,7 +191,7 @@ expressions to compare different pipelines. Choices can be nested arbitrarily.
   N 🌴: choose_int(5, 50, name='N 🌴')
 
 >>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
->>> search.results_
+>>> search.results_ # doctest: +SKIP
    mean_test_score         α   N 🌴 regressor
 0         0.480425  0.078092   NaN     ridge
 1         0.477904  0.150784   NaN     ridge

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -303,30 +303,10 @@ The results can be displayed in an interactive parallel coordinate plot with
 As mentioned, a choice can be passed as an argument of an expression's method.
 For example, we can consider several ways to perform an aggregation on a pandas DataFrame:
 
->>> import skrub
->>> import skrub.datasets
-
->>> ratings = skrub.var("ratings", skrub.datasets.fetch_movielens().ratings)
+>>> ratings = skrub.var("ratings")
 >>> agg_ratings = ratings.groupby("movieId")["rating"].agg(
 ...     skrub.choose_from(["median", "mean"], name="rating_aggregation")
 ... )
->>> agg_ratings
-<CallMethod 'agg'>
-Result:
-―――――――
-movieId
-1         4.0
-2         3.5
-3         3.0
-4         3.0
-5         3.0
-         ...
-193581    4.0
-193583    3.5
-193585    3.5
-193587    3.5
-193609    4.0
-Name: rating, Length: 9724, dtype: float64
 >>> print(agg_ratings.skb.describe_param_grid())
 - rating_aggregation: ['median', 'mean']
 

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -16,7 +16,7 @@ data into training and test set can be done independently from the pipeline.
 
 However, in many real-world scenarios, our data sources are not already
 organized into ``X`` and ``y`` matrices. Some transformations may be necessary to
-build those, and we want to keep those transformations inside the pipeline so
+build them, and we want to keep those transformations inside the pipeline so
 that they can be reliably re-applied to new data.
 
 Therefore, we must start our pipeline by creating the design matrix and targets,

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -235,6 +235,9 @@ estimator to use, any argument of an expression's method or deferred function
 call, etc. can be replaced with choices. We can also choose between several
 expressions to compare different pipelines. Choices can be nested arbitrarily.
 
+Here is an example choosing between 2 different estimators, each of which has a
+tunable hyperparameter:
+
 >>> from sklearn.ensemble import RandomForestRegressor
 
 >>> ridge = Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True, name="α"))
@@ -260,3 +263,6 @@ expressions to compare different pipelines. Choices can be nested arbitrarily.
 7         0.403278       NaN  37.0        rf
 8         0.348517       NaN   8.0        rf
 9         0.168444  7.780156   NaN     ridge
+
+The results can be displayed in an interactive parallel coordinate plot with
+:meth:`ParamSearch.plot_results`.

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -114,9 +114,10 @@ And we can obtain predictions on the test part:
 Cross-validation
 ----------------
 
-We can increase our confidence in our score by using cross-validation instead of a single split.
-mechanism now fits and evaluates the model on several splits. This is done with
-:meth:`.skb.cross_validate() <Expr.skb.cross_validate>`.
+We can increase our confidence in our score by using cross-validation instead of
+a single split. The same mechanism is used but we now fit and evaluate the model
+on several splits. This is done with :meth:`.skb.cross_validate()
+<Expr.skb.cross_validate>`.
 
 >>> pred.skb.cross_validate() # doctest: +SKIP
    fit_time  score_time  test_score

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -32,7 +32,7 @@ the same way.
 >>> from sklearn.linear_model import Ridge
 >>> import skrub
 
->>> diabetes_df = load_diabetes(as_frame=True)['frame']
+>>> diabetes_df = load_diabetes(as_frame=True)["frame"]
 
 In the original data, all features and the target are in the same dataframe.
 
@@ -40,7 +40,7 @@ In the original data, all features and the target are in the same dataframe.
 
 We build our design matrix by dropping the target. Note we use
 ``errors="ignore"`` so that pandas does not raise an error if the column we want
-to drop is already missing. Indeed, if later we are asked to make actual useful
+to drop is already missing. Indeed, when we will need to make actual useful
 predictions on unlabelled data, the "target" column will not be available.
 
 >>> X = data.drop(columns="target", errors="ignore").skb.mark_as_X()
@@ -83,8 +83,8 @@ Splitting
 ---------
 
 We can use :meth:`.skb.train_test_split() <Expr.skb.train_test_split>` to
-perform a single train-test split. Skrub first executes the first evaluates the
-expressions on which we used :meth:`.skb.mark_as_X() <Expr.skb.mark_as_X>` and
+perform a single train-test split. Skrub first evaluates the expressions on
+which we used :meth:`.skb.mark_as_X() <Expr.skb.mark_as_X>` and
 :meth:`.skb.mark_as_y() <Expr.skb.mark_as_y>`: the first few steps of the
 pipeline are executed until we have a value for ``X`` and for ``y``. Then, those
 dataframes are split using the provided splitter function (by default
@@ -97,7 +97,7 @@ dict_keys(['train', 'test', 'X_train', 'X_test', 'y_train', 'y_test'])
 We can now fit our pipeline on the training data:
 
 >>> pipeline = pred.skb.get_pipeline()
->>> pipeline.fit(split['train'])
+>>> pipeline.fit(split["train"])
 SkrubPipeline(expr=<Apply Ridge>)
 
 Only the training part of ``X`` and ``y`` are used. The subsequent steps are
@@ -105,10 +105,11 @@ evaluated, using this data, to fit the rest of the pipeline.
 
 And we can obtain predictions on the test part:
 
->>> test_pred = pipeline.predict(split['test'])
->>> test_y_true = split['y_test']
+>>> test_pred = pipeline.predict(split["test"])
+>>> test_y_true = split["y_test"]
 
 >>> from sklearn.metrics import r2_score
+
 >>> r2_score(test_y_true, test_pred)
 0.440999149220359
 
@@ -137,11 +138,13 @@ set.
 
 Rather than specifying a grid of hyperparameters separately from the pipeline,
 we simply insert special skrub objects in place of the value. For example we
-replace the hyperparameter `alpha` (which should be a float) with a range
+replace the hyperparameter ``alpha`` (which should be a float) with a range
 created by :func:`skrub.choose_float`. Skrub can use it to select the best value
 for ``alpha``.
 
->>> pred = X.skb.apply(Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True)), y=y)
+>>> pred = X.skb.apply(
+...     Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True, name="α")), y=y
+... )
 
 .. warning::
 
@@ -180,7 +183,8 @@ call, etc. can be replaced with choices. We can also choose between several
 expressions to compare different pipelines. Choices can be nested arbitrarily.
 
 >>> from sklearn.ensemble import RandomForestRegressor
->>> ridge = Ridge(alpha=skrub.choose_float(.01, 10.0, log=True, name="α"))
+
+>>> ridge = Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True, name="α"))
 >>> rf = RandomForestRegressor(n_estimators=skrub.choose_int(5, 50, name="N 🌴"))
 >>> regressor = skrub.choose_from({"ridge": ridge, "rf": rf}, name="regressor")
 >>> pred = X.skb.apply(regressor, y=y)

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -6,13 +6,12 @@
 Tuning and validating Skrub Pipelines
 =====================================
 
-Typically, we want to evaluate the prediction performance of our pipeline. This
-is usually done by fitting it on a training dataset, then obtaining prediction
+To evaluate the prediction performance of our pipeline, we can fit it on a training dataset, then obtaining prediction
 on an unseen, test dataset.
 
-In scikit-learn, estimators and pipelines are given an ``X`` and a ``y`` matrix
-with one row per observation from the very start. Therefore splitting of these
-data into training and test set can be done independently from the pipeline.
+In scikit-learn, we pass to estimators and pipelines an ``X`` and ``y`` matrix
+with one row per observation from the start. Therefore, we can split the
+data into a training and test set independently from the pipeline.
 
 However, in many real-world scenarios, our data sources are not already
 organized into ``X`` and ``y`` matrices. Some transformations may be necessary to
@@ -23,9 +22,8 @@ Therefore, we must start our pipeline by creating the design matrix and targets,
 then tell skrub which intermediate results in the pipeline constitute ``X`` and
 ``y`` respectively.
 
-Let us consider a toy example where the only step needed to obtain ``X`` and
-``y`` is extracting them from a single table -- in the input to the pipeline,
-both are in the same dataframe. More complex transformations would be handled in
+Let us consider a toy example where we simply obtain ``X`` and
+``y`` from a single table. More complex transformations would be handled in
 the same way.
 
 >>> from sklearn.datasets import load_diabetes
@@ -264,8 +262,7 @@ which always uses the default hyperparameters):
 Choices beyond estimator hyperparameters
 ----------------------------------------
 
-Choices are not limited to scikit-learn hyperparameters. In fact, a choice can
-be used wherever an expression can be used. The choice of the estimator to use,
+Choices are not limited to scikit-learn hyperparameters: we can use choices wherever we use expressions. The choice of the estimator to use,
 any argument of an expression's method or :func:`deferred` function call, etc. can be
 replaced with choices. We can also choose between several expressions to compare
 different pipelines. Choices can be nested arbitrarily.
@@ -312,9 +309,8 @@ For example, we can consider several ways to perform an aggregation on a pandas 
 >>> print(agg_ratings.skb.describe_param_grid())
 - rating_aggregation: ['median', 'mean']
 
-Finally, a choice can easily be turned into an expression with its ``as_expr``
-method (or :func:`as_expr`, which works on any object). This can be useful for
-example to choose between several completely different pipelines:
+Finally, we can choose between several completely different pipelines by turning a choice into an expression, via its
+``as_expr`` method (or by using :func:`as_expr` on any object).
 
 >>> from sklearn.preprocessing import StandardScaler
 

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -331,7 +331,7 @@ example to choose between several completely different pipelines:
 >>> pred = skrub.choose_from({"ridge": ridge_pred, "rf": rf_pred}).as_expr()
 >>> print(pred.skb.describe_param_grid())
 - choose_from({'ridge': …, 'rf': …}): 'ridge'
-  choose_from({'true': …, 'false': …}): ['true', 'false']
+  optional(StandardScaler()): [StandardScaler(), None]
   α: choose_float(0.01, 10.0, log=True, name='α')
 - choose_from({'ridge': …, 'rf': …}): 'rf'
   N 🌴: choose_int(5, 50, name='N 🌴')

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -163,18 +163,18 @@ for ``alpha``.
 We can then find the best hyperparameters.
 
 >>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
->>> search.results_ # doctest: +SKIP
-   mean_test_score  choose_float(0.01, 10.0, log=True)
-0         0.478338                            0.141359
-1         0.476022                            0.186623
-2         0.474905                            0.205476
-3         0.457807                            0.431171
-4         0.456808                            0.443038
-5         0.439670                            0.643117
-6         0.420917                            0.866328
-7         0.380719                            1.398196
-8         0.233172                            4.734989
-9         0.168444                            7.780156
+>>> search.results_  # doctest: +SKIP
+   mean_test_score         α
+0         0.478338  0.141359
+1         0.476022  0.186623
+2         0.474905  0.205476
+3         0.457807  0.431171
+4         0.456808  0.443038
+5         0.439670  0.643117
+6         0.420917  0.866328
+7         0.380719  1.398196
+8         0.233172  4.734989
+9         0.168444  7.780156
 
 
 Choices are not limited to scikit-learn hyperparameters. The choice of the

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -92,6 +92,12 @@ scikit-learn's :func:`sklearn.model_selection.train_test_split`).
 >>> split.keys()
 dict_keys(['train', 'test', 'X_train', 'X_test', 'y_train', 'y_test'])
 
+``train`` and ``test`` are the full dictionaries corresponding to the training
+and testing data. The corresponding ``X`` and ``y`` are the values, in those
+dictionaries, for the nodes marked with
+:meth:`.skb.mark_as_X() <Expr.skb.mark_as_X>`
+and :meth:`.skb.mark_as_y() <Expr.skb.mark_as_y>`.
+
 We can now fit our pipeline on the training data:
 
 >>> pipeline = pred.skb.get_pipeline()
@@ -283,6 +289,7 @@ choice into an expression, via its ``as_expr`` method (or by using
 :func:`as_expr` on any object).
 
 >>> from sklearn.preprocessing import StandardScaler
+>>> from sklearn.ensemble import RandomForestRegressor
 
 >>> data = skrub.var("data", diabetes_df)
 >>> X = data.drop(columns="target", errors="ignore").skb.mark_as_X()

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -262,9 +262,10 @@ which always uses the default hyperparameters):
 Choices beyond estimator hyperparameters
 ----------------------------------------
 
-Choices are not limited to scikit-learn hyperparameters: we can use choices wherever we use expressions. The choice of the estimator to use,
-any argument of an expression's method or :func:`deferred` function call, etc. can be
-replaced with choices. We can also choose between several expressions to compare
+Choices are not limited to scikit-learn hyperparameters: we can use choices
+wherever we use expressions. The choice of the estimator to use, any argument of
+an expression's method or :func:`deferred` function call, etc. can be replaced
+with choices. We can also choose between several expressions to compare
 different pipelines.
 
 As an example of choices outside of scikit-learn estimators, we can consider
@@ -277,8 +278,9 @@ several ways to perform an aggregation on a pandas DataFrame:
 >>> print(agg_ratings.skb.describe_param_grid())
 - rating_aggregation: ['median', 'mean']
 
-We can also choose between several completely different pipelines by turning a choice into an expression, via its
-``as_expr`` method (or by using :func:`as_expr` on any object).
+We can also choose between several completely different pipelines by turning a
+choice into an expression, via its ``as_expr`` method (or by using
+:func:`as_expr` on any object).
 
 >>> from sklearn.preprocessing import StandardScaler
 

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -265,42 +265,10 @@ Choices beyond estimator hyperparameters
 Choices are not limited to scikit-learn hyperparameters: we can use choices wherever we use expressions. The choice of the estimator to use,
 any argument of an expression's method or :func:`deferred` function call, etc. can be
 replaced with choices. We can also choose between several expressions to compare
-different pipelines. Choices can be nested arbitrarily.
+different pipelines.
 
-Here is an example choosing between 2 different estimators, each of which has a
-tunable hyperparameter:
-
->>> from sklearn.ensemble import RandomForestRegressor
-
->>> ridge = Ridge(alpha=skrub.choose_float(0.01, 10.0, log=True, name="α"))
->>> rf = RandomForestRegressor(n_estimators=skrub.choose_int(5, 50, name="N 🌴"))
->>> regressor = skrub.choose_from({"ridge": ridge, "rf": rf}, name="regressor")
->>> pred = X.skb.apply(regressor, y=y)
->>> print(pred.skb.describe_param_grid())
-- regressor: 'ridge'
-  α: choose_float(0.01, 10.0, log=True, name='α')
-- regressor: 'rf'
-  N 🌴: choose_int(5, 50, name='N 🌴')
-
->>> search = pred.skb.get_randomized_search(fitted=True)
->>> search.results_ # doctest: +SKIP
-   mean_test_score         α   N 🌴 regressor
-0         0.480425  0.078092   NaN     ridge
-1         0.477904  0.150784   NaN     ridge
-2         0.470507  0.271016   NaN     ridge
-3         0.443326  0.600529   NaN     ridge
-4         0.439670  0.643117   NaN     ridge
-5         0.423326       NaN  47.0        rf
-6         0.416455       NaN  31.0        rf
-7         0.403278       NaN  37.0        rf
-8         0.348517       NaN   8.0        rf
-9         0.168444  7.780156   NaN     ridge
-
-The results can be displayed in an interactive parallel coordinate plot with
-:meth:`ParamSearch.plot_results`.
-
-As mentioned, a choice can be passed as an argument of an expression's method.
-For example, we can consider several ways to perform an aggregation on a pandas DataFrame:
+As an example of choices outside of scikit-learn estimators, we can consider
+several ways to perform an aggregation on a pandas DataFrame:
 
 >>> ratings = skrub.var("ratings")
 >>> agg_ratings = ratings.groupby("movieId")["rating"].agg(
@@ -309,7 +277,7 @@ For example, we can consider several ways to perform an aggregation on a pandas 
 >>> print(agg_ratings.skb.describe_param_grid())
 - rating_aggregation: ['median', 'mean']
 
-Finally, we can choose between several completely different pipelines by turning a choice into an expression, via its
+We can also choose between several completely different pipelines by turning a choice into an expression, via its
 ``as_expr`` method (or by using :func:`as_expr` on any object).
 
 >>> from sklearn.preprocessing import StandardScaler
@@ -331,6 +299,10 @@ Finally, we can choose between several completely different pipelines by turning
   α: choose_float(0.01, 10.0, log=True, name='α')
 - choose_from({'ridge': …, 'rf': …}): 'rf'
   N 🌴: choose_int(5, 50, name='N 🌴')
+
+Also note that as seen above, choices can be nested arbitrarily. For example it
+is frequent to choose between several estimators, each of which contains choices
+in its hyperparameters.
 
 Linking choices
 ---------------

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -160,6 +160,59 @@ for ``alpha``.
    <Expr.skb.get_randomized_search>`.
 
 
+Here are the different kinds of choices, along with their default outcome when
+we are not using hyperparameter search:
+
+.. list-table:: default choice outcomes
+   :header-rows: 1
+
+   * - choosing function
+     - description
+     - default outcome
+   * - :func:`choose_from([10, 20]) <choose_from>`
+     - choose between the listed options 10 and 20
+     - first outcome in the list: ``10``
+   * - :func:`choose_from({"a_name": 10, "b_name": 20}) <choose_from>`
+     - choose between the listed options 10 and 20, dictionary keys are names
+       for the options.
+     - first outcome in the dict: ``10``
+   * - :func:`optional(10) <optional>`
+     - choose between the provided value and ``None`` (useful for optional
+       transformations in a pipeline eg ``optional(StandardScaler())``).
+     - the provided ``value``: ``10``
+   * - :func:`choose_bool() <choose_bool>`
+     - choose between True and False.
+     - ``True``
+   * - :func:`choose_float(1.0, 100.0) <choose_float>`
+     - sample a floating-point number in a range.
+     - the middle of the range: ``50.5``
+   * - :func:`choose_int(1, 100) <choose_int>`
+     - sample an integer in a range.
+     - the int closest to the middle of the range: ``50``
+   * - :func:`choose_float(1.0, 100.0, log=True) <choose_float>`
+     - sample a float in a range on a logarithmic scale.
+     - the middle of the range on a log scale: ``10.0``
+   * - :func:`choose_int(1, 100, log=True) <choose_int>`
+     - sample an int in a range on a logarithmic scale.
+     - the int closest to the middle of the range on a log scale: ``10``
+   * - :func:`choose_float(1.0, 100.0, n_steps=4) <choose_float>`
+     - sample a float on a grid.
+     - the step closest to the middle of the range: ``34.0`` (here steps are
+       ``[1.0, 34.0, 67.0, 100.0]``)
+   * - :func:`choose_int(1, 100, n_steps=4) <choose_int>`
+     - sample an int on a grid.
+     - the (integer) step closest to the middle of the range: ``34`` (here steps are
+       ``[1, 34, 67, 100]``)
+   * - :func:`choose_float(1.0, 100.0, log=True, n_steps=4) <choose_float>`
+     - sample a float on a logarithmically-spaced grid.
+     - the step closest to the middle of the range on a log scale: ``4.64``
+       (here steps are ``[1.0, 4.64, 21.54, 100.0]``)
+   * - :func:`choose_float(1.0, 100.0, log=True) <choose_int>`
+     - sample an int on a logarithmically-spaced grid.
+     - the (integer) step closest to the middle of the range on a log scale: ``5``
+       (here steps are ``[1, 5, 22, 100]``)
+
+
 We can then find the best hyperparameters.
 
 >>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -283,7 +283,7 @@ tunable hyperparameter:
 - regressor: 'rf'
   N 🌴: choose_int(5, 50, name='N 🌴')
 
->>> search = pred.skb.get_randomized_search(fitted=True, scoring="r2", random_state=0)
+>>> search = pred.skb.get_randomized_search(fitted=True)
 >>> search.results_ # doctest: +SKIP
    mean_test_score         α   N 🌴 regressor
 0         0.480425  0.078092   NaN     ridge

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -194,13 +194,14 @@ search.plot_results()
 
 # %%
 # Concluding, we have seen how to use skrub's ``choose_from`` objects to tune
-# hyperparameters, choose optional configurations, and nest choices.
-# We then looked at how the different choices affect the pipeline and the prediction
+# hyperparameters, choose optional configurations, and nest choices. We then
+# looked at how the different choices affect the pipeline and the prediction
 # scores.
 #
-# There is more about skrub choices than what is in covered in this example. In particular,
-# choices are not limited to choosing estimators and their hyperparameters but
-# can be used anywhere an expression can be used, such as the argument of an
-# expression's method or operator or of a :func:`deferred` function, and
-# choices can be inter-dependent. Please find more information in the
-# :ref:`user guide <skrub_pipeline_validation>`.
+# There is more to say about skrub choices than what is covered in this
+# example. In particular, choices are not limited to choosing estimators and
+# their hyperparameters: they can be used anywhere an expression can be used,
+# such as the argument of a :func:`deferred` function, or the argument of
+# another expression's method or operator. Finally, choices can be
+# inter-dependent. Please find more information in the :ref:`user guide
+# <skrub_pipeline_validation>`.

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -198,5 +198,9 @@ search.plot_results()
 # We then looked at how the different choices affect the pipeline and the prediction
 # scores.
 #
-# There is more to skrub choices, please find more information in the
+# There is about skrub choices than in covered in this example. In particular,
+# choices are not limited to choosing estimators and their hyperparameters but
+# can be used anywhere an expression can be used, such as the argument of an
+# expression's method or operator or of a :func:`deferred` function, and
+# choices can be inter-dependent. Please find more information in the
 # :ref:`user guide <skrub_pipeline_validation>`.

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -198,7 +198,7 @@ search.plot_results()
 # We then looked at how the different choices affect the pipeline and the prediction
 # scores.
 #
-# There is about skrub choices than in covered in this example. In particular,
+# There is more about skrub choices than what is in covered in this example. In particular,
 # choices are not limited to choosing estimators and their hyperparameters but
 # can be used anywhere an expression can be used, such as the argument of an
 # expression's method or operator or of a :func:`deferred` function, and


### PR DESCRIPTION
this adds a user guide page to cover validation of skrub pipelines

- `mark_as_X()` and splitting
- choices and tuning