### PR TITLE
Implementation for pruning full reports of the skrub-data folder 

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -30137,7 +30137,7 @@ packages:
 - pypi: ./
   name: skrub
   version: 0.7.dev0
-  sha256: 62c126d160758bc116ff2a2ed43f31fae909415d858a89513aab1408080d8a5a
+  sha256: 92e64508b1ccc0bd92e64ed43eb57d8f1ac00951533cfa1484c5f60e9c033e21
   requires_dist:
   - numpy>=1.23.5
   - pandas>=1.5.3

--- a/pixi.lock
+++ b/pixi.lock
@@ -30137,7 +30137,7 @@ packages:
 - pypi: ./
   name: skrub
   version: 0.7.dev0
-  sha256: 92e64508b1ccc0bd92e64ed43eb57d8f1ac00951533cfa1484c5f60e9c033e21
+  sha256: 62c126d160758bc116ff2a2ed43f31fae909415d858a89513aab1408080d8a5a
   requires_dist:
   - numpy>=1.23.5
   - pandas>=1.5.3

--- a/skrub/_data_ops/_inspection.py
+++ b/skrub/_data_ops/_inspection.py
@@ -80,11 +80,9 @@ def node_report(data_op, mode="preview", environment=None, **report_kwargs):
 def _get_output_dir(output_dir, overwrite):
     now = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
     if output_dir is None:
-        output_dir = (
-            datasets.get_data_dir()
-            / "execution_reports"
-            / f"full_data_op_report_{now}_{random_string()}"
-        )
+        output_base_dir = datasets.get_data_dir() / "execution_reports"
+        output_dir = output_base_dir / f"full_data_op_report_{now}_{random_string()}"
+        _utils.prune_folder(output_base_dir)
     else:
         output_dir = Path(output_dir).expanduser().resolve()
         if output_dir.exists():

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -1309,6 +1309,11 @@ class SkrubNamespace:
         was defined, the time it took to run, and more) and a display of the
         intermediate result (or error).
 
+        By default the report is stored in the skrub data folder.
+        TODO complete the documentation!! write a note for the rest.
+
+        note: reports older then one week are deleted in the skrub data folder
+
         Parameters
         ----------
         environment : dict or None (default=None)

--- a/skrub/_data_ops/_utils.py
+++ b/skrub/_data_ops/_utils.py
@@ -1,5 +1,6 @@
 import enum
 import os
+import shutil
 import time
 import traceback
 
@@ -69,18 +70,14 @@ def prune_folder(path: str):
     if not os.path.exists(path):
         return
 
-    files = sorted(
-        (
-            (f, os.path.getmtime(os.path.join(path, f)))
-            for f in os.listdir(path)
-            if os.path.isfile(os.path.join(path, f))
-        ),
-        key=lambda f: f[1],
-        reverse=True,
+    folders = (
+        (f, os.path.getmtime(os.path.join(path, f)))
+        for f in os.listdir(path)
+        if os.path.isdir(os.path.join(path, f))
     )
-    for f in files:
+    for dir in folders:
         try:
-            if f[1] < time_threshold and f[0].startswith("full_data_op_report_"):
-                os.remove(os.path.join(path, f[0]))
+            if dir[1] < time_threshold and dir[0].startswith("full_data_op_report_"):
+                shutil.rmtree(os.path.join(path, dir[0]))
         except Exception:
             pass

--- a/skrub/_data_ops/tests/test_utils.py
+++ b/skrub/_data_ops/tests/test_utils.py
@@ -5,17 +5,14 @@ import time
 from skrub._data_ops import _utils
 
 
-def test_prune_folder_with_standard_name():
+def test_prune_folder_with_standard_name_dirs():
     eight_days_ago = time.time() - 8 * 24 * 3600
     with tempfile.TemporaryDirectory() as tmpdir:
         for i in range(3):
-            with open(os.path.join(tmpdir, f"full_data_op_report_{i}.txt"), "w") as f:
-                f.write("This is a test file.\n")
+            dirname = os.path.join(tmpdir, f"full_data_op_report_{i}")
+            os.mkdir(dirname)
             if i < 2:
-                os.utime(
-                    os.path.join(tmpdir, f"full_data_op_report_{i}.txt"),
-                    (eight_days_ago, eight_days_ago),
-                )
+                os.utime(dirname, (eight_days_ago, eight_days_ago))
 
         assert len(os.listdir(tmpdir)) == 3
 
@@ -25,15 +22,12 @@ def test_prune_folder_with_standard_name():
         assert len(remaining_items) == 1
 
 
-def test_prune_folder_with_nonstandard_name():
+def test_prune_folder_with_nonstandard_name_dirs():
     eight_days_ago = time.time() - 8 * 24 * 3600
     with tempfile.TemporaryDirectory() as tmpdir:
-        with open(os.path.join(tmpdir, "other_report.txt"), "w") as f:
-            f.write("This is a test file.\n")
-            os.utime(
-                os.path.join(tmpdir, "other_report.txt"),
-                (eight_days_ago, eight_days_ago),
-            )
+        dirname = os.path.join(tmpdir, "other_report")
+        os.mkdir(dirname)
+        os.utime(dirname, (eight_days_ago, eight_days_ago))
 
         assert len(os.listdir(tmpdir)) == 1
 
@@ -41,3 +35,4 @@ def test_prune_folder_with_nonstandard_name():
 
         remaining_items = os.listdir(tmpdir)
         assert len(remaining_items) == 1
+        assert remaining_items[0] == "other_report"

--- a/skrub/_data_ops/tests/test_utils.py
+++ b/skrub/_data_ops/tests/test_utils.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import time
+
+from skrub._data_ops import _utils
+
+
+def test_prune_folder_with_standard_name():
+    eight_days_ago = time.time() - 8 * 24 * 3600
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for i in range(3):
+            with open(os.path.join(tmpdir, f"full_data_op_report_{i}.txt"), "w") as f:
+                f.write("This is a test file.\n")
+            if i < 2:
+                os.utime(
+                    os.path.join(tmpdir, f"full_data_op_report_{i}.txt"),
+                    (eight_days_ago, eight_days_ago),
+                )
+
+        assert len(os.listdir(tmpdir)) == 3
+
+        _utils.prune_folder(tmpdir)
+
+        remaining_items = os.listdir(tmpdir)
+        assert len(remaining_items) == 1
+
+
+def test_prune_folder_with_nonstandard_name():
+    eight_days_ago = time.time() - 8 * 24 * 3600
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "other_report.txt"), "w") as f:
+            f.write("This is a test file.\n")
+            os.utime(
+                os.path.join(tmpdir, "other_report.txt"),
+                (eight_days_ago, eight_days_ago),
+            )
+
+        assert len(os.listdir(tmpdir)) == 1
+
+        _utils.prune_folder(tmpdir)
+
+        remaining_items = os.listdir(tmpdir)
+        assert len(remaining_items) == 1


### PR DESCRIPTION
I can`t find any issues related to this PR, but this problem came up during the pydata2025 sprints. It`s a fix to ensure that the skrub-data folder does not get full of unused reports when creating a `full_report`. 

This fix ensure that when creating a `full_report` with `output_dir=None` older reports in the skrub_data folder are deleted. 

