### PR TITLE
Start applying ruff/Pylint Convention rules (PLC)

### DIFF
--- a/benchmarks/run_on_openml_datasets.py
+++ b/benchmarks/run_on_openml_datasets.py
@@ -154,7 +154,7 @@ for type_id, problem, pipeline, metric in [
                 function=metric, tasks=[task_id], output_format="dataframe"
             )
             if len(evals) > 0:
-                percentiles = {p: np.percentile(evals.value, p) for p in {25, 50, 75}}
+                percentiles = {p: np.percentile(evals.value, p) for p in (25, 50, 75)}
                 logger.info(
                     f"OpenML scores on {len(evals)} runs (on the full dataset): "
                     + " ; ".join(


### PR DESCRIPTION
PLC0208 Use a sequence type instead of a `set` when iterating over values