### PR TITLE
Provide informative errors when expressions are passed as values to skrub variables

### DIFF
--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -797,7 +797,7 @@ def check_value_type(value):
 
     if needs_eval(value):
         raise TypeError(
-            "The `value` of a `skrub.var()` must not be a skrub"
+            "The `value` of a `skrub.var()` must not be a skrub "
             f"expression or skrub choice. Got: {type(value)}."
         )
 

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -48,7 +48,7 @@ from .._reporting._utils import strip_xml_declaration
 from .._utils import PassThrough, short_repr
 from .._wrap_transformer import wrap_transformer
 from . import _utils
-from ._choosing import get_chosen_or_default
+from ._choosing import BaseChoice, get_chosen_or_default
 from ._utils import FITTED_PREDICTOR_METHODS, NULL, attribute_error
 
 __all__ = [
@@ -792,10 +792,10 @@ def check_name(name, is_var):
         )
 
 
-def check_value_type(value):
-    from ._evaluation import needs_eval
-
-    if needs_eval(value):
+def check_var_value(value):
+    """Checking that the value passed to a skrub variable is not an expression
+    or a choice."""
+    if isinstance(value, (BaseChoice, Expr)):
         raise TypeError(
             "The `value` of a `skrub.var()` must not be a skrub"
             f"expression or skrub choice. Got: {type(value)}."
@@ -927,7 +927,7 @@ def var(name, value=NULL):
     gallery.
     """
     check_name(name, is_var=True)
-    check_value_type(value)
+    check_var_value(value)
     return Expr(Var(name, value=value))
 
 
@@ -988,7 +988,7 @@ def X(value=NULL):
     >>> X.skb.is_X
     True
     """
-    check_value_type(value)
+    check_var_value(value)
     return Expr(Var("X", value=value)).skb.mark_as_X()
 
 
@@ -1050,7 +1050,7 @@ def y(value=NULL):
     >>> y.skb.is_y
     True
     """
-    check_value_type(value)
+    check_var_value(value)
     return Expr(Var("y", value=value)).skb.mark_as_y()
 
 

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -792,8 +792,19 @@ def check_name(name, is_var):
         )
 
 
+def check_value_type(value):
+    from ._evaluation import needs_eval
+
+    if needs_eval(value):
+        raise TypeError(
+            "The `value` of a `skrub.var()` must not be a skrub"
+            f"expression or skrub choice. Got: {type(value)}."
+        )
+
+
 class Var(ExprImpl):
     "A `skrub.var()` expression."
+
     _fields = ["name", "value"]
 
     def compute(self, e, mode, environment):
@@ -842,6 +853,11 @@ def var(name, value=NULL):
     Returns
     -------
     A skrub variable
+
+    Raises
+    ------
+    TypeError
+        If the provided value is a skrub expression or a skrub choose_* function.
 
     See also
     --------
@@ -911,6 +927,7 @@ def var(name, value=NULL):
     gallery.
     """
     check_name(name, is_var=True)
+    check_value_type(value)
     return Expr(Var(name, value=value))
 
 
@@ -935,6 +952,11 @@ def X(value=NULL):
     Returns
     -------
     A skrub variable
+
+    Raises
+    ------
+    TypeError
+        If the provided value is a skrub expression or a skrub choose_* function.
 
     See also
     --------
@@ -966,6 +988,7 @@ def X(value=NULL):
     >>> X.skb.is_X
     True
     """
+    check_value_type(value)
     return Expr(Var("X", value=value)).skb.mark_as_X()
 
 
@@ -991,6 +1014,11 @@ def y(value=NULL):
     Returns
     -------
     A skrub variable
+
+    Raises
+    ------
+    TypeError
+        If the provided value is a skrub expression or a skrub choose_* function.
 
     See also
     --------
@@ -1022,6 +1050,7 @@ def y(value=NULL):
     >>> y.skb.is_y
     True
     """
+    check_value_type(value)
     return Expr(Var("y", value=value)).skb.mark_as_y()
 
 

--- a/skrub/_expressions/_expressions.py
+++ b/skrub/_expressions/_expressions.py
@@ -48,7 +48,7 @@ from .._reporting._utils import strip_xml_declaration
 from .._utils import PassThrough, short_repr
 from .._wrap_transformer import wrap_transformer
 from . import _utils
-from ._choosing import BaseChoice, get_chosen_or_default
+from ._choosing import get_chosen_or_default
 from ._utils import FITTED_PREDICTOR_METHODS, NULL, attribute_error
 
 __all__ = [
@@ -792,13 +792,15 @@ def check_name(name, is_var):
         )
 
 
-def check_var_value(value):
+def _check_var_value(value):
     """Checking that the value passed to a skrub variable is not an expression
     or a choice."""
-    if isinstance(value, (BaseChoice, Expr)):
+    from ._evaluation import needs_eval
+
+    if needs_eval(value):
         raise TypeError(
-            "The `value` of a `skrub.var()` must not be a skrub "
-            f"expression or skrub choice. Got: {type(value)}."
+            "The `value` of a `skrub.var()` must not contain a skrub "
+            f"expression or skrub choice. Got object {value} of {type(value)}."
         )
 
 
@@ -927,7 +929,7 @@ def var(name, value=NULL):
     gallery.
     """
     check_name(name, is_var=True)
-    check_var_value(value)
+    _check_var_value(value)
     return Expr(Var(name, value=value))
 
 
@@ -988,7 +990,7 @@ def X(value=NULL):
     >>> X.skb.is_X
     True
     """
-    check_var_value(value)
+    _check_var_value(value)
     return Expr(Var("X", value=value)).skb.mark_as_X()
 
 
@@ -1050,7 +1052,7 @@ def y(value=NULL):
     >>> y.skb.is_y
     True
     """
-    check_var_value(value)
+    _check_var_value(value)
     return Expr(Var("y", value=value)).skb.mark_as_y()
 
 

--- a/skrub/_expressions/tests/test_evaluation.py
+++ b/skrub/_expressions/tests/test_evaluation.py
@@ -116,14 +116,6 @@ def test_needs_eval():
     )
 
 
-def test_skrub_encoder_error():
-    # skrub encoders (as well as other encoders) cannot take expressions or
-    # choices as parameters, so we check that they raise an informative error
-    # if a value that has `needs_eval` is passed as parameter
-
-    pass
-
-
 def test_find_node_by_name():
     a = skrub.var("a")
     X = skrub.X()

--- a/skrub/_expressions/tests/test_evaluation.py
+++ b/skrub/_expressions/tests/test_evaluation.py
@@ -116,6 +116,14 @@ def test_needs_eval():
     )
 
 
+def test_skrub_encoder_error():
+    # skrub encoders (as well as other encoders) cannot take expressions or
+    # choices as parameters, so we check that they raise an informative error
+    # if a value that has `needs_eval` is passed as parameter
+
+    pass
+
+
 def test_find_node_by_name():
     a = skrub.var("a")
     X = skrub.X()

--- a/skrub/_expressions/tests/test_expressions.py
+++ b/skrub/_expressions/tests/test_expressions.py
@@ -93,6 +93,41 @@ def test_environment_no_values():
     assert e.skb.eval({"d": 2, "c": 3}) == 6
 
 
+def test_environment_wrong_values():
+    a = skrub.var(name="a", value=[1, 2, 3])
+    # Testing expr as value
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.var(name="wrongvar", value=a)
+
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.X(value=a)
+
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.y(value=a)
+
+    # Testing choice as value
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.var("wrongvar", skrub.choose_bool())
+
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.X(skrub.choose_bool())
+
+    with pytest.raises(
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+    ):
+        skrub.y(skrub.choose_bool())
+
+
 def test_choice_in_environment():
     a = skrub.var("a", 100)
     b = skrub.var("b", 10)

--- a/skrub/_expressions/tests/test_expressions.py
+++ b/skrub/_expressions/tests/test_expressions.py
@@ -97,33 +97,33 @@ def test_environment_wrong_values():
     a = skrub.var(name="a", value=[1, 2, 3])
     # Testing expr as value
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.var(name="wrongvar", value=a)
 
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.X(value=a)
 
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.y(value=a)
 
     # Testing choice as value
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.var("wrongvar", skrub.choose_bool())
 
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.X(skrub.choose_bool())
 
     with pytest.raises(
-        TypeError, match=r".*`value` of a `skrub.var\(\)` must not be a skrub.*"
+        TypeError, match=r".*`value` of a `skrub.var\(\)` must not contain a skrub.*"
     ):
         skrub.y(skrub.choose_bool())
 


### PR DESCRIPTION
Fixes #1438

Error checking for the value in the variables is already done. I thought to implement both improvements in the same PR, but I'm not sure how to implement the error checking for the encoders. I was thinking about doing it in `_expressions/tests/test_evaluation.py` or somewhere in `_expressions`, but maybe I should add that to the tests for each encoder? 

