### PR TITLE
MAINT - Fix pre-commit warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,3 @@ repos:
     hooks:
     -   id: codespell
         exclude: .*/package-lock.json
-    additional_dependencies:
-    -   tomli


### PR DESCRIPTION
```
[WARNING] Unexpected key(s) present on https://github.com/codespell-project/codespell: additional_dependencies
```