### PR TITLE
Add iterator over choice combinations + pipeline param description

### DIFF
--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -140,6 +140,7 @@ For more control or in order to build pipelines for more datasets, use the skrub
    Expr.skb.clone
    Expr.skb.concat
    Expr.skb.cross_validate
+   Expr.skb.describe_defaults
    Expr.skb.describe_param_grid
    Expr.skb.describe_steps
    Expr.skb.draw_graph
@@ -152,6 +153,8 @@ For more control or in order to build pipelines for more datasets, use the skrub
    Expr.skb.get_grid_search
    Expr.skb.get_randomized_search
    Expr.skb.if_else
+   Expr.skb.iter_pipelines_grid
+   Expr.skb.iter_pipelines_randomized
    Expr.skb.mark_as_X
    Expr.skb.mark_as_y
    Expr.skb.match

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -235,6 +235,20 @@ We can then find the best hyperparameters.
 8         0.233172  4.734989
 9         0.168444  7.780156
 
+Rather than fitting a parameter search to find the best combination, it is also
+possible to obtain an iterator over different parameter combinations, to inspect
+their outputs or to have manual control over the model selection, using
+:meth:`.skb.iter_pipelines_grid() <Expr.skb.iter_pipelines_grid>` or
+:meth:`.skb.iter_pipelines_randomized() <Expr.skb.iter_pipelines_randomized>`.
+Those yield the candidate pipelines that are explored by the grid and randomized
+search respectively.
+
+A human-readable description of parameters for a pipeline can be obtained with
+:meth:`SkrubPipeline.describe_params`:
+
+>>> search.best_pipeline_.describe_params()
+{'α': 0.013881294018109133}
+
 Validating hyperparameter search with nested cross-validation
 -------------------------------------------------------------
 

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -219,6 +219,13 @@ we are not using hyperparameter search:
        (here steps are ``[1, 5, 22, 100]``)
 
 
+The default choices for an expression, those that get used when calling
+:meth:`.skb.get_pipeline() <Expr.skb.get_pipeline>`, can be inspected with
+:meth:`.skb.describe_defaults() <Expr.skb.describe_defaults>`:
+
+>>> pred.skb.describe_defaults()
+{'α': 0.316...}
+
 We can then find the best hyperparameters.
 
 >>> search = pred.skb.get_randomized_search(fitted=True)
@@ -246,8 +253,8 @@ search respectively.
 A human-readable description of parameters for a pipeline can be obtained with
 :meth:`SkrubPipeline.describe_params`:
 
->>> search.best_pipeline_.describe_params()
-{'α': 0.013881294018109133}
+>>> search.best_pipeline_.describe_params() # doctest: +SKIP
+{'α': 0.054081804486393326}
 
 Validating hyperparameter search with nested cross-validation
 -------------------------------------------------------------

--- a/doc/skrub_pipeline_validation.rst
+++ b/doc/skrub_pipeline_validation.rst
@@ -242,7 +242,7 @@ We can then find the best hyperparameters.
 8         0.233172  4.734989
 9         0.168444  7.780156
 
-Rather than fitting a parameter search to find the best combination, it is also
+Rather than fitting a randomized or grid search to find the best combination, it is also
 possible to obtain an iterator over different parameter combinations, to inspect
 their outputs or to have manual control over the model selection, using
 :meth:`.skb.iter_pipelines_grid() <Expr.skb.iter_pipelines_grid>` or
@@ -254,7 +254,7 @@ A human-readable description of parameters for a pipeline can be obtained with
 :meth:`SkrubPipeline.describe_params`:
 
 >>> search.best_pipeline_.describe_params() # doctest: +SKIP
-{'α': 0.054081804486393326}
+{'α': 0.054...}
 
 Validating hyperparameter search with nested cross-validation
 -------------------------------------------------------------

--- a/examples/expressions/10_expressions_intro.py
+++ b/examples/expressions/10_expressions_intro.py
@@ -1,6 +1,7 @@
 """
 .. _example_expressions_intro:
 
+
 Building complex tabular pipelines
 ==================================
 

--- a/examples/expressions/11_choices.py
+++ b/examples/expressions/11_choices.py
@@ -3,6 +3,7 @@
 
 .. _example_tuning_pipelines:
 
+
 Tuning pipelines
 ================
 

--- a/skrub/_expressions/_estimator.py
+++ b/skrub/_expressions/_estimator.py
@@ -8,6 +8,7 @@ from .. import _join_utils
 from ._choosing import Choice, get_default
 from ._evaluation import (
     choice_graph,
+    chosen_or_default_outcomes,
     evaluate,
     find_first_apply,
     find_node_by_name,
@@ -19,6 +20,7 @@ from ._evaluation import (
     supported_modes,
 )
 from ._expressions import Apply
+from ._inspection import describe_params
 from ._parallel_coord import DEFAULT_COLORSCALE, plot_parallel_coord
 from ._utils import X_NAME, Y_NAME, _CloudPickle, attribute_error
 
@@ -345,6 +347,11 @@ class SkrubPipeline(_CloudPickleExpr, BaseEstimator):
         new = self.__class__(node)
         _copy_attr(self, new, ["_is_fitted"])
         return new
+
+    def describe_params(self):
+        return describe_params(
+            chosen_or_default_outcomes(self.expr), choice_graph(self.expr)
+        )
 
 
 def _to_Xy_pipeline(pipeline, environment):
@@ -674,6 +681,7 @@ class ParamSearch(_CloudPickleExpr, BaseEstimator):
             attribute_error(self, "results_")
 
     def _get_cv_results_table(self, return_metadata=False, detailed=False):
+        # TODO: use _inspection.describe_params()
         check_is_fitted(self, "cv_results_")
         expr_choices = choice_graph(self.expr)
 

--- a/skrub/_expressions/_estimator.py
+++ b/skrub/_expressions/_estimator.py
@@ -145,6 +145,14 @@ class SkrubPipeline(_CloudPickleExpr, BaseEstimator):
         set_params(self.expr, {int(k.lstrip("expr__")): v for k, v in params.items()})
         return self
 
+    def get_param_grid(self):
+        grid = param_grid(self.expr)
+        new_grid = []
+        for subgrid in grid:
+            subgrid = {f"expr__{k}": v for k, v in subgrid.items()}
+            new_grid.append(subgrid)
+        return new_grid
+
     def find_fitted_estimator(self, name):
         """
         Find the scikit-learn estimator that has been fitted in a ``.skb.apply()`` step.
@@ -608,18 +616,10 @@ class ParamSearch(_CloudPickleExpr, BaseEstimator):
         _copy_attr(self, new, _SEARCH_FITTED_ATTRIBUTES)
         return new
 
-    def _get_param_grid(self):
-        grid = param_grid(self.expr)
-        new_grid = []
-        for subgrid in grid:
-            subgrid = {f"expr__{k}": v for k, v in subgrid.items()}
-            new_grid.append(subgrid)
-        return new_grid
-
     def fit(self, environment):
         search = clone(self.search)
         search.estimator = _XyPipeline(self.expr, _SharedDict(environment))
-        param_grid = self._get_param_grid()
+        param_grid = search.estimator.get_param_grid()
         if hasattr(search, "param_grid"):
             search.param_grid = param_grid
         else:

--- a/skrub/_expressions/_evaluation.py
+++ b/skrub/_expressions/_evaluation.py
@@ -687,10 +687,13 @@ class _ChosenOrDefaultOutcomes(_ExprTraversal):
         if id(choice) in self.results:
             return self.results[id(choice)]
         if not isinstance(choice, _choosing.Choice):
+            # We have a NumericChoice, the outcome is simply a number
             outcome = choice.chosen_outcome_or_default()
             self.chosen[id(choice)] = outcome
             self.results[id(choice)] = outcome
             return outcome
+        # We have a Choice and need to visit the chosen outcome (it may contain
+        # further choices).
         idx = choice.chosen_outcome_idx or 0
         self.chosen[id(choice)] = idx
         outcome = choice.outcomes[idx]

--- a/skrub/_expressions/_evaluation.py
+++ b/skrub/_expressions/_evaluation.py
@@ -676,6 +676,40 @@ def set_params(expr, params):
             target.chosen_outcome = v
 
 
+class _ChosenOrDefaultOutcomes(_ExprTraversal):
+    def run(self, expr):
+        self.chosen = {}
+        self.results = {}
+        _ = super().run(expr)
+        return self.chosen
+
+    def handle_choice(self, choice):
+        if id(choice) in self.results:
+            return self.results[id(choice)]
+        if not isinstance(choice, _choosing.Choice):
+            outcome = choice.chosen_outcome_or_default()
+            self.chosen[id(choice)] = outcome
+            self.results[id(choice)] = outcome
+            return outcome
+        idx = choice.chosen_outcome_idx or 0
+        self.chosen[id(choice)] = idx
+        outcome = choice.outcomes[idx]
+        result = yield outcome
+        self.results[id(choice)] = result
+        return result
+
+    def handle_choice_match(self, choice_match):
+        outcome = yield choice_match.choice
+        return (yield choice_match.outcome_mapping[outcome])
+
+
+def chosen_or_default_outcomes(expr):
+    expr_choices = choices(expr)
+    short_ids = {id(c): k for k, c in expr_choices.items()}
+    outcomes = _ChosenOrDefaultOutcomes().run(expr)
+    return {short_ids[k]: v for k, v in outcomes.items()}
+
+
 class _Found(Exception):
     def __init__(self, value):
         self.value = value

--- a/skrub/_expressions/_inspection.py
+++ b/skrub/_expressions/_inspection.py
@@ -7,6 +7,7 @@ import webbrowser
 from pathlib import Path
 
 import jinja2
+import numpy as np
 from sklearn.base import BaseEstimator
 
 from .. import _dataframe as sbd
@@ -15,7 +16,7 @@ from .._reporting import TableReport
 from .._reporting._serve import open_in_browser
 from .._utils import Repr, random_string, short_repr
 from . import _utils
-from ._choosing import BaseNumericChoice
+from ._choosing import BaseNumericChoice, Choice
 from ._evaluation import choice_graph, clear_results, evaluate, graph, param_grid
 from ._expressions import Apply, Value, Var
 
@@ -340,6 +341,24 @@ def draw_expr_graph(expr, url=None, direction="TB"):
             dot_graph.add_edge(pydot.Edge(_dot_id(child), _dot_id(c)))
 
     return GraphDrawing(dot_graph)
+
+
+def describe_params(params, expr_choices):
+    description = {}
+    for choice_id, param in params.items():
+        choice = expr_choices["choices"][choice_id]
+        choice_name = expr_choices["choice_display_names"][choice_id]
+        if isinstance(choice, Choice):
+            if choice.outcome_names is not None:
+                value = choice.outcome_names[param]
+            else:
+                value = f"{param}: {short_repr(choice.outcomes[param])}"
+        else:
+            value = param
+            if isinstance(value, np.number):
+                value = value.tolist()
+        description[choice_name] = value
+    return description
 
 
 def describe_param_grid(expr):

--- a/skrub/_expressions/_inspection.py
+++ b/skrub/_expressions/_inspection.py
@@ -352,7 +352,7 @@ def describe_params(params, expr_choices):
             if choice.outcome_names is not None:
                 value = choice.outcome_names[param]
             else:
-                value = f"{param}: {short_repr(choice.outcomes[param])}"
+                value = short_repr(choice.outcomes[param])
         else:
             value = param
             if isinstance(value, np.number):

--- a/skrub/_expressions/_inspection.py
+++ b/skrub/_expressions/_inspection.py
@@ -350,6 +350,9 @@ def describe_params(params, expr_choices):
         choice = expr_choices["choices"][choice_id]
         choice_name = expr_choices["choice_display_names"][choice_id]
         if isinstance(choice, Choice):
+            # If we have a Choice we use the outcome name if there is one, and
+            # if there isn't, the value if it is a simple type otherwise a
+            # short repr
             if choice.outcome_names is not None:
                 value = choice.outcome_names[param]
             else:
@@ -359,6 +362,9 @@ def describe_params(params, expr_choices):
                 ):
                     value = short_repr(value)
         else:
+            # If we have a NumericChoice we use the corresponding number. We
+            # convert numpy numbers to built-in types to avoid the long
+            # 'np.float64(5.0)' repr
             value = param
             if isinstance(value, np.number):
                 value = value.tolist()

--- a/skrub/_expressions/_inspection.py
+++ b/skrub/_expressions/_inspection.py
@@ -1,6 +1,7 @@
 import datetime
 import html
 import io
+import numbers
 import re
 import shutil
 import webbrowser
@@ -352,7 +353,11 @@ def describe_params(params, expr_choices):
             if choice.outcome_names is not None:
                 value = choice.outcome_names[param]
             else:
-                value = short_repr(choice.outcomes[param])
+                value = choice.outcomes[param]
+                if not isinstance(
+                    value, (numbers.Number, bool, str, bytes, type(None))
+                ):
+                    value = short_repr(value)
         else:
             value = param
             if isinstance(value, np.number):

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -1331,10 +1331,10 @@ class SkrubNamespace:
         >>> search = pred.skb.get_grid_search(fitted=True)
         >>> search.results_
               C   N 🌴 classifier mean_test_score
-        0   NaN  30.0         rf             0.89
+        0   NaN    30         rf             0.89
         1   0.1   NaN   logistic             0.84
         2  10.0   NaN   logistic             0.80
-        3   NaN   3.0         rf             0.65
+        3   NaN     3         rf             0.65
         4   NaN   NaN      dummy             0.50
         """  # noqa: E501
         for c in choices(self._expr).values():

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -1341,10 +1341,10 @@ class SkrubNamespace:
         >>> search = pred.skb.get_grid_search(fitted=True)
         >>> search.results_
               C   N 🌴 classifier mean_test_score
-        0   NaN    30         rf             0.89
+        0   NaN  30.0         rf             0.89
         1   0.1   NaN   logistic             0.84
         2  10.0   NaN   logistic             0.80
-        3   NaN     3         rf             0.65
+        3   NaN   3.0         rf             0.65
         4   NaN   NaN      dummy             0.50
         """  # noqa: E501
         _check_grid_search_possible(self._expr)

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -976,6 +976,43 @@ class SkrubNamespace:
 
         return describe_param_grid(self._expr)
 
+    def describe_defaults(self):
+        """Describe the hyper-parameters used by the default pipeline.
+
+        Returns a dict mapping choice names to a simplified representation of
+        the corresponding value in the default pipeline.
+
+        Examples
+        --------
+        >>> import skrub
+        >>> from sklearn.datasets import make_classification
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from sklearn.feature_selection import SelectKBest
+        >>> from sklearn.ensemble import RandomForestClassifier
+
+        >>> X, y = skrub.X(), skrub.y()
+        >>> selector = SelectKBest(k=skrub.choose_int(4, 20, log=True, name='k'))
+        >>> logistic = LogisticRegression(
+        ...     C=skrub.choose_float(0.1, 10.0, log=True, name="C"),
+        ... )
+        >>> rf = RandomForestClassifier(
+        ...     n_estimators=skrub.choose_int(3, 30, log=True, name="N 🌴"),
+        ...     random_state=0,
+        ... )
+        >>> classifier = skrub.choose_from(
+        ...     {"logistic": logistic, "rf": rf}, name="classifier"
+        ... )
+        >>> pred = X.skb.apply(selector, y=y).skb.apply(classifier, y=y)
+        >>> print(pred.skb.describe_defaults())
+        {'k': 9, 'classifier': 'logistic', 'C': 1.000...}
+        """
+        from ._evaluation import choice_graph, chosen_or_default_outcomes
+        from ._inspection import describe_params
+
+        return describe_params(
+            chosen_or_default_outcomes(self._expr), choice_graph(self._expr)
+        )
+
     def full_report(
         self,
         environment=None,

--- a/skrub/_expressions/tests/test_estimators.py
+++ b/skrub/_expressions/tests/test_estimators.py
@@ -424,6 +424,20 @@ def test_train_test_split(with_y):
         assert e.skb.eval() == [7, 6, 5, 4, 3, 2, 1, 0]
 
 
+def test_iter_pipelines():
+    e = skrub.choose_from([1, 2, 3], name="c").as_expr()
+    assert [p.describe_params() for p in e.skb.iter_pipelines_grid()] == [
+        {"c": 1},
+        {"c": 2},
+        {"c": 3},
+    ]
+
+    e = skrub.choose_int(0, 1000, name="c").as_expr()
+    assert [
+        p.describe_params() for p in e.skb.iter_pipelines_randomized(3, random_state=0)
+    ] == [{"c": 548}, {"c": 715}, {"c": 602}]
+
+
 #
 # caching
 #

--- a/skrub/_expressions/tests/test_inspection.py
+++ b/skrub/_expressions/tests/test_inspection.py
@@ -232,9 +232,9 @@ def test_describe_params():
     e = c6.match({"a": [c4, c2.as_expr() + c7], "b": c5}).as_expr()
     print(e.skb.describe_defaults())
     expected = {
-        "choose_from(['a', 'b'])": "'a'",
+        "choose_from(['a', 'b'])": "a",
         "choose_from({'2': …, '1': …, '3': …})": "2",
-        "c2": "5.5",
+        "c2": 5.5,
         "choose_float(100.0, 200.0, default=110.5)": 110.5,
     }
 

--- a/skrub/_expressions/tests/test_inspection.py
+++ b/skrub/_expressions/tests/test_inspection.py
@@ -219,3 +219,25 @@ def test_describe_param_grid():
       classifier: 'rf'
       N 🌴: choose_int(20, 400, name='N 🌴')
     """
+
+
+def test_describe_params():
+    c1 = skrub.choose_float(0.0, 1.0)
+    c2 = skrub.choose_from((5.5, c1), name="c2")
+    c3 = skrub.choose_bool()
+    c4 = skrub.choose_from({"2": c2, "1": c1, "3": c3})
+    c5 = skrub.choose_int(10, 20, default=11, name="c5")
+    c6 = skrub.choose_from(["a", "b"])
+    c7 = skrub.choose_float(100.0, 200.0, default=110.5)
+    e = c6.match({"a": [c4, c2.as_expr() + c7], "b": c5}).as_expr()
+    print(e.skb.describe_defaults())
+    expected = {
+        "choose_from(['a', 'b'])": "0: 'a'",
+        "choose_from({'2': …, '1': …, '3': …})": "2",
+        "c2": "0: 5.5",
+        "choose_float(100.0, 200.0, default=110.5)": 110.5,
+    }
+
+    assert e.skb.describe_defaults() == expected
+    assert e.skb.get_pipeline().describe_params() == expected
+    assert skrub.X().skb.describe_defaults() == {}

--- a/skrub/_expressions/tests/test_inspection.py
+++ b/skrub/_expressions/tests/test_inspection.py
@@ -232,9 +232,9 @@ def test_describe_params():
     e = c6.match({"a": [c4, c2.as_expr() + c7], "b": c5}).as_expr()
     print(e.skb.describe_defaults())
     expected = {
-        "choose_from(['a', 'b'])": "0: 'a'",
+        "choose_from(['a', 'b'])": "'a'",
         "choose_from({'2': …, '1': …, '3': …})": "2",
-        "c2": "0: 5.5",
+        "c2": "5.5",
         "choose_float(100.0, 200.0, default=110.5)": 110.5,
     }
 


### PR DESCRIPTION
Makes it possible to get some pipelines configured with different choice combinations, when wen want to inspect their output rather than just pick the best with a gridsearchcv or randomizedsearchcv (or when we want to control the validation ourselves)

```
        >>> import numpy as np
        >>> from sklearn import preprocessing
        >>> import skrub

        >>> scaler = skrub.choose_from(
        ...     [
        ...         preprocessing.MinMaxScaler(),
        ...         preprocessing.StandardScaler(),
        ...         preprocessing.RobustScaler(),
        ...         preprocessing.MaxAbsScaler(),
        ...     ],
        ...     name="scaler",
        ... )
        >>> out = skrub.X().skb.apply(scaler)

        >>> X = np.asarray([-4.0, 3.0, 10.0])[:, None]

        >>> for p in out.skb.iter_pipelines_grid():
        ...     print("======================================")
        ...     print("params:", p.describe_params())
        ...     print("result:")
        ...     print(p.fit_transform({"X": X}))
        ======================================
        params: {'scaler': 'MinMaxScaler()'}
        result:
        [[0. ]
         [0.5]
         [1. ]]
        ======================================
        params: {'scaler': 'StandardScaler()'}
        result:
        [[-1.22474487]
         [ 0.        ]
         [ 1.22474487]]
        ======================================
        params: {'scaler': 'RobustScaler()'}
        result:
        [[-1.]
         [ 0.]
         [ 1.]]
        ======================================
        params: {'scaler': 'MaxAbsScaler()'}
        result:
        [[-0.4]
         [ 0.3]
         [ 1. ]]
```


This PR also adds `.skb.describe_defaults()` and `SkrubPipeline.describe_params()`

Those methods give access to the human-readable mapping of choice names/repr to chosen outcomes: basically the corresponding row in the parallel coordinate plot.

They can be useful to inspect a single pipeline such as the `best_pipeline_` or to quickly see what are the parameters for the default pipeline returned by `.skb.get_pipeline()`

Importantly the choices that are not used in this configuration (the NaNs in the parallel coordinate plot) do not appear in the resulting dict



```
>>> import skrub
>>> from sklearn.datasets import make_classification
>>> from sklearn.linear_model import LogisticRegression
>>> from sklearn.feature_selection import SelectKBest
>>> from sklearn.ensemble import RandomForestClassifier

>>> X, y = skrub.X(), skrub.y()
>>> selector = SelectKBest(k=skrub.choose_int(4, 20, log=True, name='k'))
>>> logistic = LogisticRegression(
...     C=skrub.choose_float(0.1, 10.0, log=True, name="C"),
... )
>>> rf = RandomForestClassifier(
...     n_estimators=skrub.choose_int(3, 30, log=True, name="N 🌴"),
...     random_state=0,
... )
>>> classifier = skrub.choose_from(
...     {"logistic": logistic, "rf": rf}, name="classifier"
... )
>>> pred = X.skb.apply(selector, y=y).skb.apply(classifier, y=y)
>>> print(pred.skb.describe_defaults())
{'k': 9, 'classifier': 'logistic', 'C': 1.0}
```