### PR TITLE
only evaluate items of builtin collections not subclasses

### DIFF
--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -180,12 +180,17 @@ class _DataOpTraversal:
                 last_result = node_durations[stack[-1].target_id]
             elif isinstance(top, DataOp):
                 push_computation(self.handle_data_op)
-            elif isinstance(top, _BUILTIN_MAP):
+
+            # We recurse into built-in collections but not their subclasses (we
+            # would not know how to reconstruct a collection from the items'
+            # values). Thus we compare types directly rather than using isinstance.
+            elif type(top) in _BUILTIN_MAP:
                 push_computation(self.handle_mapping)
-            elif isinstance(top, _BUILTIN_SEQ):
+            elif type(top) in _BUILTIN_SEQ:
                 push_computation(self.handle_seq)
-            elif isinstance(top, slice):
+            elif type(top) is slice:
                 push_computation(self.handle_slice)
+
             elif isinstance(top, _choosing.BaseChoice):
                 push_computation(self.handle_choice)
             elif isinstance(top, _choosing.Match):


### PR DESCRIPTION
When evaluating a DataOp, we evaluate built-in collections such as lists by evaluating each item and then reconstructing the list. This allows things like `choose_from([choose_from(...), choose_from(...)])` (because we recurse into the list) and many more useful cases. This is similar to what scikit-learn `clone` does.

However, we should not do it for instances of subclasses of those builtin-types, because their initializers may work differently or they may have other invariants we do not know about so we may not be able to reconstruct the new collection from the evaluated items. `sklearn.clone` only considers the built-in classes, not their subclasses.

At the moment we also open subclasses, this PR fixes that (ie makes the behavior the same as `clone`)

eg this fails on main but works in this PR

```
>>> from collections import namedtuple

>>> import skrub

>>> Pair = namedtuple("Pair", ["first", "second"])
>>> p = Pair(1, 2)
>>> skrub.as_data_op(p).skb.eval()
Pair(first=1, second=2)
```

(In main we get `TypeError: Pair.__new__() missing 1 required positional argument: 'second'` when trying to call `Pair([1, 2])` )