### PR TITLE
MAINT - let ruff find the target version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,10 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.4.8
+    rev: v0.14.2
     hooks:
-    -   id: ruff
-        args: ["--fix", "--output-format=full"]
+    -   id: ruff-check
+        args: ["--fix", "--show-fixes", "--output-format=full"]
 -   repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
 
   # lint
   "black==23.3.0",
-  "ruff==0.4.8",
+  "ruff==0.14.2",
   "pre-commit",
 
   # test
@@ -121,7 +121,7 @@ statsmodels = "*"
 
 [tool.pixi.feature.lint.dependencies]
 black = "==23.3.0"
-ruff = "==0.4.8"
+ruff = "==0.14.2"
 pre-commit = "*"
 
 [tool.pixi.feature.optional.dependencies]
@@ -286,6 +286,8 @@ select = ["E", "F", "W", "I"]
 ignore = [
   # space before : (needed for how black formats slicing)
   "E203",
+  # use `is` and `is not` for type comparisons
+  "E721",
   # do not assign a lambda expression, use a def
   "E731",
   # do not use variables named 'l', 'O', or 'I'


### PR DESCRIPTION
Indeed ruff infers the target version from `project.requires-python`.

https://docs.astral.sh/ruff/settings/#target-version