### PR TITLE
use dataop name in Call __repr__ if available

### DIFF
--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1442,10 +1442,10 @@ class Call(DataOpImpl):
             name = getattr(self.func, "__name__", repr(self.func))
         else:
             impl = self.func._skrub_impl
-            if isinstance(impl, GetItem):
-                name = f"{{ ... }}[{short_repr(impl.key)}]"
-            elif isinstance(impl, Var):
+            if impl.name is not None:
                 name = impl.name
+            elif isinstance(impl, GetItem):
+                name = f"{{ ... }}[{short_repr(impl.key)}]"
             else:
                 name = type(impl).__name__
         return name

--- a/skrub/_data_ops/tests/test_deferred.py
+++ b/skrub/_data_ops/tests/test_deferred.py
@@ -71,6 +71,17 @@ def test_deferred_callables_repr():
     Result:
     ―――――――
     20
+    >>> @skrub.deferred
+    ... def add(x):
+    ...     return lambda y: x + y
+    >>> a = skrub.var("a", 1)
+    >>> b = skrub.var("b", 2)
+    >>> c = add(a).skb.set_name("add a")(b)
+    >>> c
+    <Call 'add a'>
+    Result:
+    ―――――――
+    3
     """
 
 


### PR DESCRIPTION
tiny tweak to the `__repr__` of Call nodes: when they have a name, always use it as <Call "the name">

in this (nonsensical) example

```
>>> import skrub

>>> add = skrub.deferred(lambda x:lambda y:x+y)
>>> a, b = skrub.var('a'), skrub.var('b')
>>> add(a).skb.set_name('add a')(b)
<Call 'add a'>
```

in the main branch the output would be `<Call 'Call'>` which is not as nice