### PR TITLE
Improve .expr.subsample docs

### DIFF
--- a/doc/skrub_pipeline.rst
+++ b/doc/skrub_pipeline.rst
@@ -396,6 +396,8 @@ Finally, there are other situations where using :func:`deferred` can be helpful:
 - See :ref:`example_tuning_pipelines` for an example of hyper-parameter tuning using
   skrub pipelines.
 
+.. _user_guide_subsampling_ref:
+
 Subsampling to develop pipelines with reduced computation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -801,6 +801,26 @@ class SkrubNamespace:
         using the subsampling allows us to do a "dry run" of the
         cross-validation or model fitting much faster than when using the
         full data.
+
+        Sampling only one variable does not sample the other:
+
+        >>> data = skrub.var("data", df)
+        >>> X = data.drop("target", axis=1, errors="ignore").skb.mark_as_X()
+        >>> X = X.skb.subsample(n=15)
+        >>> y = data["target"].skb.mark_as_y()
+        >>> X.shape
+        <GetAttr 'shape'>
+        Result (on a subsample):
+        ――――――――――――――――――――――――
+        (15, 10)
+        >>> y.shape
+        <GetAttr 'shape'>
+        Result:
+        ―――――――
+        (442,)
+
+        Read more about subsampling in the :ref:`User Guide <user_guide_subsampling_ref>`.
+
         """  # noqa : E501
         return Expr(SubsamplePreviews(self._expr, n=n, how=how))
 


### PR DESCRIPTION
Fixes #1446 

Todo: 
- Add an example in the docstring
- Add a cross-reference to the user guide
- Expand a bit on this in the user guide 