### PR TITLE
Start applying ruff/NumPy-specific rules (NPY)

### DIFF
--- a/benchmarks/bench_fuzzy_join_count_vs_hash.py
+++ b/benchmarks/bench_fuzzy_join_count_vs_hash.py
@@ -274,7 +274,7 @@ def fuzzy_join(
     else:
         idx = df_joined.index[df_joined["fj_nan"] == 1]
         if len(idx) != 0:
-            df_joined.iloc[idx, df_joined.columns.get_loc("fj_idx") :] = np.NaN
+            df_joined.iloc[idx, df_joined.columns.get_loc("fj_idx") :] = np.nan
         df_joined.drop(columns=["fj_idx", "fj_nan"], inplace=True)
 
     if return_score:

--- a/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
+++ b/benchmarks/bench_fuzzy_join_sparse_vs_dense.py
@@ -490,7 +490,7 @@ def fuzzy_join(
     else:
         idx = df_joined.index[df_joined["fj_nan"] == 1]
         if len(idx) != 0:
-            df_joined.iloc[idx, df_joined.columns.get_loc("fj_idx") :] = np.NaN
+            df_joined.iloc[idx, df_joined.columns.get_loc("fj_idx") :] = np.nan
         df_joined.drop(columns=["fj_idx", "fj_nan"], inplace=True)
 
     if return_score:

--- a/benchmarks/bench_minhash_batch_number.py
+++ b/benchmarks/bench_minhash_batch_number.py
@@ -151,7 +151,7 @@ class MinHashEncoder(BaseEstimator, TransformerMixin):
         ndarray of shape (n_components, )
             The encoded string.
         """
-        min_hashes = np.ones(self.n_components) * np.infty
+        min_hashes = np.ones(self.n_components) * np.inf
         grams = get_unique_ngrams(string, self.ngram_range)
         if len(grams) == 0:
             grams = get_unique_ngrams(" Na ", self.ngram_range)


### PR DESCRIPTION
* `np.NaN` will be removed in NumPy 2.0. Use `numpy.nan` instead. 
* `np.infty` will be removed in NumPy 2.0. Use `numpy.inf` instead.