### PR TITLE
FIX - Fixing a condition in conftest for polars w/out pyarrow

### DIFF
--- a/skrub/_dataframe/tests/test_common.py
+++ b/skrub/_dataframe/tests/test_common.py
@@ -18,7 +18,7 @@ from pandas.testing import assert_frame_equal as pd_assert_frame_equal
 import skrub
 from skrub import selectors as s
 from skrub._dataframe import _common as ns
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 def test_not_implemented():
@@ -104,7 +104,7 @@ def test_to_numpy(df_module, example_data_dict):
     assert_array_equal(array[2:], np.asarray(example_data_dict["str-col"])[2:])
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_to_pandas(df_module, pd_module):
     with pytest.raises(TypeError):
         ns.to_pandas(np.arange(3))
@@ -727,7 +727,7 @@ def test_mean(df_module):
     )
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_corr(df_module):
     df = df_module.example_dataframe
 

--- a/skrub/_reporting/tests/test_patch_display.py
+++ b/skrub/_reporting/tests/test_patch_display.py
@@ -3,12 +3,12 @@ import pickle
 import pytest
 
 from skrub import patch_display, unpatch_display
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 @pytest.mark.parametrize("repeat_patch", [1, 2])
 @pytest.mark.parametrize("repeat_unpatch", [1, 2])
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_patch_display(df_module, repeat_patch, repeat_unpatch, capsys):
     df = df_module.make_dataframe(
         dict(

--- a/skrub/_reporting/tests/test_summarize.py
+++ b/skrub/_reporting/tests/test_summarize.py
@@ -9,13 +9,13 @@ from skrub import _column_associations
 from skrub import _dataframe as sbd
 from skrub._reporting import _sample_table
 from skrub._reporting._summarize import summarize_dataframe
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 @pytest.mark.parametrize("order_by", [None, "date.utc", "value"])
 @pytest.mark.parametrize("with_plots", [False, True])
 @pytest.mark.parametrize("with_associations", [False, True])
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_summarize(
     monkeypatch, df_module, air_quality, order_by, with_plots, with_associations
 ):
@@ -116,7 +116,7 @@ def test_high_cardinality_column(pd_module):
     assert "10 most frequent" in summary["columns"][0]["value_counts_plot"]
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_all_null(df_module):
     df = df_module.make_dataframe(
         {
@@ -145,7 +145,7 @@ def small_df_summary(df_module):
     return make_summary
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_small_df(small_df_summary):
     summary = small_df_summary(11)
     thead, first_slice, ellipsis, last_slice = summary["sample_table"]["parts"]
@@ -260,7 +260,7 @@ def test_duplicate_columns(pd_module):
     assert cols[1]["mean"] == 3.5
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_high_cardinality_columns(df_module):
     df = df_module.make_dataframe(
         {
@@ -274,7 +274,7 @@ def test_high_cardinality_columns(df_module):
     assert cols[1]["is_high_cardinality"]
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_bool_column_mean(df_module):
     df = df_module.make_dataframe({"a": [True, False, True, True, False, True]})
     summary = summarize_dataframe(df)

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -11,14 +11,14 @@ import pytest
 from skrub import TableReport, ToDatetime, datasets
 from skrub import _dataframe as sbd
 from skrub._reporting._sample_table import make_table
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 def get_report_id(html):
     return re.search(r'<skrub-table-report.*?id="report_([a-z0-9]+)"', html).group(1)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_report(air_quality):
     col_filt = {
         "first_2": {
@@ -66,13 +66,13 @@ def test_report(air_quality):
     assert len(all_report_ids) == len(set(all_report_ids))
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_few_columns(df_module, check_polars_numpy2):
     report = TableReport(df_module.example_dataframe)
     assert "First 10 columns" not in report.html()
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_few_rows(df_module, check_polars_numpy2):
     df = sbd.slice(df_module.example_dataframe, 2)
     TableReport(df).html()
@@ -88,7 +88,7 @@ def test_open(pd_module, browser_mock):
     assert b"the title" in browser_mock.content
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_non_hashable_values(df_module):
     # non-regression test for #1066
     df = df_module.make_dataframe(dict(a=[[1, 2, 3], None, [4]]))
@@ -96,7 +96,7 @@ def test_non_hashable_values(df_module):
     assert "[1, 2, 3]" in html
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_nat(df_module):
     # non-regression for:
     # https://github.com/skrub-data/skrub/issues/1111
@@ -109,7 +109,7 @@ def test_nat(df_module):
     TableReport(df).html()
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_bool_column_mean(df_module):
     df = df_module.make_dataframe({"a": [True, False, True, True, False, True]})
     html = TableReport(df).html()
@@ -123,7 +123,7 @@ def test_duplicate_columns(pd_module):
     TableReport(df).html()
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_infinite_values(df_module):
     # Non-regression for https://github.com/skrub-data/skrub/issues/1134
     # (histogram plot failing with infinite values)
@@ -137,7 +137,7 @@ def test_infinite_values(df_module):
     TableReport(df).html()
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_duration(df_module):
     df = df_module.make_dataframe(
         {"a": [datetime.timedelta(days=2), datetime.timedelta(days=3)]}
@@ -196,7 +196,7 @@ def test_write_html_with_not_utf8_encoding(tmp_path, pd_module):
     assert "</html>" not in saved_content
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_verbosity_parameter(df_module, capsys):
     df = df_module.make_dataframe(
         dict(
@@ -219,7 +219,7 @@ def test_verbosity_parameter(df_module, capsys):
     assert capsys.readouterr().err != ""
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_write_to_stderr(df_module, capsys):
     df = df_module.make_dataframe(
         dict(
@@ -240,7 +240,7 @@ def test_write_to_stderr(df_module, capsys):
     assert re.search(pattern, captured.err)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_max_plot_columns_parameter(df_module):
     df = df_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(10)}
@@ -300,7 +300,7 @@ def test_error_input_type():
         TableReport(df)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_single_column_report(df_module):
     # Check that single column report works
     single_col = df_module.example_column

--- a/skrub/conftest.py
+++ b/skrub/conftest.py
@@ -105,8 +105,8 @@ if _POLARS_INSTALLED:
 else:
     _polars_installed_without_pyarrow = False
 
-polars_installed_without_pyarrow = pytest.mark.skipif(
-    _polars_installed_without_pyarrow=False,
+skip_polars_installed_without_pyarrow = pytest.mark.skipif(
+    _polars_installed_without_pyarrow,
     reason="When polars is installed, requires pyarrow to be installed too",
 )
 

--- a/skrub/tests/test_check_input.py
+++ b/skrub/tests/test_check_input.py
@@ -4,7 +4,7 @@ import pytest
 
 from skrub import _dataframe as sbd
 from skrub._check_input import CheckInputDataFrame
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 def test_good_input(df_module):
@@ -39,7 +39,7 @@ def test_input_is_an_array():
         check.fit_transform(np.ones((2,)))
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_wrong_dataframe_library_in_transform():
     pl = pytest.importorskip("polars")
     df = pl.DataFrame({"a": [0, 1], "b": [10, 20]})

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -5,10 +5,10 @@ import pytest
 
 from skrub import _dataframe as sbd
 from skrub import column_associations
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_column_associations(df_module):
     x = (np.ones((7, 3)) * np.arange(3)).ravel()
     y = 2 - 3 * x
@@ -28,7 +28,7 @@ def test_column_associations(df_module):
     )
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_infinite(df_module):
     # non-regression test for https://github.com/skrub-data/skrub/issues/1133
     # (column associations would raise an exception on low-cardinality float

--- a/skrub/tests/test_fuzzy_join.py
+++ b/skrub/tests/test_fuzzy_join.py
@@ -8,7 +8,7 @@ from sklearn.feature_extraction.text import HashingVectorizer
 from skrub import ToDatetime, _join_utils, fuzzy_join
 from skrub import selectors as s
 from skrub._dataframe import _common as ns
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 @pytest.mark.parametrize(
@@ -238,7 +238,7 @@ def test_numerical_column(df_module):
     assert ns.shape(fj_num3) == (2, n_cols)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_datetime_column(df_module):
     """
     Testing that ``fuzzy_join`` works with datetime columns.
@@ -294,7 +294,7 @@ def test_datetime_column(df_module):
     assert ns.shape(fj_time3) == (2, n_cols)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_mixed_joins(df_module):
     """
     Test fuzzy joining on mixed and multiple column types.

--- a/skrub/tests/test_join_utils.py
+++ b/skrub/tests/test_join_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 from skrub import _dataframe as sbd
 from skrub import _join_utils
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 @pytest.mark.parametrize(
@@ -174,7 +174,7 @@ def test_left_join_wrong_right_type(df_module, left):
         )
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_left_join_types_not_equal(df_module, left):
     try:
         import polars as pl

--- a/skrub/tests/test_to_datetime.py
+++ b/skrub/tests/test_to_datetime.py
@@ -16,7 +16,7 @@ from skrub._to_datetime import (
     _get_time_zone,
     to_datetime,
 )
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 ISO = "%Y-%m-%dT%H:%M:%S"
 
@@ -45,7 +45,7 @@ def datetime_col(df_module):
     return sbd.col(df_module.example_dataframe, "datetime-col")
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 @pytest.mark.parametrize(
     "format",
     [
@@ -87,7 +87,7 @@ def test_datetime_to_datetime(datetime_col):
     assert encoder.format_ is None
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_rejected_columns(df_module):
     with pytest.raises(ValueError, match=".*does not contain strings"):
         ToDatetime().fit_transform(sbd.col(df_module.example_dataframe, "float-col"))
@@ -99,7 +99,7 @@ def test_rejected_columns(df_module):
         )
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_transform_failures(datetime_col, df_module):
     encoder = ToDatetime().fit(strftime(datetime_col, ISO))
     test_col = df_module.make_column(
@@ -110,7 +110,7 @@ def test_transform_failures(datetime_col, df_module):
     assert sbd.to_list(sbd.fill_nulls(strftime(transformed, ISO), "????")) == expected
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_mixed_offsets(df_module):
     s = df_module.make_column(
         "when", ["2020-01-02T08:00:01+02:00", "2020-01-02T08:00:01+04:00"]

--- a/skrub/tests/test_to_float32.py
+++ b/skrub/tests/test_to_float32.py
@@ -6,7 +6,7 @@ from skrub._apply_to_cols import RejectColumn
 from skrub._to_categorical import ToCategorical
 from skrub._to_datetime import ToDatetime
 from skrub._to_float32 import ToFloat32
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 def is_float32(df_module, column):
@@ -31,7 +31,7 @@ def test_to_float_32(values, df_module):
     assert is_float32(df_module, out)
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_rejected_columns(df_module):
     columns = [
         df_module.make_column("c", ["1", "2", "hello"]),

--- a/skrub/tests/test_to_str.py
+++ b/skrub/tests/test_to_str.py
@@ -6,7 +6,7 @@ from skrub import _dataframe as sbd
 from skrub._apply_to_cols import RejectColumn
 from skrub._to_datetime import ToDatetime
 from skrub._to_str import ToStr
-from skrub.conftest import polars_installed_without_pyarrow
+from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
 def test_to_str(df_module):
@@ -27,7 +27,7 @@ def test_to_str(df_module):
     df_module.assert_column_equal(sbd.is_null(out), sbd.is_null(expected))
 
 
-@polars_installed_without_pyarrow
+@skip_polars_installed_without_pyarrow
 def test_rejected_columns(df_module):
     columns = [
         ToDatetime().fit_transform(df_module.make_column("", ["2020-02-02"])),


### PR DESCRIPTION
#1648 added a slight mistake in how the mark is checked. This PR fixes that and renames the marker so the name is more explicit. 