### PR TITLE
Change message for skipping plots in the display

### DIFF
--- a/skrub/_reporting/_data/templates/column-summaries.html
+++ b/skrub/_reporting/_data/templates/column-summaries.html
@@ -26,7 +26,7 @@
         data-manager="AlertDismissable">
         <div class="alert-content shrinkable-text">
             Plotting was skipped as the dataframe exceeded the
-            <code href="https://skrub-data.org/stable/reference/generated/skrub.TableReport.html#skrub.TableReport">max_plot_columns</code>
+            <a href="https://skrub-data.org/stable/reference/generated/skrub.TableReport.html"><code>max_plot_columns</code></a>
             limit set for the TableReport during report creation.
         </div>
         {{buttons.dismissbutton()}}


### PR DESCRIPTION
As a user, I didn't understand why I couldn't see the plot when I filtered columns.
I changed the alert message for being clearer that the plotting is defined as generation time.