### PR TITLE
rename values for .skb.apply(how=...)

### DIFF
--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -249,15 +249,15 @@ class SkrubLearner(_CloudPickleDataOp, BaseEstimator):
         >>> learner.find_fitted_estimator("classifier")
         DummyClassifier()
 
-        Depending on the parameters passed to ``skb.apply()``, the estimator we provide
-        can be wrapped in a skrub transformer that applies it to several columns in the
-        input, or to a subset of the columns in a dataframe. In other cases it may be
-        applied without any wrapping. We provide examples for those 3 different cases
-        below.
+        Depending on the parameters passed to :meth:`DataOp.skb.apply`, the
+        estimator we provide can be wrapped in a skrub transformer that applies
+        it to several columns in the input, or to a subset of the columns in a
+        dataframe. In other cases it may be applied without any wrapping. We
+        provide examples for those 3 different cases below.
 
         Case 1: the ``StringEncoder`` is a skrub single-column transformer: it
         transforms a single column. In the learner it gets wrapped in a
-        ``skrub.ApplyToCols`` which independently fits a separate instance of the
+        :class:`ApplyToCols` which independently fits a separate instance of the
         ``StringEncoder`` to each of the columns it transforms (in this case there is
         only one column, ``'product'``). The individual transformers can be found in the
         fitted attribute ``transformers_`` which maps column names to the corresponding
@@ -269,13 +269,13 @@ class SkrubLearner(_CloudPickleDataOp, BaseEstimator):
         >>> encoder.transformers_['product'].vectorizer_.vocabulary_
         {' pe': 2, 'pen': 12, 'en ': 8, ' pen': 3, 'pen ': 13, ' cu': 0, 'cup': 6, 'up ': 18, ' cup': 1, 'cup ': 7, ' sp': 4, 'spo': 16, 'poo': 14, 'oon': 10, 'on ': 9, ' spo': 5, 'spoo': 17, 'poon': 15, 'oon ': 11}
 
-        This case (wrapping in ``ApplyToCols``) happens when the estimator is a skrub
+        This case (wrapping in :class:`ApplyToCols`) happens when the estimator is a skrub
         single-column transformer (it has a ``__single_column_transformer__``
-        attribute), we pass ``.skb.apply(how='columnwise')`` or we pass
+        attribute), we pass ``.skb.apply(how='cols')`` or we pass
         ``.skb.apply(allow_reject=True)``.
 
         Case 2: the ``PCA`` is a regular scikit-learn transformer. In the learner it
-        gets wrapped in a ``skrub.ApplyToFrame`` which applies it to the subset of columns
+        gets wrapped in a :class:`ApplyToFrame` which applies it to the subset of columns
         in the dataframe selected by the ``cols`` argument passed to ``.skb.apply()``.
         The fitted ``PCA`` can be found in the fitted attribute ``transformer_``.
 
@@ -287,8 +287,9 @@ class SkrubLearner(_CloudPickleDataOp, BaseEstimator):
         >>> pca.transformer_.mean_
         array([2020.,    4.,    4.], dtype=float32)
 
-        This case (wrapping in ``ApplyToFrame``) happens when the estimator is a
-        scikit-learn transformer but not a single-column transformer.
+        This case (wrapping in :class:`ApplyToFrame`) happens when the estimator is a
+        scikit-learn transformer but not a single-column transformer, or we
+        pass ``.skb.apply(how='frame')``.
 
         The ``DummyRegressor`` is a scikit-learn predictor. In the learner it gets
         applied directly to the input dataframe without any wrapping.
@@ -301,7 +302,7 @@ class SkrubLearner(_CloudPickleDataOp, BaseEstimator):
 
         This case (no wrapping) happens when the estimator is a scikit-learn predictor
         (not a transformer), the input is not a dataframe (e.g. it is a numpy array), or
-        we pass ``.skb.apply(how='full_frame')``.
+        we pass ``.skb.apply(how='no_wrap')``.
         """  # noqa: E501
         node = find_node_by_name(self.data_op, name)
         if node is None:


### PR DESCRIPTION
As discussed in [1614](https://github.com/skrub-data/skrub/issues/1614#issuecomment-3304425737) , this changes the values for the `how` parameter of `.skb.apply()` to match the names of the corresponding transformers. The options are now

```
'auto' -> let skrub decide, the default
'cols' -> ApplyToCols
'frame' -> ApplyToFrame
'no_wrap' -> no wrapping
```

the behavior is unchanged, only the values change. The old values 'auto', 'columnwise', 'sub_frame', 'full_frame' are kept with a FutureWarning