### PR TITLE
Change parallel coord order to put score last

### DIFF
--- a/skrub/_expressions/_estimator.py
+++ b/skrub/_expressions/_estimator.py
@@ -731,12 +731,12 @@ class ParamSearch(_CloudPickleExpr, BaseEstimator):
         metadata["log_scale_columns"] = [
             renaming[c] for c in metadata["log_scale_columns"]
         ]
-        for k in result_keys[: len(metric_names)]:
-            table.insert(table.shape[1], k, self.cv_results_[k])
         if detailed:
-            for k in result_keys[len(metric_names) :]:
+            for k in result_keys[len(metric_names) :][::-1]:
                 if k in self.cv_results_:
                     table.insert(table.shape[1], k, self.cv_results_[k])
+        for k in result_keys[: len(metric_names)][::-1]:
+            table.insert(table.shape[1], k, self.cv_results_[k])
         metadata["col_score"] = f"mean_test_{metric_names[0]}"
         table = table.sort_values(
             metadata["col_score"],

--- a/skrub/_expressions/tests/test_estimators.py
+++ b/skrub/_expressions/tests/test_estimators.py
@@ -176,12 +176,12 @@ def test_randomized_search(expression, data, n_jobs):
     assert list(search.results_.columns) == ["C", "mean_test_score"]
     assert list(search.detailed_results_.columns) == [
         "C",
-        "mean_test_score",
-        "std_test_score",
-        "mean_fit_time",
-        "std_fit_time",
-        "mean_score_time",
         "std_score_time",
+        "mean_score_time",
+        "std_fit_time",
+        "mean_fit_time",
+        "std_test_score",
+        "mean_test_score",
     ]
     assert search.results_["mean_test_score"].iloc[0] == pytest.approx(0.84, abs=0.05)
     assert search.decision_function(data).shape == (100,)
@@ -304,19 +304,19 @@ def test_multimetric():
     )
     assert list(expr_search.results_.columns) == [
         "C",
-        "mean_test_roc_auc",
         "mean_test_accuracy",
+        "mean_test_roc_auc",
     ]
     assert list(expr_search.detailed_results_.columns) == [
         "C",
-        "mean_test_roc_auc",
-        "mean_test_accuracy",
-        "std_test_roc_auc",
-        "std_test_accuracy",
-        "mean_fit_time",
-        "std_fit_time",
-        "mean_score_time",
         "std_score_time",
+        "mean_score_time",
+        "std_fit_time",
+        "mean_fit_time",
+        "std_test_accuracy",
+        "std_test_roc_auc",
+        "mean_test_accuracy",
+        "mean_test_roc_auc",
     ]
 
     sklearn_results = (

--- a/skrub/_expressions/tests/test_parallel_coord.py
+++ b/skrub/_expressions/tests/test_parallel_coord.py
@@ -80,9 +80,11 @@ def test_parallel_coord():
     assert dim["label"] == "c9"
     assert list(dim["ticktext"]) == ["4", "choose_int(1, 3, name='c8')"]
     dim = next(data)
-    assert dim["label"] == "score"
+    assert dim["label"] == "score time"
     dim = next(data)
     assert dim["label"] == "fit time"
+    dim = next(data)
+    assert dim["label"] == "score"
 
 
 def test_multi_scoring():
@@ -90,9 +92,10 @@ def test_multi_scoring():
 
     X, y = make_classification()
     X = pd.DataFrame(X)
+    X.columns = [str(c) for c in X.columns]
     X, y = skrub.X(X), skrub.y(y)
 
-    cols = skrub.choose_from([[0], [1]], name="cols")
+    cols = skrub.choose_from([["0"], ["1"]], name="cols")
     pred = X[cols].skb.apply(DummyClassifier(), y=y)
     search = pred.skb.get_grid_search(
         fitted=True,
@@ -102,5 +105,12 @@ def test_multi_scoring():
     fig = search.plot_results()
 
     dimensions = fig.data[0]["dimensions"]
-    assert dimensions[1]["label"] == "mean_test_accuracy"
-    assert dimensions[2]["label"] == "mean_test_neg_brier_score"
+    assert [d["label"] for d in dimensions] == [
+        "cols",
+        "score time",
+        "fit time",
+        "std_test_neg_brier_score",
+        "std_test_accuracy",
+        "mean_test_neg_brier_score",
+        "mean_test_accuracy",
+    ]


### PR DESCRIPTION
This changes the order of metrics in the `ParamSearch.results_` and parallel coordinate plot to put the score on the right (next to the colorbar)

It also gets rid of a warning in `test_multi_scoring`