### PR TITLE
Add a check box in the distribution of TableReport to switch between a percentage of numbers in the plot.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,9 @@ Changes
 - A new parameter ``float_precision`` has been added to the global config to control the number of significant digits
   displayed for floating-point values in reports. :pr:`1470` by :user:`George S <georgescutelnicu>`.
 
+- The display of :class:`TableReport` has the new capability to switch between display percentage and the value of
+  the histogram and the value_counts plot. :pr:`1506` by :user:`Lionel Kusch<lionelkusch>`.
+
 Bugfixes
 --------
 - Fixed a bug that caused the :class:`StringEncoder` and :class:`TextEncoder` to raise an exception if the

--- a/skrub/_reporting/_data/templates/column-summaries.html
+++ b/skrub/_reporting/_data/templates/column-summaries.html
@@ -18,7 +18,7 @@
 	    </div>
 	    <button type="button" data-test="select-all-columns" data-manager="SelectAllVisibleColumns">Select all</button>
 	    <button type="button" data-test="deselect-all-columns" data-manager="DeselectAllColumns">Deselect all</button>
-	    <input type="checkbox" data-test="percentage-display" data-manager="PercentageDisplay">%</input>
+	    <input type="checkbox" data-test="percentage-display" data-manager="PercentageDisplay" checked >%</input>
 	</div>
     </div>
 

--- a/skrub/_reporting/_data/templates/column-summaries.html
+++ b/skrub/_reporting/_data/templates/column-summaries.html
@@ -18,6 +18,7 @@
 	    </div>
 	    <button type="button" data-test="select-all-columns" data-manager="SelectAllVisibleColumns">Select all</button>
 	    <button type="button" data-test="deselect-all-columns" data-manager="DeselectAllColumns">Deselect all</button>
+	    <input type="checkbox" data-test="percentage-display" data-manager="PercentageDisplay">%</input>
 	</div>
     </div>
 

--- a/skrub/_reporting/_data/templates/column-summary.html
+++ b/skrub/_reporting/_data/templates/column-summary.html
@@ -98,7 +98,10 @@
         {% for plot_name in column.plot_names %}
         <div>
             <div class="margin-t-m" data-svg-needs-adjust-viewbox data-test="switch-display" data-manager="SwitchFigures" style="display: block;">
-                {{ column[plot_name] | safe }}
+                {{ column[plot_name][1] | safe }}
+            </div>
+            <div class="margin-t-m" data-svg-needs-adjust-viewbox data-test="switch-display" data-manager="SwitchFigures" style="display: none;">
+                {{ column[plot_name][0] | safe }}
             </div>
             {% if plot_name == "value_counts_plot" %}
             <details data-test="frequent-values-details">

--- a/skrub/_reporting/_data/templates/column-summary.html
+++ b/skrub/_reporting/_data/templates/column-summary.html
@@ -97,7 +97,7 @@
 
         {% for plot_name in column.plot_names %}
         <div>
-            <div class="margin-t-m" data-svg-needs-adjust-viewbox>
+            <div class="margin-t-m" data-svg-needs-adjust-viewbox data-test="switch-display" data-manager="SwitchFigures" style="display: block;">
                 {{ column[plot_name] | safe }}
             </div>
             {% if plot_name == "value_counts_plot" %}

--- a/skrub/_reporting/_data/templates/report.js
+++ b/skrub/_reporting/_data/templates/report.js
@@ -753,6 +753,34 @@ if (customElements.get('skrub-table-report') === undefined) {
     }
     SkrubTableReport.register(SelectAllVisibleColumns);
 
+    class PercentageDisplay extends Manager {
+        constructor(elem, exchange) {
+            super(elem, exchange);
+            this.elem.addEventListener("change", () => {
+                this.exchange.send({
+                    kind: "SWITCH_FIGURES"
+                });
+            });
+        }
+    }
+    SkrubTableReport.register(PercentageDisplay);
+
+    class SwitchFigures extends Manager {
+        constructor(elem, exchange) {
+            super(elem, exchange);
+        }
+
+        SWITCH_FIGURES() {
+            if (this.elem.style.display === 'none') {
+                this.elem.style.display = 'block'; // Show the div
+            } else {
+                this.elem.style.display = 'none'; // Hide the div
+            }
+        }
+    }
+    SkrubTableReport.register(SwitchFigures);
+
+
 
     class Toggletip extends Manager {
         constructor(elem, exchange) {
@@ -817,7 +845,7 @@ if (customElements.get('skrub-table-report') === undefined) {
         const refElement = document.getElementById(refElementId);
         const color = window.getComputedStyle(refElement, null).getPropertyValue('color');
         const match = color.match(/^rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*$/i);
-        if(match){
+        if (match) {
             const [r, g, b] = [match[1], match[2], match[3]];
 
             // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
@@ -827,7 +855,7 @@ if (customElements.get('skrub-table-report') === undefined) {
                 // If the text is very bright we have a dark theme
                 return 'dark';
             }
-            if (luma < 75 ) {
+            if (luma < 75) {
                 // If the text is very dark we have a light theme
                 return 'light';
             }

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -199,6 +199,17 @@ def _robust_hist(values, ax, color):
     n_high_outliers = (high < values).sum()
     n, bins, patches = ax.hist(inliers)
     n_out = n_low_outliers + n_high_outliers
+
+    # Display percentage on the bar of the histrogram
+    threshold_display = np.max(n) / 2
+    for x_, value in zip(bins, n):
+        percentage = value / np.sum(n)
+        percentage_string = _utils.format_percent(percentage)
+        if value > threshold_display:
+            ax.text(x_, value - threshold_display, percentage_string, rotation='vertical')
+        else:
+            ax.text(x_, value + threshold_display * 0.1, percentage_string, rotation='vertical')
+
     if not n_out:
         return 0, 0
     width = bins[1] - bins[0]

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -202,19 +202,26 @@ def _robust_hist(values, ax, color):
 
     # Display percentage on the bar of the histrogram
     threshold_display = np.max(n) / 2
-    for x_, value in zip(bins, n):
+    for index, value in enumerate(n):
         percentage = value / np.sum(n)
         percentage_string = _utils.format_percent(percentage)
         if value > threshold_display:
             ax.text(
-                x_, value - threshold_display, percentage_string, rotation="vertical"
+                bins[index] + 0.2 * (bins[index + 1] - bins[index]),
+                value - threshold_display * 0.8,
+                percentage_string,
+                rotation="vertical",
+                color="black",
+                fontsize=8,
             )
         else:
             ax.text(
-                x_,
-                value + threshold_display * 0.1,
+                bins[index] + 0.2 * (bins[index + 1] - bins[index]),
+                value + threshold_display * 0.05,
                 percentage_string,
                 rotation="vertical",
+                color=_TEXT_COLOR_PLACEHOLDER,
+                fontsize=8,
             )
 
     if not n_out:

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -206,9 +206,16 @@ def _robust_hist(values, ax, color):
         percentage = value / np.sum(n)
         percentage_string = _utils.format_percent(percentage)
         if value > threshold_display:
-            ax.text(x_, value - threshold_display, percentage_string, rotation='vertical')
+            ax.text(
+                x_, value - threshold_display, percentage_string, rotation="vertical"
+            )
         else:
-            ax.text(x_, value + threshold_display * 0.1, percentage_string, rotation='vertical')
+            ax.text(
+                x_,
+                value + threshold_display * 0.1,
+                percentage_string,
+                rotation="vertical",
+            )
 
     if not n_out:
         return 0, 0

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -217,7 +217,7 @@ def _robust_hist(values, ax, color):
         else:
             ax.text(
                 bins[index] + 0.2 * (bins[index + 1] - bins[index]),
-                value + threshold_display * 0.05,
+                value + threshold_display * 0.1,
                 percentage_string,
                 rotation="vertical",
                 color=_TEXT_COLOR_PLACEHOLDER,

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -209,11 +209,21 @@ def _add_value_counts(summary, column, *, dataframe_summary, with_plots):
     else:
         summary["value_is_constant"] = False
         if with_plots:
-            summary["value_counts_plot"] = _plotting.value_counts(
-                value_counts,
-                n_unique,
-                dataframe_summary["n_rows"],
-                color=_plotting.COLORS[1],
+            summary["value_counts_plot"] = (
+                _plotting.value_counts(
+                    value_counts,
+                    n_unique,
+                    dataframe_summary["n_rows"],
+                    color=_plotting.COLORS[1],
+                    percentage=False,
+                ),
+                _plotting.value_counts(
+                    value_counts,
+                    n_unique,
+                    dataframe_summary["n_rows"],
+                    color=_plotting.COLORS[1],
+                    percentage=True,
+                ),
             )
 
 
@@ -231,10 +241,14 @@ def _add_datetime_summary(summary, column, with_plots):
     summary["max"] = max_date.isoformat()
     if with_plots:
         (
-            summary["histogram_plot"],
+            histogram_raw,
             summary["n_low_outliers"],
             summary["n_high_outliers"],
-        ) = _plotting.histogram(column, color=_plotting.COLORS[0])
+        ) = _plotting.histogram(column, color=_plotting.COLORS[0], percentage=False)
+        hist_percentage, _, _ = _plotting.histogram(
+            column, color=_plotting.COLORS[0], percentage=True
+        )
+        summary["histogram_plot"] = (histogram_raw, hist_percentage)
 
 
 def _add_numeric_summary(
@@ -267,11 +281,22 @@ def _add_numeric_summary(
         return
     if order_by_column is None:
         (
-            summary["histogram_plot"],
+            histogram_raw,
             summary["n_low_outliers"],
             summary["n_high_outliers"],
         ) = _plotting.histogram(
-            column, duration_unit=duration_unit, color=_plotting.COLORS[0]
+            column,
+            duration_unit=duration_unit,
+            color=_plotting.COLORS[0],
+            percentage=False,
         )
+        (histogram_percentage, _, _) = _plotting.histogram(
+            column,
+            duration_unit=duration_unit,
+            color=_plotting.COLORS[0],
+            percentage=True,
+        )
+        summary["histogram_plot"] = (histogram_raw, histogram_percentage)
     else:
-        summary["line_plot"] = _plotting.line(order_by_column, column)
+        plot = _plotting.line(order_by_column, column)
+        summary["line_plot"] = (plot, plot)

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -209,21 +209,11 @@ def _add_value_counts(summary, column, *, dataframe_summary, with_plots):
     else:
         summary["value_is_constant"] = False
         if with_plots:
-            summary["value_counts_plot"] = (
-                _plotting.value_counts(
-                    value_counts,
-                    n_unique,
-                    dataframe_summary["n_rows"],
-                    color=_plotting.COLORS[1],
-                    percentage=False,
-                ),
-                _plotting.value_counts(
-                    value_counts,
-                    n_unique,
-                    dataframe_summary["n_rows"],
-                    color=_plotting.COLORS[1],
-                    percentage=True,
-                ),
+            summary["value_counts_plot"] = _plotting.value_counts(
+                value_counts,
+                n_unique,
+                dataframe_summary["n_rows"],
+                color=_plotting.COLORS[1],
             )
 
 
@@ -241,14 +231,10 @@ def _add_datetime_summary(summary, column, with_plots):
     summary["max"] = max_date.isoformat()
     if with_plots:
         (
-            histogram_raw,
+            summary["histogram_plot"],
             summary["n_low_outliers"],
             summary["n_high_outliers"],
-        ) = _plotting.histogram(column, color=_plotting.COLORS[0], percentage=False)
-        hist_percentage, _, _ = _plotting.histogram(
-            column, color=_plotting.COLORS[0], percentage=True
-        )
-        summary["histogram_plot"] = (histogram_raw, hist_percentage)
+        ) = _plotting.histogram(column, color=_plotting.COLORS[0])
 
 
 def _add_numeric_summary(
@@ -281,22 +267,11 @@ def _add_numeric_summary(
         return
     if order_by_column is None:
         (
-            histogram_raw,
+            summary["histogram_plot"],
             summary["n_low_outliers"],
             summary["n_high_outliers"],
         ) = _plotting.histogram(
-            column,
-            duration_unit=duration_unit,
-            color=_plotting.COLORS[0],
-            percentage=False,
+            column, duration_unit=duration_unit, color=_plotting.COLORS[0]
         )
-        (histogram_percentage, _, _) = _plotting.histogram(
-            column,
-            duration_unit=duration_unit,
-            color=_plotting.COLORS[0],
-            percentage=True,
-        )
-        summary["histogram_plot"] = (histogram_raw, histogram_percentage)
     else:
-        plot = _plotting.line(order_by_column, column)
-        summary["line_plot"] = (plot, plot)
+        summary["line_plot"] = _plotting.line(order_by_column, column)

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -111,7 +111,8 @@ def test_no_title(pd_module):
 def test_high_cardinality_column(pd_module):
     df = pd_module.make_dataframe({"s": [f"value {i}" for i in range(30)]})
     summary = summarize_dataframe(df, with_plots=True)
-    assert "10 most frequent" in summary["columns"][0]["value_counts_plot"]
+    assert "10 most frequent" in summary["columns"][0]["value_counts_plot"][0]
+    assert "10 most frequent" in summary["columns"][0]["value_counts_plot"][1]
 
 
 def test_all_null(df_module):

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -50,7 +50,8 @@ def test_summarize(
     assert round(c["unique_proportion"], 3) == 0.118
     c["unique_proportion"] = 0.118
     if with_plots:
-        assert c["value_counts_plot"].startswith("<?xml")
+        for figure in c["value_counts_plot"]:
+            assert figure.startswith("<?xml")
         assert c["plot_names"] == ["value_counts_plot"]
         c["plot_names"] = []
         c.pop("value_counts_plot")


### PR DESCRIPTION
This PR is based on the PR #1496.

This PR solves the desire requirement behaviour of the issue #1454 .

The principle of this feature is to use JavaScript to send a message which changes the style of the html division of the figure between 'none' and 'block' (default value). This means that there are 2 figures created for each column: one with a percentage label and one with normal numbers.

WARNING: The percentage is fixed in the size of the display number, which is not the case for the number. This can create some not rendering well for large numbers. 

