### PR TITLE
add sizes of dataframes and total sizes on disk

### DIFF
--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -12,9 +12,9 @@ def fetch_employee_salaries(data_home=None, split="all"):
     Description of the dataset:
         Annual salary information including gross pay and overtime pay for all
         active, permanent employees of Montgomery County, MD paid in calendar
-        year 2016. Size on disk: 1.3MB.
         year 2016. This dataset is a copy of https://www.openml.org/d/42125
         where some features are dropped to avoid data leaking.
+        Size on disk: 1.3MB.
 
     .. note::
 
@@ -40,11 +40,10 @@ def fetch_employee_salaries(data_home=None, split="all"):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``employee_salaries`` : pd.DataFrame, the dataframe. Size 9228 rows x 9
-          columns.
+        - ``employee_salaries`` : pd.DataFrame, the dataframe. Shape: (9228, 9)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
           labels. Shape: (9228, 8)
-        - ``y`` : pd.DataFrame, target labels. Size 9228 rows x 1 column.
+        - ``y`` : pd.DataFrame, target labels. Shape: (9228, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -91,11 +90,10 @@ def fetch_medical_charge(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``medical_charge`` : pd.DataFrame, the dataframe. Size 163065 rows x 12
-          columns.
+        - ``medical_charge`` : pd.DataFrame, the dataframe. Shape: (163065, 12)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 163065 rows x 11 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 163065 rows x 1 column.
+          labels. Shape: (163065, 11)
+        - ``y`` : pd.DataFrame, target labels. Shape: (163065, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -119,10 +117,10 @@ def fetch_midwest_survey(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``midwest_survey`` : pd.DataFrame, the dataframe. Size 2494 rows x 29 columns.
+        - ``midwest_survey`` : pd.DataFrame, the dataframe. Shape: (2494, 29)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 2494 rows x 28 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 2494 rows x 1 column.
+          labels. Shape: (2494, 28)
+        - ``y`` : pd.DataFrame, target labels. Shape: (2494, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -147,11 +145,10 @@ def fetch_open_payments(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``open_payments`` : pd.DataFrame, the dataframe. Size 73558 rows x 6
-          columns.
+        - ``open_payments`` : pd.DataFrame, the dataframe. Shape: (73558, 6)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 73558 rows x 5 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 73558 rows x 1 column.
+          labels. Shape: (73558, 5)
+        - ``y`` : pd.DataFrame, target labels. Shape: (73558, 1)
         - ``metadata`` : a dictionary containing the name, description, source
           and target
     """
@@ -178,11 +175,10 @@ def fetch_traffic_violations(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``traffic_violations`` : pd.DataFrame, the dataframe. Size 1578154
-          rows x 43 columns.
+        - ``traffic_violations`` : pd.DataFrame, the dataframe. Shape: (1578154, 43)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 1578154 rows x 42 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 1578154 rows x 1 column.
+          labels. Shape: (1578154, 42)
+        - ``y`` : pd.DataFrame, target labels. Shape: (1578154, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -207,11 +203,10 @@ def fetch_drug_directory(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``drug_directory`` : pd.DataFrame, the dataframe. Size 120215 rows x 21
-          columns.
+        - ``drug_directory`` : pd.DataFrame, the dataframe. Shape: (120215, 21)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 120215 rows x 20 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 120215 rows x 1 column.
+          labels. Shape: (120215, 20)
+        - ``y`` : pd.DataFrame, target labels. Shape: (120215, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -245,10 +240,10 @@ def fetch_credit_fraud(data_home=None, split="train"):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``baskets`` : pd.DataFrame, table containing baskets ID and target. Size
-          92790 rows x 2 columns.
-        - ``product`` : pd.DataFrame, table containing features about products contained
-          in baskets. Size 163357 rows x 7 columns.
+        - ``baskets`` : pd.DataFrame, table containing baskets ID and target.
+        Shape: (92790, 2)
+        - ``product`` : pd.DataFrame, table containing features about products
+          contained in baskets. Shape: (163357, 7)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -288,10 +283,10 @@ def fetch_toxicity(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``toxicity`` : pd.DataFrame, the dataframe. Size 1000 rows x 2 columns.
+        - ``toxicity`` : pd.DataFrame, the dataframe. Shape: (1000, 2)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 1000 rows x 1 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 1000 rows x 1 columns.
+          labels. Shape: (1000, 1)
+        - ``y`` : pd.DataFrame, target labels. Shape: (1000, 1)
         - ``metadata`` : a dictionary containing the name, description, source and
           target
     """
@@ -323,11 +318,10 @@ def fetch_videogame_sales(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``videogame_sales`` : pd.DataFrame, the full dataframe. Size 16572
-          rows x 11 columns.
+        - ``videogame_sales`` : pd.DataFrame, the full dataframe. Shape: (16572, 11)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target
-          labels. Size 16572 rows x 5 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 16572 rows x 1 column.
+          labels. Shape: (16572, 5)
+        - ``y`` : pd.DataFrame, target labels. Shape: (16572, 1)
         - ``metadata`` : a dictionary containing the name, source and target
     """
 
@@ -356,11 +350,10 @@ def fetch_bike_sharing(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``bike_sharing``: pd.DataFrame, the full dataframe. Size 17379 rows x 11
-          columns.
+        - ``bike_sharing``: pd.DataFrame, the full dataframe. Shape: (17379, 11)
         - ``X`` : pd.DataFrame, features, i.e. the dataframe without the target labels.
-          Size 17379 rows x 10 columns.
-        - ``y`` : pd.DataFrame, target labels. Size 17379 rows x 1 column.
+          Shape: (17379, 10)
+        - ``y`` : pd.DataFrame, target labels. Shape: (17379, 1)
         - ``metadata`` : a dictionary containing the name and target
     """
 
@@ -372,8 +365,8 @@ def fetch_movielens(data_home=None):
         https://github.com/skrub-data/skrub-data-files
 
     This is a regression use-case, where the goal is to predict movie ratings.
-    More details are provided in the output's ``metadata['description']``. Size on disk:
-        3.6MB.
+    More details are provided in the output's ``metadata['description']``.
+    Size on disk: 3.6MB.
 
     Parameters
     ----------
@@ -385,10 +378,8 @@ def fetch_movielens(data_home=None):
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``movies`` : pd.DataFrame, movie ID, title and genres. Size 9742 rows
-          x 3 columns.
-        - ``ratings``: pd.DataFrame, user ID, movie ID, rating. Size 100836
-          rows x 4 columns.
+        - ``movies`` : pd.DataFrame, movie ID, title and genres. Shape: (9742, 3)
+        - ``ratings``: pd.DataFrame, user ID, movie ID, rating. Shape: (100836, 4)
         - ``metadata`` : a dictionary containing the name source and description
     """
 
@@ -399,8 +390,8 @@ def fetch_flight_delays(data_home=None):
     """Fetch the flight delays dataset (regression) available at \
         https://github.com/skrub-data/skrub-data-files
 
-    This is a regression use-case, where the goal is to predict flight delays. Size on
-    disk: 657MB.
+    This is a regression use-case, where the goal is to predict flight delays.
+    Size on disk: 657MB.
 
     Parameters
     ----------
@@ -413,18 +404,18 @@ def fetch_flight_delays(data_home=None):
         A dictionary-like object with the following keys:
 
         - ``flights``: information about the flights, including departure and
-          arrival airports, and delay. Size 2370030 rows x 12 columns.
+          arrival airports, and delay. Shape: (2370030, 12)
         - ``airports``: information about airports, such as city and coordinates.
           The airport's ``iata`` can be matched to the flights' ``Origin`` and
-          ``Dest``. Size 3376 rows x 7 columns.
+          ``Dest``. Shape: (3376, 7)
         - ``weather``: weather data that could be used to help improve the delay
           predictions. Note the weather data is not measured at the airports
           directly but at weather stations, whose location and information is
-          provided in ``stations``. Size 11282238 rows x 5 columns.
+          provided in ``stations``. Shape: (11282238, 5)
         - ``stations``: information about the weather stations. ``weather`` and
           ``stations`` can be joined on their ``ID`` columns. Weather stations
           can only be matched to the nearest airport based on the latitude and
-          longitude. Size 124245 rows x 9 columns.
+          longitude. Shape: (124245, 9)
         - ``metadata`` : a dictionary containing the name  of the dataset.
     """
     return load_dataset_files("flight_delays", data_home)
@@ -444,17 +435,16 @@ def fetch_country_happiness(data_home=None):
     data_home: str or path, default=None
         The directory where to download and unzip the files.
 
-    Returnj
+    Returns
     -------
     bunch : sklearn.utils.Bunch
         A dictionary-like object with the following keys:
 
-        - ``happiness_report``: dataframe, data from the world happiness report. Size
-          146 rows x 12 columns.
-        - ``GDP_per_capita``: dataframe from the World Bank. Size 262 rows x 2 columns.
-        - ``life_expectancy``: dataframe from the World Bank. Size 260 rows x 2 columns.
-        - ``legal_rights_index``: dataframe from the World Bank. Size 238 rows x 2
-          columns.
+        - ``happiness_report``: dataframe, data from the world happiness report.
+          Shape: (146, 12)
+        - ``GDP_per_capita``: dataframe from the World Bank. Shape: (262, 2)
+        - ``life_expectancy``: dataframe from the World Bank. Shape: (260, 2)
+        - ``legal_rights_index``: dataframe from the World Bank. Shape: (238, 2)
         - ``metadata`` : a dictionary containing the name of the dataset, a
           description and the sources.
     """


### PR DESCRIPTION
I added the sizes on disk and the sizes of the dataframes for all the functions in `datasets`, except for the the `fetch_ken_embeddings`, `fetch_ken_types` and `fetch_ken_table_aliases`.