### PR TITLE
WIP 🚧 allow setting dataop choices with optuna

### DIFF
--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -950,39 +950,52 @@ def set_params(data_op, params):
             target.chosen_outcome = v
 
 
-class _ChosenOrDefaultOutcomes(_DataOpTraversal):
-    """Helper for `chosen_or_default_outcomes`."""
+def get_choice_default(choice_id, display_name, choice):
+    if isinstance(choice, _choosing.Choice):
+        return choice.chosen_outcome_idx or 0
+    else:
+        return choice.chosen_outcome_or_default()
 
-    def run(self, data_op):
+
+class _ChoiceEvaluator(_DataOpTraversal):
+    """Helper for `eval_choices`."""
+
+    def run(self, data_op, policy):
+        graph = choice_graph(data_op)
+        data_op_choices = graph["choices"]
+        self.display_names = graph["choice_display_names"]
+        self.choice_ids = {id(c): k for k, c in data_op_choices.items()}
+        self.Xy_choices = graph["Xy_choices"]
+        self.policy = policy
         self.chosen = {}
         self.results = {}
         _ = super().run(data_op)
         return self.chosen
 
     def handle_choice(self, choice):
-        if id(choice) in self.results:
-            return self.results[id(choice)]
-        if not isinstance(choice, _choosing.Choice):
-            # We have a NumericChoice, the outcome is simply a number
-            outcome = choice.chosen_outcome_or_default()
-            self.chosen[id(choice)] = outcome
-            self.results[id(choice)] = outcome
-            return outcome
-        # We have a Choice and need to visit the chosen outcome (it may contain
-        # further choices).
-        idx = choice.chosen_outcome_idx or 0
-        self.chosen[id(choice)] = idx
-        outcome = choice.outcomes[idx]
-        result = yield outcome
-        self.results[id(choice)] = result
-        return result
+        c_id = self.choice_ids[id(choice)]
+        if c_id in self.results:
+            return self.results[c_id]
+        display_name = self.display_names[c_id]
+        if c_id in self.Xy_choices:
+            # Clamp to default if ancestor of X or y
+            param = get_choice_default(c_id, display_name, choice)
+        else:
+            param = self.policy(c_id, display_name, choice)
+        if isinstance(choice, _choosing.Choice):
+            value = yield choice.outcomes[param]
+        else:
+            value = param
+        self.chosen[c_id] = param
+        self.results[c_id] = value
+        return value
 
     def handle_choice_match(self, choice_match):
         outcome = yield choice_match.choice
         return (yield choice_match.outcome_mapping[outcome])
 
 
-def chosen_or_default_outcomes(data_op):
+def eval_choices(data_op, policy=get_choice_default):
     """Get the selected or default outcomes for choices in the DataOp.
 
     Return a mapping from the choice's ID (0, 1, ... -- see `choice_graph`) to
@@ -1000,7 +1013,7 @@ def chosen_or_default_outcomes(data_op):
     >>> from sklearn.linear_model import Ridge
     >>> from sklearn.dummy import DummyRegressor
     >>> from skrub import choose_from, choose_float
-    >>> from skrub._data_ops._evaluation import chosen_or_default_outcomes, choices
+    >>> from skrub._data_ops._evaluation import eval_choices, choices
 
     >>> e = choose_from(
     ...     [DummyRegressor(), Ridge(alpha=choose_float(0.1, 1.0, name="alpha"))],
@@ -1016,18 +1029,15 @@ def chosen_or_default_outcomes(data_op):
 
     In the default configuration, the 'regressor' chooses the DummyRegressor. So the
     'alpha' choice is not used. It does not appear in the
-    `chosen_or_default_outcomes` result:
+    `eval_choices` result:
 
-    >>> pprint(chosen_or_default_outcomes(e))
+    >>> pprint(eval_choices(e))
     {1: 0}
 
     Here we only see that choice 'regressor' (ID 1) in chooses its first outcome
     (index 0), and the choice 'alpha' (ID 0) does not appear.
     """  # noqa: E501
-    data_op_choices = choices(data_op)
-    short_ids = {id(c): k for k, c in data_op_choices.items()}
-    outcomes = _ChosenOrDefaultOutcomes().run(data_op)
-    return {short_ids[k]: v for k, v in outcomes.items()}
+    return _ChoiceEvaluator().run(data_op, policy=policy)
 
 
 class _Found(Exception):


### PR DESCRIPTION
setting skrub.DataOp choices with Optuna

Apparently @rcap107 was asked a few times about combining skrub dataops and optuna, which is a great idea.

This is very rough first draft of what this could look like. Still missing some functionality, tests & docs etc.

## search estimator interface

The DataOp now has a `.skb.make_optuna_search()` method, which can be used to search for the best choice outcomes with optuna.

For example:

```python
import skrub
from sklearn.datasets import make_classification
from sklearn.linear_model import LogisticRegression
from sklearn.ensemble import RandomForestClassifier
from sklearn.dummy import DummyClassifier

X_a, y_a = make_classification(random_state=0)
X, y = skrub.X(X_a), skrub.y(y_a)
logistic = LogisticRegression(C=skrub.choose_float(0.1, 10.0, log=True, name="C"))
rf = RandomForestClassifier(
    n_estimators=skrub.choose_int(3, 30, name="n estimators"), random_state=0
)
classifier = skrub.choose_from(
    {"logistic": logistic, "random forest": rf, "dummy": DummyClassifier()},
    name="classifier",
)
pred = X.skb.apply(classifier, y=y)

search = pred.skb.make_optuna_search(fitted=True, random_state=0)  # <--- 🎯 optuna --------------

print("\nparam grid:")
print(pred.skb.describe_param_grid())

print("best params:")
print(search.best_learner_.describe_params())
```

prints

```
[... optuna output]
[I 2025-10-06 23:33:43,972] Trial 9 finished with value: 0.8399999999999999 and parameters: {'2:classifier': '0:logistic', '0:C': 0.10037026315054523}. Best is trial 6 with value: 0.9099999999999999.

param grid:
- classifier: 'logistic'
  C: choose_float(0.1, 10.0, log=True, name='C')
- classifier: 'random forest'
  n estimators: choose_int(3, 30, name='n estimators')
- classifier: 'dummy'

best params:
{'n estimators': 7, 'classifier': 'random forest'}
```

We can pass our own optuna study to control how it is created
For example above change `make_optuna_search()` to:

```python
import optuna

study = optuna.create_study(
    storage="sqlite:///db.sqlite3", direction="maximize", study_name="classifier"
)

search = pred.skb.make_optuna_search(fitted=True, n_trials=200, study=study)
```

and we can monitor the search progress / explore results with `❯ optuna-dashboard sqlite:///db.sqlite3`

## low-level interface

For more control over the use of optuna, the SkrubLearner.collect_params() method can be used to obtain a set of parameters from an optuna trial. this is useful for more advanced optuna features (multi-objective, ask-and-tell interface, ...). Here is a simple example revisited from the optuna tutorial:

```python
import optuna
import skrub

x = skrub.choose_float(-10, 10, name="x").as_data_op()
err = (x - 2) ** 2

def objective(trial):
    learner = err.skb.make_learner()
    params = learner.collect_params(trial)
    learner.set_params(**params)
    return learner.fit_transform({})


study = optuna.create_study(direction="minimize")
study.optimize(objective, n_trials=100)
print(study.best_params)
```

prints something similar to

```
[...]
[I 2025-10-06 23:41:17,610] Trial 99 finished with value: 1.210419581181497 and parameters: {'0:x': 0.8998092978117398}. Best is trial 61 with value: 0.0005685118895572634.
{'0:x': 2.0238434873614843}
```
