### PR TITLE
Improve error message for non-dataframe input in the TableReport

### DIFF
--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -420,7 +420,10 @@ def _collect_polars_lazyframe(df):
 
 @dispatch
 def shape(obj):
-    raise NotImplementedError()
+    raise NotImplementedError(
+        "Operation not supported on this object. Expecting a Pandas or Polars"
+        f"dataframe, but got an object of type {type(obj)}."
+    )
 
 
 @shape.specialize("pandas")

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from skrub import TableReport, ToDatetime
+from skrub import TableReport, ToDatetime, datasets
 from skrub import _dataframe as sbd
 
 
@@ -268,3 +268,9 @@ def test_minimal_mode(pd_module):
     assert "data-test-associations-skipped" in html
     assert 'id="column-summaries-panel"' not in html
     assert 'id="column-associations-panel"' not in html
+
+
+def test_error_input_type():
+    df = datasets.fetch_employee_salaries()
+    with pytest.raises(NotImplementedError, match="not supported on this object"):
+        TableReport(df)


### PR DESCRIPTION
Fixes https://github.com/skrub-data/skrub/issues/1408

Additionally, we could add this error message to all `sbd` functions. WDYT?