### PR TITLE
Fixing a bug in two examples introduced by refactoring

### DIFF
--- a/examples/00_getting_started.py
+++ b/examples/00_getting_started.py
@@ -75,14 +75,14 @@ TableReport(employees_df)
 
 from skrub import set_config
 
-set_config(use_tablereport=True)
+set_config(use_table_report=True)
 
 employees_df
 
 # %%
 # This setting can easily be reverted:
 
-set_config(use_tablereport=False)
+set_config(use_table_report=False)
 
 employees_df
 

--- a/examples/10_apply_on_cols.py
+++ b/examples/10_apply_on_cols.py
@@ -15,7 +15,7 @@ and transforming dataframe columns using arbitrary logic.
 import skrub
 from skrub.datasets import fetch_employee_salaries
 
-skrub.set_config(use_tablereport=True)
+skrub.set_config(use_table_report=True)
 data = fetch_employee_salaries()
 X, y = data.X, data.y
 X


### PR DESCRIPTION
Docs don't render because I changed a name and forgot to update them 