### PR TITLE
wrap parallel coordinate plot tick labels

### DIFF
--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -70,8 +70,7 @@ def _add_jitter(column):
 
 
 def _wrap_label(column):
-    """ Add "<br>" to limit the width of a label to at most 20 chars
-    """
+    """Add "<br>" to limit the width of a label to at most 20 chars"""
     label = "<br>\n".join(textwrap.wrap(column["label"], width=20))
     return {**column, "label": label}
 

--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import numpy as np
 import pandas as pd
 from sklearn.preprocessing import OrdinalEncoder
@@ -76,6 +78,7 @@ def _prepare_column(col, *, is_log_scale, is_int):
         "mean_fit_time": "fit time",
         "mean_score_time": "score time",
     }.get(result["label"], result["label"])
+    result["label"] = "<br>\n".join(textwrap.wrap(result["label"], width=20))
     return result
 
 

--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -69,17 +69,21 @@ def _add_jitter(column):
     return column
 
 
+def _wrap_label(column):
+    label = "<br>\n".join(textwrap.wrap(column["label"], width=20))
+    return {**column, "label": label}
+
+
 def _prepare_column(col, *, is_log_scale, is_int):
     if pd.api.types.is_bool_dtype(col) or not pd.api.types.is_numeric_dtype(col):
-        return _prepare_obj_column(col)
+        return _wrap_label(_prepare_obj_column(col))
     result = _prepare_numeric_column(col, is_log_scale=is_log_scale, is_int=is_int)
     result["label"] = {
         "mean_test_score": "score",
         "mean_fit_time": "fit time",
         "mean_score_time": "score time",
     }.get(result["label"], result["label"])
-    result["label"] = "<br>\n".join(textwrap.wrap(result["label"], width=20))
-    return result
+    return _wrap_label(result)
 
 
 def _prepare_obj_column(col):

--- a/skrub/_expressions/_parallel_coord.py
+++ b/skrub/_expressions/_parallel_coord.py
@@ -70,6 +70,8 @@ def _add_jitter(column):
 
 
 def _wrap_label(column):
+    """ Add "<br>" to limit the width of a label to at most 20 chars
+    """
     label = "<br>\n".join(textwrap.wrap(column["label"], width=20))
     return {**column, "label": label}
 

--- a/skrub/_expressions/tests/test_parallel_coord.py
+++ b/skrub/_expressions/tests/test_parallel_coord.py
@@ -103,4 +103,4 @@ def test_multi_scoring():
 
     dimensions = fig.data[0]["dimensions"]
     assert dimensions[1]["label"] == "mean_test_accuracy"
-    assert dimensions[2]["label"] == "mean_test_neg_brier_score"
+    assert dimensions[2]["label"] == "mean_test_neg_<br>\nbrier_score"

--- a/skrub/_expressions/tests/test_parallel_coord.py
+++ b/skrub/_expressions/tests/test_parallel_coord.py
@@ -103,4 +103,4 @@ def test_multi_scoring():
 
     dimensions = fig.data[0]["dimensions"]
     assert dimensions[1]["label"] == "mean_test_accuracy"
-    assert dimensions[2]["label"] == "mean_test_neg_<br>\nbrier_score"
+    assert dimensions[2]["label"].replace("<br>\n", "") == "mean_test_neg_brier_score"


### PR DESCRIPTION
closes #1367 

alternative to #1385 

needs testing on many pipelines and display combinations to see if it makes things better or worse on average


example on home page:

![screenshot_2025-05-15T15:08:10+02:00](https://github.com/user-attachments/assets/b4a68dd1-8fb4-4abd-9d31-4b13e140d124)
