### PR TITLE
Improve choices example

### DIFF
--- a/examples/data_ops/11_choices.py
+++ b/examples/data_ops/11_choices.py
@@ -3,7 +3,7 @@
 
 .. _example_tuning_pipelines:
 
-Tuning DataOps
+Hyperparameter tuning with DataOps
 ==============
 
 A machine-learning pipeline typically contains some values or choices which


### PR DESCRIPTION
This PR suggests a lot of rewording and adds links to references of the choices example. To be useful, this example should be significantly shorter, and most parts detailing the features of the data ops or choices should go to the user guides, in https://github.com/skrub-data/skrub/pull/1529.