### PR TITLE
Updating doc makefile to avoid issues with obsolete files

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,3 +47,4 @@ html-noplot:
 clean:
 	rm -rf _build/ reference/generated/
 	rm -rf _build/ generated_for_index
+	rm -f reference/*.rst


### PR DESCRIPTION
While I was working on the refactoring PR I had various issues trying to build the docs locally, even though they were being built properly on the CI. 

After some debugging, I think the cause of the issues was the presence of old files in the `doc/reference` page: sphinx was finding a file named `expressions.rst` and was expecting `skrub.Expr`, which I had removed by then.

This PR adds a simple line to clean the folder (except for the templates). It's not a problem on CI, but it might be when developing locally. 