### PR TITLE
avoid error when 2 threads fetch the same dataset at the same time

### DIFF
--- a/skrub/datasets/_utils.py
+++ b/skrub/datasets/_utils.py
@@ -274,7 +274,16 @@ def _extract_archive(dataset_dir, archive_path):
         temp_dir = tempfile.mkdtemp(dir=dataset_dir)
         shutil.unpack_archive(archive_path, temp_dir, format="zip")
         path_source = Path(temp_dir) / dataset_name
-        path_source.rename(dataset_dir / dataset_name)
+        path_target = dataset_dir / dataset_name
+        try:
+            path_source.rename(path_target)
+        except OSError:  # pragma: nocover
+            if path_target.is_dir():
+                # another thread was fetching the dataset at the same time and
+                # beat us to it; no problem
+                return
+            else:
+                raise
     except (Exception, KeyboardInterrupt):
         try:
             archive_path.unlink()


### PR DESCRIPTION
solves half of #1655  (the concurrency issue in the fetcher); the other half (too many useless downloads in tests) is tackled in another pr #1656 