### PR TITLE
discussion/wip allow passing kwargs in .skb.apply()

### DIFF
--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -73,8 +73,11 @@ class SingleColumnTransformer(BaseEstimator):
 
     __single_column_transformer__ = True
 
-    def fit(self, column, y=None):
+    def fit(self, column, y=None, **kwargs):
         """Fit the transformer.
+
+        This default implementation simply calls ``fit_transform()`` and
+        returns ``self``.
 
         Subclasses should implement ``fit_transform`` and ``transform``.
 
@@ -87,12 +90,15 @@ class SingleColumnTransformer(BaseEstimator):
         y : column or dataframe
             Prediction targets.
 
+        kwargs :
+            Extra named arguments are passed to ``self.fit_transform()``.
+
         Returns
         -------
         self
             The fitted transformer.
         """
-        self.fit_transform(column, y=y)
+        self.fit_transform(column, y=y, **kwargs)
         return self
 
     def _check_single_column(self, column, function_name):
@@ -132,35 +138,35 @@ def _wrap_add_check_single_column(f):
     if f.__name__ == "fit":
 
         @functools.wraps(f)
-        def fit(self, X, y=None):
+        def fit(self, X, y=None, **kwargs):
             self._check_single_column(X, f.__name__)
-            return f(self, X, y=y)
+            return f(self, X, y=y, **kwargs)
 
         return fit
     elif f.__name__ == "partial_fit":
 
         @functools.wraps(f)
-        def partial_fit(self, X, y=None):
+        def partial_fit(self, X, y=None, **kwargs):
             self._check_single_column(X, f.__name__)
-            return f(self, X, y=y)
+            return f(self, X, y=y, **kwargs)
 
         return partial_fit
 
     elif f.__name__ == "fit_transform":
 
         @functools.wraps(f)
-        def fit_transform(self, X, y=None):
+        def fit_transform(self, X, y=None, **kwargs):
             self._check_single_column(X, f.__name__)
-            return f(self, X, y=y)
+            return f(self, X, y=y, **kwargs)
 
         return fit_transform
     else:
         assert f.__name__ == "transform", f.__name__
 
         @functools.wraps(f)
-        def transform(self, X):
+        def transform(self, X, **kwargs):
             self._check_single_column(X, f.__name__)
-            return f(self, X)
+            return f(self, X, **kwargs)
 
         return transform
 
@@ -438,7 +444,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         self.rename_columns = rename_columns
         self.n_jobs = n_jobs
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, **kwargs):
         """Fit the transformer on each column independently.
 
         Parameters
@@ -449,15 +455,19 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         y : Pandas or Polars Series or DataFrame, default=None
             The target data.
 
+        kwargs :
+            Extra named arguments are passed to the ``fit_transform()`` method of
+            the individual column transformers (the clones of ``self.transformer``).
+
         Returns
         -------
         ApplyToCols
             The transformer itself.
         """
-        self.fit_transform(X, y)
+        self.fit_transform(X, y, **kwargs)
         return self
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y=None, **kwargs):
         """Fit the transformer on each column independently and transform X.
 
         Parameters
@@ -467,6 +477,10 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
 
         y : Pandas or Polars Series or DataFrame, default=None
             The target data.
+
+        kwargs :
+            Extra named arguments are passed to the ``fit_transform()`` method of
+            the individual column transformers (the clones of ``self.transformer``).
 
         Returns
         -------
@@ -485,18 +499,24 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
                 self._columns,
                 self.transformer,
                 self.allow_reject,
+                kwargs,
             )
             for col_name in all_columns
         )
         return self._process_fit_transform_results(results, X)
 
-    def transform(self, X):
+    def transform(self, X, **kwargs):
         """Transform a dataframe.
 
         Parameters
         ----------
         X : Pandas or Polars DataFrame
             The column to transform.
+
+        kwargs :
+            Extra named arguments are passed to the ``transform()`` method of
+            the fitted individual column transformers (the values of
+            ``self.transformers_``, which are clones of ``self.transformer``).
 
         Returns
         -------
@@ -507,10 +527,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         parallel = Parallel(n_jobs=self.n_jobs)
         func = delayed(_transform_column)
         outputs = parallel(
-            func(
-                sbd.col(X, col_name),
-                self.transformers_.get(col_name),
-            )
+            func(sbd.col(X, col_name), self.transformers_.get(col_name), kwargs)
             for col_name in sbd.column_names(X)
         )
         transformed_columns = []
@@ -586,7 +603,9 @@ def _prepare_transformer_input(transformer, column):
     return sbd.make_dataframe_like(column, [column])
 
 
-def _fit_transform_column(column, y, columns_to_handle, transformer, allow_reject):
+def _fit_transform_column(
+    column, y, columns_to_handle, transformer, allow_reject, kwargs
+):
     col_name = sbd.name(column)
     if col_name not in columns_to_handle:
         return col_name, [column], None
@@ -595,7 +614,7 @@ def _fit_transform_column(column, y, columns_to_handle, transformer, allow_rejec
     transformer_input = _prepare_transformer_input(transformer, column)
     allowed = (RejectColumn,) if allow_reject else ()
     try:
-        output = transformer.fit_transform(transformer_input, y=y)
+        output = transformer.fit_transform(transformer_input, y=y, **kwargs)
     except allowed:
         return col_name, [column], None
     except Exception as e:
@@ -608,12 +627,12 @@ def _fit_transform_column(column, y, columns_to_handle, transformer, allow_rejec
     return col_name, output_cols, transformer
 
 
-def _transform_column(column, transformer):
+def _transform_column(column, transformer, kwargs):
     if transformer is None:
         return [column]
     transformer_input = _prepare_transformer_input(transformer, column)
     try:
-        output = transformer.transform(transformer_input)
+        output = transformer.transform(transformer_input, **kwargs)
     except Exception as e:
         raise ValueError(
             f"Transformer {transformer.__class__.__name__}.transform "

--- a/skrub/_apply_to_frame.py
+++ b/skrub/_apply_to_frame.py
@@ -137,7 +137,7 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
         self.keep_original = keep_original
         self.rename_columns = rename_columns
 
-    def fit(self, X, y=None):
+    def fit(self, X, y=None, **kwargs):
         """Fit the transformer on all columns jointly.
 
         Parameters
@@ -148,15 +148,19 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
         y : Pandas or Polars Series or DataFrame, default=None
             The target data.
 
+        kwargs :
+            Extra named arguments are passed to the ``fit_transform()`` method
+            of ``self.transformer``.
+
         Returns
         -------
         ApplyToFrame
             The transformer itself.
         """
-        self.fit_transform(X, y)
+        self.fit_transform(X, y, **kwargs)
         return self
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y=None, **kwargs):
         """Fit the transformer on all columns jointly and transform X.
 
         Parameters
@@ -166,6 +170,10 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
 
         y : Pandas or Polars Series or DataFrame, default=None
             The target data.
+
+        kwargs :
+            Extra named arguments are passed to the ``fit_transform()`` method
+            of ``self.transformer``.
 
         Returns
         -------
@@ -183,7 +191,7 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
         if self._columns:
             self.transformer_ = clone(self.transformer)
             _utils.set_output(self.transformer_, X)
-            transformed = self.transformer_.fit_transform(to_transform, y)
+            transformed = self.transformer_.fit_transform(to_transform, y, **kwargs)
             transformed = _utils.check_output(
                 self.transformer_, to_transform, transformed, allow_column_list=False
             )
@@ -212,13 +220,17 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
         result = sbd.copy_index(X, result)
         return result
 
-    def transform(self, X):
+    def transform(self, X, **kwargs):
         """Transform a dataframe.
 
         Parameters
         ----------
         X : Pandas or Polars DataFrame
             The column to transform.
+
+        kwargs :
+            Extra named arguments are passed to the ``transform()`` method
+            of ``self.transformer_``.
 
         Returns
         -------
@@ -236,7 +248,7 @@ class ApplyToFrame(TransformerMixin, BaseEstimator):
             passthrough = selectors.select(X, selectors.inv(self._columns))
         if not self._columns:
             return passthrough
-        transformed = self.transformer_.transform(to_transform)
+        transformed = self.transformer_.transform(to_transform, **kwargs)
         # we do not call `_utils.check_output` here, assuming that if the output
         # had a correct type (e.g. polars dataframe) in `fit_transform` it will
         # have the same (correct) type in `transform`.

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -99,7 +99,10 @@ class SkrubNamespace:
         how="auto",
         allow_reject=False,
         unsupervised=False,
+        kwargs=None,
     ):
+        if kwargs is None:
+            kwargs = {}
         data_op = DataOp(
             Apply(
                 estimator=estimator,
@@ -109,6 +112,7 @@ class SkrubNamespace:
                 how=how,
                 allow_reject=allow_reject,
                 unsupervised=unsupervised,
+                kwargs=kwargs,
             )
         )
         return data_op
@@ -124,6 +128,13 @@ class SkrubNamespace:
         how="auto",
         allow_reject=False,
         unsupervised=False,
+        fit_kwargs=None,
+        fit_transform_kwargs=None,
+        transform_kwargs=None,
+        predict_kwargs=None,
+        predict_proba_kwargs=None,
+        decision_function_kwargs=None,
+        score_kwargs=None,
     ):
         """
         Apply a scikit-learn estimator to a dataframe or numpy array.
@@ -181,6 +192,30 @@ class SkrubNamespace:
             transformer, or when we are not interested in scoring with
             ground-truth labels), simply leave the default ``y=None`` and there
             is no need to pass a value for ``unsupervised``.
+
+        fit_kwargs : dict, optional, default=None
+            Extra named arguments to pass to the estimator's ``fit()`` method,
+            for example ``fit_kwargs={'sample_weights': [.1, .5, .4]}``. May be
+            (or contain) a DataOp, which will be evaluated before passing the
+            kwargs to ``fit``.
+        fit_transform_kwargs : dict, optional, default=None
+            Extra named arguments for ``fit_transform``. See the description of
+            the ``fit_kwargs`` parameter.
+        transform_kwargs : dict, optional, default=None
+            Extra named arguments for ``transform``. See the description of the
+            ``fit_kwargs`` parameter.
+        predict_kwargs : dict, optional, default=None
+            Extra named arguments for ``predict``. See the description of the
+            ``fit_kwargs`` parameter.
+        predict_proba_kwargs : dict, optional, default=None
+            Extra named arguments for ``predict_proba``. See the description of
+            the ``fit_kwargs`` parameter.
+        decision_function_kwargs : dict, optional, default=None
+            Extra named arguments for ``decision_function``. See the
+            description of the ``fit_kwargs`` parameter.
+        score_kwargs : dict, optional, default=None
+            Extra named arguments for ``score``. See the description of the
+            ``fit_kwargs`` parameter.
 
         Returns
         -------
@@ -329,6 +364,15 @@ class SkrubNamespace:
             how=how,
             allow_reject=allow_reject,
             unsupervised=unsupervised,
+            kwargs={
+                "fit": fit_kwargs,
+                "fit_transform": fit_transform_kwargs,
+                "transform": transform_kwargs,
+                "predict": predict_kwargs,
+                "predict_proba": predict_proba_kwargs,
+                "decision_function": decision_function_kwargs,
+                "score": score_kwargs,
+            },
         )
 
     def apply_func(self, func, *args, **kwargs):

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -421,6 +421,148 @@ def test_apply_on_cols(use_choice):
     assert (out.values == expected).all()
 
 
+def test_apply_kwargs():
+    class E(BaseEstimator):
+        def fit(self, X, y=None, extra_f=None):
+            assert extra_f == "kwarg for fit"
+            return self
+
+        def predict(self, X, extra_p=None):
+            assert extra_p == "kwarg for predict"
+            return 0
+
+        def score(self, X, y=None, **kwargs):
+            assert not kwargs
+            return 0
+
+    pred = skrub.var("a").skb.apply(
+        E(),
+        fit_kwargs={"extra_f": "kwarg for fit"},
+        predict_kwargs={"extra_p": "kwarg for predict"},
+    )
+    learner = pred.skb.make_learner()
+    learner.fit({"a": 0})
+    learner.predict({"a": 0})
+    learner.score({"a": 0})
+
+
+def test_apply_transformer_kwargs():
+    # check kwargs get passed correctly to the transformer for all 'how' values.
+    class T(BaseEstimator):
+        def fit_transform(self, X, y=None, extra_f=None):
+            assert extra_f == "kwarg for fit_transform"
+            return X
+
+        def transform(self, X, extra_t=None):
+            assert extra_t == "kwarg for transform"
+            return X
+
+    kwargs = {
+        "fit_transform_kwargs": {"extra_f": "kwarg for fit_transform"},
+        "transform_kwargs": {"extra_t": "kwarg for transform"},
+    }
+    learner = (
+        skrub.var("df")
+        .skb.apply(T(), how="no_wrap", **kwargs)
+        .skb.apply(T(), how="cols", **kwargs)
+        .skb.apply(T(), how="frame", **kwargs)
+        .skb.make_learner()
+    )
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+    learner.fit({"df": df})
+    learner.fit_transform({"df": df})
+    learner.transform({"df": df})
+
+
+def test_apply_kwargs_evaluation():
+    class E(BaseEstimator):
+        def fit(self, X, y=None, extra_f=None):
+            assert extra_f == "kwarg for fit"
+            return self
+
+        def predict(self, X, extra_p=None):
+            assert extra_p == "kwarg for predict"
+            return 0
+
+        def predict_proba(self, X, **kwargs):
+            assert not kwargs
+            return 0
+
+        def score(self, X, y=None, **kwargs):
+            assert not kwargs
+            return 0
+
+    get_extra_f_n_calls = 0
+
+    @skrub.deferred
+    def get_extra_f(a):
+        nonlocal get_extra_f_n_calls
+        get_extra_f_n_calls += 1
+        return "kwarg for fit"
+
+    get_predict_kwargs_n_calls = 0
+
+    @skrub.deferred
+    def get_predict_kwargs(a):
+        nonlocal get_predict_kwargs_n_calls
+        get_predict_kwargs_n_calls += 1
+        return {"extra_p": "kwarg for predict"}
+
+    get_predict_proba_kwargs_n_calls = 0
+
+    @skrub.deferred
+    def get_predict_proba_kwargs(a):
+        nonlocal get_predict_proba_kwargs_n_calls
+        get_predict_proba_kwargs_n_calls += 1
+        # None is a valid value for kwargs, get translated to {}
+        return None
+
+    assert get_extra_f_n_calls == 0
+    a = skrub.var("a")
+    pred = a.skb.apply(
+        E(),
+        fit_kwargs={"extra_f": get_extra_f(a)},
+        predict_kwargs=get_predict_kwargs(a),
+        predict_proba_kwargs=get_predict_proba_kwargs(a),
+    )
+    learner = pred.skb.make_learner()
+    assert get_extra_f_n_calls == 0
+    assert get_predict_kwargs_n_calls == 0
+    assert get_predict_proba_kwargs_n_calls == 0
+
+    learner.fit({"a": 0})
+    assert get_extra_f_n_calls == 1
+    # the kwargs for predict have not been evaluated when calling fit()
+    assert get_predict_kwargs_n_calls == 0
+    assert get_predict_proba_kwargs_n_calls == 0
+
+    learner.predict({"a": 0})
+    assert get_extra_f_n_calls == 1
+    assert get_predict_kwargs_n_calls == 1
+    assert get_predict_proba_kwargs_n_calls == 0
+
+    learner.predict_proba({"a": 0})
+    assert get_extra_f_n_calls == 1
+    assert get_predict_kwargs_n_calls == 1
+    assert get_predict_proba_kwargs_n_calls == 1
+
+    learner.score({"a": 0})
+    assert get_extra_f_n_calls == 1
+    assert get_predict_kwargs_n_calls == 1
+    assert get_predict_proba_kwargs_n_calls == 1
+
+
+def test_apply_bad_kwargs():
+    with pytest.raises(
+        (TypeError, RuntimeError),
+        match=(
+            r".*The `fit_kwargs` passed to `\.skb\.apply\(\)` should be a dict of named"
+            r" arguments"
+        ),
+    ):
+        skrub.X(0).skb.apply(DummyRegressor(), fit_kwargs="BAD", y=skrub.y(0))
+
+
 def test_concat_horizontal_duplicate_cols():
     X_df = pd.DataFrame({"a": [0, 1, 2], "b": [3, 4, 5]})
     X = skrub.X()


### PR DESCRIPTION
This allows passing extra named arguments to the methods of estimators passed to `.skb.apply()`. Still hesitating slightly about whether this is needed.

Also, we should agree on the exact interface: a single dict like `kwargs={"fit": {"sample_weight": sw}}`, several like `fit_kwargs={"sample_weight": sw}` (what is currently in this PR), other variations...