### PR TITLE
Add support for random_state in StringEncoder

### DIFF
--- a/skrub/_string_encoder.py
+++ b/skrub/_string_encoder.py
@@ -42,6 +42,10 @@ class StringEncoder(SingleColumnTransformer):
         Option ``char_wb`` creates character n-grams only from text inside word
         boundaries; n-grams at the edges of words are padded with space.
 
+    random_state : int, RandomState instance or None, default=None
+        Used during randomized svd. Pass an int for reproducible results across
+        multiple function calls.
+
     See Also
     --------
     MinHashEncoder :
@@ -78,11 +82,13 @@ class StringEncoder(SingleColumnTransformer):
         vectorizer="tfidf",
         ngram_range=(3, 4),
         analyzer="char_wb",
+        random_state=None,
     ):
         self.n_components = n_components
         self.vectorizer = vectorizer
         self.ngram_range = ngram_range
         self.analyzer = analyzer
+        self.random_state = random_state
 
     def get_feature_names_out(self):
         """Get output feature names for transformation.
@@ -138,7 +144,9 @@ class StringEncoder(SingleColumnTransformer):
         del X_filled  # optimizes memory: we no longer need X
 
         if (min_shape := min(X_out.shape)) > self.n_components:
-            self.tsvd_ = TruncatedSVD(n_components=self.n_components)
+            self.tsvd_ = TruncatedSVD(
+                n_components=self.n_components, random_state=self.random_state
+            )
             result = self.tsvd_.fit_transform(X_out)
         elif X_out.shape[1] == self.n_components:
             result = X_out.toarray()


### PR DESCRIPTION
The `StringEncoder` uses the default randomized strategy in its `TruncatedSVD` instance. This PR adds support for passing a `random_state` for reproducible results.

In a side comment this is my first PR in skrub :tada: 