### PR TITLE
typing error "y" vector

### DIFF
--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -2002,7 +2002,7 @@ class SkrubNamespace:
 
     @check_expr
     def mark_as_y(self):
-        """Mark this expression as being the ``y`` vector.
+        """Mark this expression as being the ``y`` table.
 
         Returns a copy; the original expression is left unchanged.
 

--- a/skrub/_expressions/_skrub_namespace.py
+++ b/skrub/_expressions/_skrub_namespace.py
@@ -2002,7 +2002,7 @@ class SkrubNamespace:
 
     @check_expr
     def mark_as_y(self):
-        """Mark this expression as being the ``X`` table.
+        """Mark this expression as being the ``y`` vector.
 
         Returns a copy; the original expression is left unchanged.
 


### PR DESCRIPTION
I noticed a typo in the documentation. Quick modification.