### PR TITLE
[DISCUSSION] Adding `.skb.iter_eval`?

### DIFF
--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -11,6 +11,7 @@ from ._evaluation import (
     clone,
     describe_steps,
     evaluate,
+    iter_evaluate,
     nodes,
 )
 from ._expressions import (
@@ -931,6 +932,26 @@ class SkrubNamespace:
             }
         environment = env_with_subsampling(self._expr, environment, keep_subsampling)
         return evaluate(
+            self._expr, mode="fit_transform", environment=environment, clear=True
+        )
+
+    def iter_eval(self, environment=None, *, keep_subsampling=False):
+        if environment is not None and not isinstance(environment, typing.Mapping):
+            raise TypeError(
+                "The `environment` passed to `eval()` should be None or a dictionary, "
+                f"got: '{type(environment)}'"
+            )
+        if environment is None:
+            environment = self.get_data()
+        else:
+            environment = {
+                **environment,
+                "_skrub_use_var_values": not _var_values_provided(
+                    self._expr, environment
+                ),
+            }
+        environment = env_with_subsampling(self._expr, environment, keep_subsampling)
+        return iter_evaluate(
             self._expr, mode="fit_transform", environment=environment, clear=True
         )
 


### PR DESCRIPTION
I wonder if it would be useful to allow evaluating an expression step by step, to inspect the results, debug, build reports, test etc. We could add a method `.skb.iter_eval()` that returns a generator which yields each sub-expression and its result as it evaluates them

```
>>> import skrub

>>> a = skrub.var('a')
>>> b = skrub.var('b')
>>> c = a * a + b

>>> for item in c.skb.iter_eval({'a': 10, 'b': 20}):
...     print(item)
(<Var 'a'>, 10)
(<BinOp: mul>, 100)
(<Var 'b'>, 20)
(<BinOp: add>, 120)
```

(note as the pr shows in terms of implementation there is almost nothing to do, as we already use a loop and not recursion to evaluate the expressions)