### PR TITLE
Fixing typo in StringEncoder title

### DIFF
--- a/examples/02_text_with_string_encoders.py
+++ b/examples/02_text_with_string_encoders.py
@@ -227,7 +227,7 @@ results.append(("TextEncoder", text_encoder_results))
 plot_box_results(results)
 
 # %%
-# SringEncoder
+# StringEncoder
 # ^^^^^^^^^^^^
 # |TextEncoder| embeddings are very strong, but they are also quite expensive to
 # use. A simpler, faster alternative for encoding strings is the |StringEncoder|,


### PR DESCRIPTION
Fixes #1455

Simple typo fix in [String Encoder Example](https://skrub-data.org/stable/auto_examples/02_text_with_string_encoders.html#sringencoder)

It was written "SringEncoder"
Now it is fixed:

![image](https://github.com/user-attachments/assets/cf4f974e-19b9-469c-a2fe-6688664cc52a)

