### PR TITLE
MAINT - post 0.6.2 release

### DIFF
--- a/doc/version.json
+++ b/doc/version.json
@@ -5,8 +5,8 @@
         "url": "https://skrub-data.org/dev/"
     },
     {
-        "name": "0.6.1 (stable)",
-        "version": "0.6.1",
+        "name": "0.6.2 (stable)",
+        "version": "0.6.2",
         "url": "https://skrub-data.org/stable/",
         "preferred": true
     }


### PR DESCRIPTION
Update the `doc/version.js` to make stable point to 0.6.2