### PR TITLE
Update our development status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
     {name = "Gael Varoquaux"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
I noticed that we still broadcast a beta status: https://pypi.org/project/skrub/

I think that we should change this. Here is a PR doing it.