### PR TITLE
typo in docs for mark_as_y

### DIFF
--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -2002,7 +2002,7 @@ class SkrubNamespace:
 
     @check_expr
     def mark_as_y(self):
-        """Mark this expression as being the ``X`` table.
+        """Mark this expression as being the ``y`` table.
 
         Returns a copy; the original expression is left unchanged.
 


### PR DESCRIPTION
No related issue, just a small typo spotted while reading the docs.