### PR TITLE
feat: Add cardinality information in table report

### DIFF
--- a/skrub/_config.py
+++ b/skrub/_config.py
@@ -15,6 +15,7 @@ _global_config = {
     "subsampling_seed": int(os.environ.get("SKB_SUBSAMPLING_SEED", 0)),
     "enable_subsampling": os.environ.get("SKB_ENABLE_SUBSAMPLING", "default"),
     "float_precision": int(os.environ.get("SKB_FLOAT_PRECISION", 3)),
+    "cardinality_threshold": int(os.environ.get("SKB_CARDINALITY_THRESHOLD", 40)),
 }
 _threadlocal = threading.local()
 
@@ -72,6 +73,7 @@ def set_config(
     subsampling_seed=None,
     enable_subsampling=None,
     float_precision=None,
+    cardinality_threshold=None,
 ):
     """Set global skrub configuration.
 
@@ -140,6 +142,14 @@ def set_config(
         This configuration can also be set with the ``SKB_FLOAT_PRECISION``
         environment variable.
 
+    cardinality_threshold: int,  default=40
+        Control the threshold value used to warn user if they have
+        high cardinality columns in there dataset. It's also used as the default
+        value of ``TableVectorizer`` `cardinality_threshold` parameter.
+
+        This configuration can also be set with the ``SKB_CARDINALITY_THRESHOLD``
+        environment variable.
+
     See Also
     --------
     get_config : Retrieve current values for global configuration.
@@ -200,6 +210,16 @@ def set_config(
             )
         local_config["float_precision"] = float_precision
 
+    if cardinality_threshold is not None:
+        if (
+            not isinstance(cardinality_threshold, numbers.Integral)
+            or cardinality_threshold < 0
+        ):
+            raise ValueError(
+                "'cardinality_threshold' must be a positive"
+                "integer, got {cardinality_threshold!r}"
+            )
+
     _apply_external_patches(local_config)
 
 
@@ -213,6 +233,7 @@ def config_context(
     subsampling_seed=None,
     enable_subsampling=None,
     float_precision=None,
+    cardinality_threshold=None,
 ):
     """Context manager for global skrub configuration.
 
@@ -281,6 +302,14 @@ def config_context(
         This configuration can also be set with the ``SKB_FLOAT_PRECISION``
         environment variable.
 
+    cardinality_threshold: int,  default=40
+        Control the threshold value used to warn user if they have
+        high cardinality columns in there dataset. It's also used as the default
+        value of ``TableVectorizer`` `cardinality_threshold` parameter.
+
+        This configuration can also be set with the ``SKB_CARDINALITY_THRESHOLD``
+        environment variable.
+
     Yields
     ------
     None.
@@ -305,6 +334,7 @@ def config_context(
         subsampling_seed=subsampling_seed,
         enable_subsampling=enable_subsampling,
         float_precision=float_precision,
+        cardinality_threshold=cardinality_threshold,
     )
 
     try:

--- a/skrub/_reporting/_data/templates/column-summary.html
+++ b/skrub/_reporting/_data/templates/column-summary.html
@@ -78,6 +78,13 @@
                 <dt>(constant) String length</dt>
                 <dd>{{ column.constant_string_length }}</dd>
                 {% endif %}
+
+                <dt>Cardinality</dt>
+                {% set cardinality_class = "warning" if column.is_high_cardinality else "ok" %}
+                <dd class=" {{ cardinality_class }}">
+                    {{ "high" if column.is_high_cardinality else "low" }}
+                    ({{ ">" if column.is_high_cardinality else "<" }} {{ config["cardinality_threshold"] }})
+                </dd>
             </dl>
         </div>
 
@@ -88,7 +95,7 @@
             <div class="copybutton-grid">
                 <div class="box">
                     <pre id="{{ val_id }}"
-                         data-copy-text="{{ column.constant_value.__repr__() }}">{{ column.constant_value }}</pre>
+                        data-copy-text="{{ column.constant_value.__repr__() }}">{{ column.constant_value }}</pre>
                     {{ buttons.copybutton(val_id) }}
                 </div>
             </div>

--- a/skrub/_reporting/_html.py
+++ b/skrub/_reporting/_html.py
@@ -8,6 +8,7 @@ import secrets
 import jinja2
 import pandas as pd
 
+from skrub import _config
 from skrub import _dataframe as sbd
 from skrub import selectors as s
 
@@ -152,6 +153,7 @@ def to_html(summary, standalone=True, column_filters=None, minimal_report_mode=F
             "base64_column_filters": _b64_encode(column_filters),
             "report_id": f"report_{secrets.token_hex()[:8]}",
             "minimal_report_mode": minimal_report_mode,
+            "config": _config.get_config(),
         }
     )
 

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -1,7 +1,7 @@
 """Get information and plots for a dataframe, that are used to generate reports."""
 import sys
 
-from .. import _column_associations
+from .. import _column_associations, _config
 from .. import _dataframe as sbd
 from . import _plotting, _sample_table, _utils
 
@@ -154,6 +154,9 @@ def _summarize_column(
         summary["n_unique"] = sbd.n_unique(column)
         summary["unique_proportion"] = summary["n_unique"] / max(
             1, dataframe_summary["n_rows"]
+        )
+        summary["is_high_cardinality"] = (
+            summary["n_unique"] > _config.get_config()["cardinality_threshold"]
         )
     except Exception:
         # for some dtypes n_unique can fail eg with a typeerror for

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -69,6 +69,7 @@ def test_summarize(
         "most_frequent_values": ["Paris", "London"],
         "value_is_constant": False,
         "is_duration": False,
+        "is_high_cardinality": False,
     }
 
     assert summary["columns"][4]["constant_value"] == "no2"
@@ -252,3 +253,16 @@ def test_duplicate_columns(pd_module):
     assert cols[0]["mean"] == 1.5
     assert cols[1]["name"] == "a"
     assert cols[1]["mean"] == 3.5
+
+
+def test_high_cardinality_columns(df_module):
+    df = df_module.make_dataframe(
+        {
+            "low-cardinality": [0] * 100,
+            "high-cardinality": range(100),
+        }
+    )
+    summary = summarize_dataframe(df)
+    cols = summary["columns"]
+    assert not cols[0]["is_high_cardinality"]
+    assert cols[1]["is_high_cardinality"]

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -8,8 +8,8 @@ from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.validation import check_is_fitted
 
+from . import _config, _utils
 from . import _dataframe as sbd
-from . import _utils
 from . import selectors as s
 from ._check_input import CheckInputDataFrame
 from ._clean_categories import CleanCategories
@@ -730,7 +730,7 @@ class TableVectorizer(TransformerMixin, BaseEstimator):
     def __init__(
         self,
         *,
-        cardinality_threshold=40,
+        cardinality_threshold=_config.get_config()["cardinality_threshold"],
         low_cardinality=LOW_CARDINALITY_TRANSFORMER,
         high_cardinality=HIGH_CARDINALITY_TRANSFORMER,
         numeric=NUMERIC_TRANSFORMER,

--- a/skrub/tests/test_config.py
+++ b/skrub/tests/test_config.py
@@ -19,6 +19,7 @@ def test_config_context():
         "subsampling_seed": 0,
         "enable_subsampling": "default",
         "float_precision": 3,
+        "cardinality_threshold": 40,
     }
 
     # Not using as a context manager affects nothing


### PR DESCRIPTION
This PR introduces a information on column cardinality in the table report.
As a bonus `cardinality_threshold` as been added as a configuration integer.

UI preview:
<img width="626" alt="Screenshot 2025-07-09 at 15 20 46" src="https://github.com/user-attachments/assets/b375da9f-143d-42d7-96dc-853838cc5f38" />


Closes #1414.