### PR TITLE
Fix duplicated doc issue with `to_datetime`

### DIFF
--- a/skrub/_to_datetime.py
+++ b/skrub/_to_datetime.py
@@ -473,7 +473,7 @@ def to_datetime(data, format=None):
     output : pandas or polars {DataFrame, Series}.
         The input transformed to Datetime.
 
-    See also
+    See Also
     --------
     ToDatetime :
         Parse datetimes represented as strings and return Datetime columns.

--- a/skrub/_to_datetime.py
+++ b/skrub/_to_datetime.py
@@ -460,13 +460,23 @@ def to_datetime(data, format=None):
 
     Parameters
     ----------
-    data : dataframe or column
-        The dataframe or column to transform.
+    data : pandas or polars ``{DataFrame, Series}``
+        The dataframe or series to transform.
 
     format : str or None, optional, default=None
         Format string to use to parse datetime strings.
         See the reference documentation for format codes:
         https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes .
+
+    Returns
+    -------
+    output : pandas or polars {DataFrame, Series}.
+        The input transformed to Datetime.
+
+    See also
+    --------
+    ToDatetime :
+        Parse datetimes represented as strings and return Datetime columns.
 
     Examples
     --------


### PR DESCRIPTION
Fixes https://github.com/skrub-data/skrub/issues/1423

`to_datetime` is indeed our only public function using the dispatch mechanism, which creates some trouble due to overloading in Sphinx. [It seems tricky to configure Sphinx overloading behavior](https://github.com/sphinx-doc/sphinx/issues/10359). Fortunately, we can hide it by wrapping the dispatched function.