### PR TITLE
set choice name in home page parallel coord

### DIFF
--- a/doc/generate_pipeline_for_index.py
+++ b/doc/generate_pipeline_for_index.py
@@ -46,7 +46,7 @@ fraud_flags = baskets["fraud_flag"].skb.mark_as_y()
 
 # A pandas-based data-preparation pipeline that merges the tables
 aggregated_products = products.groupby("basket_ID").agg(
-    skrub.choose_from(("mean", "max", "count"))).reset_index()
+    skrub.choose_from(("mean", "max", "count"), name="agg")).reset_index()
 features = basket_IDs.merge(aggregated_products, on="basket_ID")
 from sklearn.ensemble import ExtraTreesClassifier
 predictions = features.skb.apply(ExtraTreesClassifier(), y=fraud_flags)


### PR DESCRIPTION
With the new order of columns, because plotly does not leave a margin on the left, the tick label gets cropped otherwise