### PR TITLE
FIX - .skb.concat fails when it is passed a dataframe with non-strings as column names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Bugfixes
   when applied to categorical columns. :pr:`1570` by :user:`Riccardo Cappuzzo<rcap107>`.
 - Fixed the display of DataOp objects in google colab cell outputs (no output
   was displayed). :pr:`1590` by :user:`Jérôme Dockès <jeromedockes>`.
+- Fixed an error that occurred when using ``.skb.concat`` with a pandas dataframe
+  with column names that aren't strings. :pr:`1594` by :user:`Riccardo Cappuzzo<rcap107>`.
 
 Release 0.6.1
 ===================

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1699,7 +1699,15 @@ class Concat(DataOpImpl):
                 f"Invalid axis value {e.axis!r} for concat. Expected one of 0 or 1."
             )
 
-        result = sbd.concat(e.first, *e.others, axis=e.axis)
+        if e.axis == 1:
+            first = _check_column_names(e.first)
+            others = list(map(_check_column_names, e.others))
+        else:
+            # No need to sanitize column names if concatenating vertically.
+            first = e.first
+            others = e.others
+
+        result = sbd.concat(first, *others, axis=e.axis)
 
         if e.axis == 1:
             if mode == "preview" or "fit" in mode:

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -337,13 +337,11 @@ def test_concat_vertical_duplicate_cols():
     assert out_1.shape[0] == out_2.shape[0] == 4
 
 
-def test_concat_vertical_non_str_colname():
-    X = pd.DataFrame(
-        np.random.rand(100, 5), columns=[f"Feature number {i}" for i in range(5)]
-    )
+def test_concat_horizontal_non_str_colname():
+    X = pd.DataFrame({"a": [0, 1], "b": [2, 3]})
     X_op = skrub.X(X)
 
-    y = pd.Series(np.ones(100))
+    y = pd.Series([1, 1])
     y_no_name = (
         y.to_frame()
     )  # note that the name is left empty so pandas will auto-name it 0
@@ -355,18 +353,16 @@ def test_concat_vertical_non_str_colname():
     ):
         concat_op = X_op.skb.concat([skrub.as_data_op(y_no_name)], axis=1)
 
-    expected_columns = [f"Feature number {i}" for i in range(5)] + ["0"]
-    assert concat_op.skb.eval().shape == (100, 6)
-    assert concat_op.skb.eval().columns.tolist() == expected_columns
+    assert concat_op.skb.eval().shape == (2, 3)
+    assert concat_op.skb.eval().columns.tolist() == ["a", "b", "0"]
 
     # check that no warning is raised because all column names are strings
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         concat_op = X_op.skb.concat([skrub.as_data_op(y_with_name)], axis=1)
 
-    expected_columns = [f"Feature number {i}" for i in range(5)] + ["y"]
-    assert concat_op.skb.eval().shape == (100, 6)
-    assert concat_op.skb.eval().columns.tolist() == expected_columns
+    assert concat_op.skb.eval().shape == (2, 3)
+    assert concat_op.skb.eval().columns.tolist() == ["a", "b", "y"]
 
 
 def test_class_skb():

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -186,6 +186,15 @@ def make_column_names_unique(*dataframes):
     used = set()
     result = []
     for df in dataframes:
+        column_names = sbd.column_names(df)
+        if not all(isinstance(c) is str for c in column_names):
+            msg = "All column names must be strings."
+            if sbd.is_pandas(df):
+                msg += (
+                    " If you defined a Dataframe using pd.Series.to_frame(), make"
+                    " sure to pass a column name (e.g. pd.Series.to_frame('my_col'))."
+                )
+            raise TypeError(msg)
         new_names = pick_column_names(sbd.column_names(df), forbidden_names=used)
         result.append(sbd.set_column_names(df, new_names))
         used.update(new_names)

--- a/skrub/_join_utils.py
+++ b/skrub/_join_utils.py
@@ -186,15 +186,6 @@ def make_column_names_unique(*dataframes):
     used = set()
     result = []
     for df in dataframes:
-        column_names = sbd.column_names(df)
-        if not all(isinstance(c) is str for c in column_names):
-            msg = "All column names must be strings."
-            if sbd.is_pandas(df):
-                msg += (
-                    " If you defined a Dataframe using pd.Series.to_frame(), make"
-                    " sure to pass a column name (e.g. pd.Series.to_frame('my_col'))."
-                )
-            raise TypeError(msg)
         new_names = pick_column_names(sbd.column_names(df), forbidden_names=used)
         result.append(sbd.set_column_names(df, new_names))
         used.update(new_names)


### PR DESCRIPTION
Fixes #1593 for data ops concat