### PR TITLE
Included pixi in the building documentation section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -369,6 +369,17 @@ specific examples, you can use the following command with a regex pattern:
 This is especially helpful when you're only modifying or checking a few examples.
 
 It is also possible to build the documentation without running the examples
+without running the examples by using the following command:
+
+.. code:: bash
+
+    make html-noplot
+
+This command generates the documentation without re-executing the examples, which can
+take a long time. This is useful if you are only modifying the documentation itself, such as fixing
+typos or improving explanations.
+
+
 
 **Using pixi**
 


### PR DESCRIPTION
Included pixi in the building documentation section of Contributing (including a warning on Intel-based macOS systems)