### PR TITLE
Improve contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,6 +153,8 @@ Please follow the steps in "From Source" tab in :ref:`Installing from source<ins
 .. the tests with the command ``pytest -s skrub/tests``; note that this may
 .. take a long time. Some tests may raise warnings such as:
 
+If you ran the tests ``pytest -s skrub/tests``;
+you may have seen some warnings such as:
 
 .. code:: sh
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -126,33 +126,6 @@ Setting up the environment
 
 Please follow the steps in "From Source" tab in :ref:`Installing from source<installing_from_source>` page.
 
-.. To contribute, you will first have to run through some steps:
-
-.. - Set up your environment by forking the repository (`Github doc on
-..   forking and
-..   cloning <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`__).
-.. - Add ``upstream`` to your remotes with ``git remote add upstream git@github.com:skrub-data/skrub.git``.
-
-.. - Create and activate a new virtual environment:
-
-..   - With `venv <https://docs.python.org/3/library/venv.html>`__, create
-..     the env with ``python -m venv env_skrub`` and then activate it with
-..     ``source env_skrub/bin/activate``.
-..   - With
-..     `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__,
-..     create the env with ``conda create -n env_skrub`` and activate it with
-..     ``conda activate env_skrub``.
-..   - While at the root of your local copy of skrub and within the new
-..     env, install the required development dependencies by running
-..     ``pip install --editable ".[dev, lint, test, doc]"``.
-
-.. - Run ``pre-commit install`` to activate some checks that will run every
-..   time you do a ``git commit`` (mostly, formatting checks).
-
-.. If you want to make sure that everything runs properly, you can run all
-.. the tests with the command ``pytest -s skrub/tests``; note that this may
-.. take a long time. Some tests may raise warnings such as:
-
 If you ran the tests ``pytest -s skrub/tests``;
 you may have seen some warnings such as:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,7 +204,7 @@ Additionally, you might have updated the internal dataframe API in
 ``amazing_function``.
 
 Run each updated test file using ``pytest``
-([pytest docs](https://docs.pytest.org/en/stable/)):
+( [pytest docs](https://docs.pytest.org/en/stable/) ):
 
 .. code:: sh
 
@@ -350,13 +350,6 @@ and addressing any issues.**
 
 First, make sure you have properly installed the development version of skrub.
 You can follow the :ref:`installation_instructions` > "From source" section, if needed.
-
-Building the documentation requires installing some additional packages:
-
-.. code:: bash
-
-    cd skrub
-    pip install '.[doc]'
 
 To build the documentation, you need to be in the ``doc`` folder:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -154,7 +154,6 @@ Please follow the steps in "From Source" tab in :ref:`Installing from source<ins
 .. take a long time. Some tests may raise warnings such as:
 
 
-
 .. code:: sh
 
   UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,7 +204,7 @@ Additionally, you might have updated the internal dataframe API in
 ``amazing_function``.
 
 Run each updated test file using ``pytest``
-( [pytest docs](https://docs.pytest.org/en/stable/) ):
+(`pytest docs <https://docs.pytest.org/en/stable//>`__):
 
 .. code:: sh
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -124,41 +124,46 @@ See the relevant sections above on how to do this.
 Setting up the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To contribute, you will first have to run through some steps:
+Please follow the steps in "From Source" tab in :ref:`Installing from source<installing_from_source>` page.
 
-- Set up your environment by forking the repository (`Github doc on
-  forking and
-  cloning <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`__).
-- Add ``upstream`` to your remotes with ``git remote add upstream git@github.com:skrub-data/skrub.git``.
+.. To contribute, you will first have to run through some steps:
 
-- Create and activate a new virtual environment:
+.. - Set up your environment by forking the repository (`Github doc on
+..   forking and
+..   cloning <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`__).
+.. - Add ``upstream`` to your remotes with ``git remote add upstream git@github.com:skrub-data/skrub.git``.
 
-  - With `venv <https://docs.python.org/3/library/venv.html>`__, create
-    the env with ``python -m venv env_skrub`` and then activate it with
-    ``source env_skrub/bin/activate``.
-  - With
-    `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__,
-    create the env with ``conda create -n env_skrub`` and activate it with
-    ``conda activate env_skrub``.
-  - While at the root of your local copy of skrub and within the new
-    env, install the required development dependencies by running
-    ``pip install --editable ".[dev, lint, test, doc]"``.
+.. - Create and activate a new virtual environment:
 
-- Run ``pre-commit install`` to activate some checks that will run every
-  time you do a ``git commit`` (mostly, formatting checks).
+..   - With `venv <https://docs.python.org/3/library/venv.html>`__, create
+..     the env with ``python -m venv env_skrub`` and then activate it with
+..     ``source env_skrub/bin/activate``.
+..   - With
+..     `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__,
+..     create the env with ``conda create -n env_skrub`` and activate it with
+..     ``conda activate env_skrub``.
+..   - While at the root of your local copy of skrub and within the new
+..     env, install the required development dependencies by running
+..     ``pip install --editable ".[dev, lint, test, doc]"``.
 
-If you want to make sure that everything runs properly, you can run all
-the tests with the command ``pytest -s skrub/tests``; note that this may
-take a long time. Some tests may raise warnings such as:
+.. - Run ``pre-commit install`` to activate some checks that will run every
+..   time you do a ``git commit`` (mostly, formatting checks).
+
+.. If you want to make sure that everything runs properly, you can run all
+.. the tests with the command ``pytest -s skrub/tests``; note that this may
+.. take a long time. Some tests may raise warnings such as:
+
+
 
 .. code:: sh
 
   UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].
     warnings.warn(
 
+
 This is expected, and you may proceed with the next steps without worrying about them. However, no tests should fail at this point: if they do fail, then let us know.
 
-Now that the development environment is ready, you may start working on
+Now that the development environment is ready, you may create a new branch and start working on
 the new issue.
 
 .. code:: sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -204,7 +204,7 @@ Additionally, you might have updated the internal dataframe API in
 ``amazing_function``.
 
 Run each updated test file using ``pytest``
-(`pytest docs <https://docs.pytest.org/en/stable//>`__):
+(`pytest docs <https://docs.pytest.org/en/stable>`_):
 
 .. code:: sh
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -128,20 +128,11 @@ To setup your development environment, you need to follow the steps in "From Sou
 present in :ref:`Installing from source<installing_from_source>` page.
 After that, you can return to this page to continue.
 
-If you ran the tests ``pytest -s skrub/tests``;
-you may have seen some warnings such as:
-
-.. code:: sh
-
-  UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].
-    warnings.warn(
-
-This is expected, and you may proceed with the next steps without worrying about them. However, no tests should fail at this point: if they do fail, then let us know.
-
 Now that the development environment is ready, you may create a new branch and start working on
 the new issue.
 
 .. code:: sh
+
    # fetch latest updates and start from the current head
    git fetch upstream
    git checkout -b my-branch-name-eg-fix-issue-123

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,7 +134,6 @@ you may have seen some warnings such as:
   UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].
     warnings.warn(
 
-
 This is expected, and you may proceed with the next steps without worrying about them. However, no tests should fail at this point: if they do fail, then let us know.
 
 Now that the development environment is ready, you may create a new branch and start working on

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -124,7 +124,9 @@ See the relevant sections above on how to do this.
 Setting up the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Please follow the steps in "From Source" tab in :ref:`Installing from source<installing_from_source>` page.
+To setup your development environment, you need to follow the steps in "From Source" tab
+present in :ref:`Installing from source<installing_from_source>` page.
+After that, you can return to this page to continue.
 
 If you ran the tests ``pytest -s skrub/tests``;
 you may have seen some warnings such as:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -177,7 +177,7 @@ install the local package in editable mode with development dependencies:
 
     pip install --editable ".[dev, lint, test, doc]"
 
-Enable pre-commit hooks to ensure code style consistency,this will activate some checks
+Enable pre-commit hooks to ensure code style consistency, this will activate some checks
 that will run every time you do a ``git commit`` (mostly, formatting checks):
 
 .. code:: console

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -155,7 +155,7 @@ You should see something like this:
 '''''''''''''''''''''''''
 
 Now, setup a development environment.
-You can set up a virtual environment with Conda, or with python's `venv`:
+You can set up a virtual environment with Conda, or with python's ``venv``:
 
 - With `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -155,7 +155,7 @@ You should see something like this:
 '''''''''''''''''''''''''
 
 Now, setup a development environment.
-Below is two options for setting up a virtual environment:
+You can set up a virtual environment with Conda, or with python's `venv`:
 
 - With `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__:
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -175,7 +175,7 @@ install the local package in editable mode with development dependencies:
 
 .. code:: console
 
-    pip install --editable ".[dev, lint, test, doc]"
+    pip install -e ".[dev, lint, test, doc]"
 
 Enabling pre-commit hooks ensures code style consistency by triggering checks (mainly formatting) every time you run a ``git commit``.
 
@@ -198,10 +198,20 @@ To ensure your environment is correctly set up, run the test suite:
 
 .. code:: console
 
-    pytest -s skrub/tests
+    pytest --pyargs skrub
 
 Testing should take about 5 minutes.
-If no errors or failures are found, your environment is ready for development!
+
+If you see some warnings like:
+.. code:: sh
+
+  UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].
+    warnings.warn(
+
+This is expected, and you may proceed with the next steps without worrying about them.
+However, no tests should fail at this point: if they do fail, then let us know.
+
+After that, your environment is ready for development!
 
 **Deep learning dependencies**
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -177,8 +177,7 @@ install the local package in editable mode with development dependencies:
 
     pip install --editable ".[dev, lint, test, doc]"
 
-Enable pre-commit hooks to ensure code style consistency, this will activate some checks
-that will run every time you do a ``git commit`` (mostly, formatting checks):
+Enabling pre-commit hooks ensures code style consistency by triggering checks (mainly formatting) every time you run a ``git commit``.
 
 .. code:: console
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -33,7 +33,7 @@ Install
 
     pip install skrub -U
 
-
+|
 
 **Deep learning dependencies**
 
@@ -58,6 +58,7 @@ and `sentence-transformers <https://pypi.org/project/sentence-transformers/>`_.
 
     conda install -c conda-forge skrub
 
+|
 
 **Deep learning dependencies**
 
@@ -191,7 +192,7 @@ IDE integrations. These revisions are listed in .git-blame-ignore-revs:
 
     git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-1. Run the tests
+4. Run the tests
 ''''''''''''''''
 
 To ensure your environment is correctly set up, run the test suite:

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -33,7 +33,7 @@ Install
 
     pip install skrub -U
 
-|
+
 
 **Deep learning dependencies**
 
@@ -58,7 +58,6 @@ and `sentence-transformers <https://pypi.org/project/sentence-transformers/>`_.
 
     conda install -c conda-forge skrub
 
-|
 
 **Deep learning dependencies**
 
@@ -104,6 +103,8 @@ and `sentence-transformers <https://anaconda.org/conda-forge/sentence-transforme
         <div class="tab-pane fade" id="source-tab-pane" role="tabpanel" aria-labelledby="source-tab" tabindex="0">
             <hr />
 
+.. _installing_from_source:
+
 Advanced Usage for Contributors
 -------------------------------
 
@@ -139,25 +140,44 @@ are correctly set up:
 
     git remote -v
 
+You should see something like this:
+
+.. code:: console
+
+    origin  git@github.com:<YOUR_USERNAME>/skrub.git (fetch)
+    origin  git@github.com:<YOUR_USERNAME>/skrub.git (push)
+    upstream        git@github.com:skrub-data/skrub.git (fetch)
+    upstream        git@github.com:skrub-data/skrub.git (push)
+
 
 3. Setup your environment
 '''''''''''''''''''''''''
 
-Now, setup a development environment. For example, you can use
-`conda <https://docs.conda.io/en/latest/>`_  to create a virtual environment:
+Now, setup a development environment.
+Below is two options for setting up a virtual environment:
+
+- With `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`__:
 
 .. code:: console
 
-    conda create -n skrub python=3.10 # or any later python version
-    conda activate skrub
+    conda create -n env_skrub python=3.10 # or any later python version
+    conda activate env_skrub
 
-Install the local package in editable mode with development dependencies:
+- With `venv <https://docs.python.org/3/library/venv.html>`__:
+.. code:: console
+
+    python -m venv env_skrub
+    source env_skrub/bin/activate
+
+Then, with the environment activated and at the root of your local copy of skrub,
+install the local package in editable mode with development dependencies:
 
 .. code:: console
 
-    pip install -e ".[dev, lint, test]"
+    pip install --editable ".[dev, lint, test, doc]"
 
-Enable pre-commit hooks to ensure code style consistency:
+Enable pre-commit hooks to ensure code style consistency,this will activate some checks
+that will run every time you do a ``git commit`` (mostly, formatting checks):
 
 .. code:: console
 
@@ -171,7 +191,7 @@ IDE integrations. These revisions are listed in .git-blame-ignore-revs:
 
     git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-4. Run the tests
+1. Run the tests
 ''''''''''''''''
 
 To ensure your environment is correctly set up, run the test suite:
@@ -182,11 +202,6 @@ To ensure your environment is correctly set up, run the test suite:
 
 Testing should take about 5 minutes.
 If no errors or failures are found, your environment is ready for development!
-
-Now that you're set up, review our :ref:`implementation guidelines<implementation guidelines>`
-and start coding!
-
-|
 
 **Deep learning dependencies**
 
@@ -200,6 +215,10 @@ and `sentence-transformers <https://pypi.org/project/sentence-transformers/>`_.
 
     $ pip install -e ".[transformers]"
 
+
+Now that you're set up,
+you may return to :ref:`writing your first pull request<writing-your-first-pull-request>`
+and start coding!
 
 .. raw:: html
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -161,7 +161,7 @@ You can set up a virtual environment with Conda, or with python's ``venv``:
 
 .. code:: console
 
-    conda create -n env_skrub python=3.10 # or any later python version
+    conda create -n env_skrub python=3.13
     conda activate env_skrub
 
 - With `venv <https://docs.python.org/3/library/venv.html>`__:

--- a/doc/table_report.py
+++ b/doc/table_report.py
@@ -4,5 +4,7 @@ from skrub.datasets import fetch_employee_salaries
 
 def generate_demo():
     X = fetch_employee_salaries().X
-    with open("_templates/demo_table_report_generated.html", "w") as f:
+    with open(
+        file="_templates/demo_table_report_generated.html", mode="w", encoding="utf-8"
+    ) as f:
         f.write(TableReport(X, n_rows=5).html_snippet())

--- a/doc/table_report.py
+++ b/doc/table_report.py
@@ -5,6 +5,6 @@ from skrub.datasets import fetch_employee_salaries
 def generate_demo():
     X = fetch_employee_salaries().X
     with open(
-        file="_templates/demo_table_report_generated.html", mode="w", encoding="utf-8"
+        "_templates/demo_table_report_generated.html", "w", encoding="utf-8"
     ) as f:
         f.write(TableReport(X, n_rows=5).html_snippet())


### PR DESCRIPTION
 Fix issue #1345
I have built the documentation, and everything that I changed is displayed correctly. If needed I can upload some printscreens.

The only thing that I could not change is to enable the Tab "From Source" directly through the link for installation, I believe that is because of the embedded HTML that is not reactive.

Also, even in the current version of documentation in scrub, the link to [Advanced Usage for Contributors](https://skrub-data.org/stable/install.html#advanced-usage-for-contributors) does not work; one should enter the link and click the "From Source" tab.

But I think this is not an impeditive to merge this PR.
Please let me know if you think that there is better ways to organize the information that I have changed.