### PR TITLE
improve short repr of choices with long argument list

### DIFF
--- a/skrub/_expressions/tests/test_interactive_features.py
+++ b/skrub/_expressions/tests/test_interactive_features.py
@@ -261,7 +261,17 @@ def test_repr():
     ――――――――――――――――――――――――
     array([[11., 11.],
            [11., 11.]])
-    """
+
+
+    short_repr of choices:
+
+    >>> c1 = skrub.choose_float(10, 100)
+    >>> c2 = skrub.choose_float(1, 100, log=True, n_steps=100, default=10)
+    >>> e = skrub.var('x') + c1 + c2
+    >>> print(e.skb.describe_param_grid())
+    - choose_float(10, 100): choose_float(10, 100)
+      choose_float(1, 100, log=True, n_...): choose_float(1, 100, log=True, n_steps=100, default=10)
+    """  # noqa: E501
 
 
 def test_format():

--- a/skrub/_utils.py
+++ b/skrub/_utils.py
@@ -1,6 +1,7 @@
 import collections
 import importlib
 import itertools
+import re
 import reprlib
 import secrets
 from typing import Iterable
@@ -218,6 +219,8 @@ class _ShortRepr(Repr):
 
         r = repr(instance)
         if "\n" in r or len(r) > 50:
+            if (m := re.match(r"^(\w{1,25})\((.*)\)$", r)) is not None:
+                return f"{m.group(1)}({m.group(2)[:20]}...)"
             return f"{instance.__class__.__name__}(...)"
         return super().repr_instance(instance, level)
 

--- a/skrub/tests/test_utils.py
+++ b/skrub/tests/test_utils.py
@@ -72,6 +72,12 @@ def test_short_repr():
 
     assert _utils.short_repr(A()) == "short"
 
+    class A:
+        def __repr__(self):
+            return f"make({list(range(100))})"
+
+    assert _utils.short_repr(A()) == "make([0, 1, 2, 3, 4, 5, 6...)"
+
 
 def test_passthrough():
     p = _utils.PassThrough()


### PR DESCRIPTION
small adjustment in how repr are shortened when needed that gives a better results for some choices (used as parallel coord axis labels among other things)

with the pr 

```
>>> c1 = skrub.choose_float(10, 100)
>>> c2 = skrub.choose_float(10.0, 100.0, log=True, n_steps=10, default=30.0)
>>> e = skrub.var('x', 0.0) + c1 + c2
>>> print(e.skb.describe_param_grid())
- choose_float(10, 100): choose_float(10, 100)
  choose_float(10.0, 100.0, log=Tru...): choose_float(10.0, 100.0, log=True, n_steps=10, default=30.0)
```

main branch

```
>>> print(e.skb.describe_param_grid())
- choose_float(10, 100): choose_float(10, 100)
  DiscretizedNumericChoice(...): choose_float(10.0, 100.0, log=True, n_steps=10, default=30.0)
```
