### PR TITLE
DOC: front page vocabulary / priority

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -47,7 +47,7 @@ still full-width (unlike the article) #}
   <!-- Feature Section 1 -->
   <div class="row mb-0 row-padding-between-features">
     <div class="col-md-5 mb-5">
-      <h4 class="feature-title">Effortless Pipelines</h4>
+      <h4 class="feature-title">Effortless Tabular Learning</h4>
       <p class="feature-text">Create strong scikit-learn pipeline baselines effortlessly with
         <a class="reference internal"
         href="reference/generated/skrub.TableVectorizer.html#tablevectorizer"
@@ -72,6 +72,30 @@ still full-width (unlike the article) #}
   <!-- Feature Section 2 -->
   <div class="row mb-0 flex-md-row-reverse row-padding-between-features">
     <div class="col-md-5">
+      <h4 class="feature-title">Interactive Data Exploration</h4>
+      <p class="feature-text">Explore your dataframes interactively with
+        <a class="reference internal"
+        href="reference/generated/skrub.TableReport.html#tablereport"
+        title="skrub.TableReport"><code class="xref py py-class docutils
+        literal notranslate"><span class="pre">TableReport</span></code></a>.
+      </p>
+      {% include "demo_table_report_code.html" %}
+      <p class="feature-text-see-also">
+        <a href="https://skrub-data.org/skrub-reports/">Try it on your dataset →</a>
+      </p>
+      <div class="row">
+        <p class="click-table-report-hint"><i class="fa-solid
+fa-caret-left"></i> Click anywhere on the table</p>
+      </div>
+    </div>
+    <div class="col-md-7">
+      {% include "demo_table_report_generated.html" %}
+    </div>
+  </div>
+
+  <!-- Feature Section 3 -->
+  <div class="row mb-0 row-padding-between-features">
+    <div class="col-md-5">
       <h4 class="feature-title">Powerful Feature Engineering</h4>
       <p class="feature-text">Encode text and high cardinality categorical data with the
         <a class="reference internal"
@@ -93,29 +117,6 @@ still full-width (unlike the article) #}
     </div>
     <div class="col-md-7 pe-5">
       <div class="encoding-image"></div>
-    </div>
-  </div>
-
-  <!-- Feature Section 3 -->
-  <div class="row mb-0 row-padding-between-features">
-    <div class="col-md-5">
-      <h4 class="feature-title">Interactive Data Exploration</h4>
-      <p class="feature-text">Explore your dataframes interactively with
-        <a class="reference internal"
-        href="reference/generated/skrub.TableReport.html#tablereport"
-        title="skrub.TableReport"><code class="xref py py-class docutils
-        literal notranslate"><span class="pre">TableReport</span></code></a>.
-      </p>
-      {% include "demo_table_report_code.html" %}
-      <p class="feature-text-see-also">
-        <a href="https://skrub-data.org/skrub-reports/">Try it on your dataset →</a>
-      </p>
-      <div class="row">
-        <p class="click-table-report-hint">Click anywhere on the table <i class="fa-solid fa-arrow-trend-down"></i> </p>
-      </div>
-    </div>
-    <div class="col-md-7">
-      {% include "demo_table_report_generated.html" %}
     </div>
   </div>
 


### PR DESCRIPTION
1. Rename "Effortless pipelines" to "Effortless Tabular Learning"

2. Put the table report before the GapEncoder: it's a stronger seller

An iteration on the front page to change a bit the focus that we broadcast (this is just an iteration, we could be more, but I think that it is good to work with iteration)