### PR TITLE
fix: replace columns with many nulls with missing indicators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ New features
 - :meth:`DataOp.skb.full_report` now accepts a new parameter, title, that is displayed
   in the html report.
   :pr:`1654` by :user:`Marie Sacksick <MarieSacksick>`.
+- :class:`DropUninformative` now replaces columns with many null values (but not
+  entirely null) with missing indicator columns instead of dropping them, preserving
+  information about whether values were present while avoiding spending feature
+  dimensions on encoding the actual values. Updated in :pr:`1723` by
+  :user:`Hanh Tran <honghanhh>`.
 
 Changes
 -------

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -109,8 +109,8 @@ class _Ellipsis:
 class Choice(BaseChoice):
     """A choice among an enumerated set of outcomes."""
 
-    outcomes: list[typing.Any]
-    outcome_names: typing.Optional[list[str]]
+    outcomes: typing.List[typing.Any]
+    outcome_names: typing.Optional[typing.List[str]]
     name: typing.Optional[str] = None
     chosen_outcome_idx: typing.Optional[int] = None
 

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -162,12 +162,14 @@ class Cleaner(TransformerMixin, BaseEstimator):
     Parameters
     ----------
     drop_null_fraction : float or None, default=1.0
-        Fraction of null above which the column is dropped. If ``drop_null_fraction``
-        is set to ``1.0``, the column is dropped if it contains only
-        nulls or NaNs (this is the default behavior). If ``drop_null_fraction`` is a
-        number in ``[0.0, 1.0)``, the column is dropped if the fraction of nulls
-        is strictly larger than ``drop_null_fraction``. If ``drop_null_fraction`` is
-        ``None``, this selection is disabled: no columns are dropped based on the
+        Fraction of null above which the column is replaced by a missing indicator
+        (instead of being dropped), or dropped if entirely null. If
+        ``drop_null_fraction`` is set to ``1.0``, only entirely null columns are
+        dropped (this is the default behavior). If ``drop_null_fraction`` is a
+        number in ``[0.0, 1.0)``, columns with a fraction of nulls strictly larger
+        than ``drop_null_fraction`` are replaced by a missing indicator (or
+        dropped if entirely null). If ``drop_null_fraction`` is ``None``, this
+        selection is disabled: no columns are replaced or dropped based on the
         number of null values they contain.
 
     drop_if_constant : bool, default=False
@@ -216,9 +218,11 @@ class Cleaner(TransformerMixin, BaseEstimator):
       with NA markers.
 
     - ``DropUninformative()``: drop the column if it is considered to be
-      "uninformative". A column is considered to be "uninformative" if it contains
-      only missing values (``drop_null_fraction``), only a constant value
-      (``drop_if_constant``), or if all values are distinct (``drop_if_unique``).
+      "uninformative", or replace it with a missing indicator. A column is considered
+      to be "uninformative" if it contains only missing values (``drop_null_fraction``),
+      only a constant value (``drop_if_constant``), or if all values are distinct
+      (``drop_if_unique``). When a column has too many null values (but not entirely
+      null), it is replaced by a missing indicator column instead of being dropped.
       By default, the ``Cleaner`` keeps all columns, unless they contain only
       missing values.
       Note that setting ``drop_if_unique`` to ``True`` may lead to dropping columns
@@ -447,12 +451,13 @@ class TableVectorizer(TransformerMixin, BaseEstimator):
         :class:`~sklearn.compose.ColumnTransformer`.
 
     drop_null_fraction : float or None, default=1.0
-        Fraction of null above which the column is dropped. If `drop_null_fraction` is
-        set to ``1.0``, the column is dropped if it contains only
-        nulls or NaNs (this is the default behavior). If `drop_null_fraction` is a
-        number in ``[0.0, 1.0)``, the column is dropped if the fraction of nulls
-        is strictly larger than `drop_null_fraction`. If `drop_null_fraction` is ``None``,
-        this selection is disabled: no columns are dropped based on the number
+        Fraction of null above which the column is replaced by a missing indicator
+        (instead of being dropped), or dropped if entirely null. If `drop_null_fraction` is
+        set to ``1.0``, only entirely null columns are dropped (this is the default
+        behavior). If `drop_null_fraction` is a number in ``[0.0, 1.0)``, columns
+        with a fraction of nulls strictly larger than `drop_null_fraction` are replaced
+        by a missing indicator (or dropped if entirely null). If `drop_null_fraction` is ``None``,
+        this selection is disabled: no columns are replaced or dropped based on the number
         of null values they contain.
 
     drop_if_constant : bool, default=False
@@ -625,7 +630,9 @@ class TableVectorizer(TransformerMixin, BaseEstimator):
     Before applying the main transformer, the ``TableVectorizer`` applies
     several preprocessing steps, for example to detect numbers or dates that are
     represented as strings. By default, columns that contain only null values are
-    dropped. Moreover, a final post-processing step is applied to all
+    dropped. Columns with many nulls (but not entirely null) are replaced by missing
+    indicator columns instead of being dropped, preserving information about whether
+    values were present or not. Moreover, a final post-processing step is applied to all
     non-categorical columns in the encoder's output to cast them to float32.
     If ``datetime_format`` is provided, it will be used to parse all datetime
     columns.

--- a/skrub/datasets/_ken_embeddings.py
+++ b/skrub/datasets/_ken_embeddings.py
@@ -4,6 +4,7 @@ Get the Wikipedia embeddings for feature augmentation.
 # Required for ignoring lines too long in the docstrings
 # flake8: noqa: E501
 
+import typing
 import urllib.request
 import warnings
 from dataclasses import dataclass
@@ -58,7 +59,7 @@ class DatasetAll:
     X: pd.DataFrame
     y: pd.Series
     path: Path
-    read_csv_kwargs: dict[str]
+    read_csv_kwargs: typing.Dict[str, typing.Any]
 
     def __eq__(self, other):
         """
@@ -96,7 +97,7 @@ class DatasetInfoOnly:
     source: str
     target: str
     path: Path
-    read_csv_kwargs: dict[str]
+    read_csv_kwargs: typing.Dict[str, typing.Any]
 
 
 def fetch_figshare(


### PR DESCRIPTION
## Fixes

Fixes #1714 

## Description
This PR replaces columns with many nulls with missing indicators. Instead of dropping columns that exceed the drop_null_fraction threshold, replace them with missing indicator columns (`float32: 1.0` for missing, `0.0` for present). This preserves information about whether values were present while avoiding spending feature dimensions on sparse columns.
- Modify DropUninformative to return missing indicators for columns with  many nulls (when `drop_null_fraction < 1.0`)
- Entirely null columns are still dropped (as the indicator would be constant)
- Default behavior unchanged (`drop_null_fraction=1.0` only drops entirely null columns)
- Update documentation for `DropUninformative`, `Cleaner`, and `TableVectorizer`
- Add tests for missing indicator replacement