### PR TITLE
Fix pyarrow missing module when using ToDatetime with polars dataframe

### DIFF
--- a/skrub/_dataframe/_common.py
+++ b/skrub/_dataframe/_common.py
@@ -277,6 +277,7 @@ def _to_pandas_polars_column(obj):
     try:
         return obj.to_pandas()
     except ImportError:
+        # pyarrow is needed for polars .to_pandas() and may not be installed
         return pd.Series(to_numpy(obj))
 
 


### PR DESCRIPTION
Bugfixing the pyarrow missing import.  
tested in local.  
Will try to do another PR to add a CI about it.  