### PR TITLE
Adding templates for prs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,5 +1,12 @@
 # Bug Fix Pull Request
 
+<!--
+Before proceeding, please confirm that:
+1. The changes have been discussed with the maintainers
+2. A plan has been agreed upon
+3. The related issue has been assigned to you
+-->
+
 ## Description
 
 <!-- Please include a summary of the bug fix -->

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,5 +1,12 @@
 # Documentation Pull Request
 
+<!--
+Before proceeding, please confirm that:
+1. The changes have been discussed with the maintainers
+2. A plan has been agreed upon
+3. The related issue has been assigned to you
+-->
+
 ## Description
 
 <!-- Please include a summary of the documentation changes -->

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,5 +1,12 @@
 # New Feature Pull Request
 
+<!--
+Before proceeding, please confirm that:
+1. The changes have been discussed with the maintainers
+2. A plan has been agreed upon
+3. The related issue has been assigned to you
+-->
+
 ## Description
 
 <!-- Please include a summary of the new feature -->

--- a/.github/PULL_REQUEST_TEMPLATE/refactoring.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactoring.md
@@ -1,5 +1,12 @@
 # Refactoring Pull Request
 
+<!--
+Before proceeding, please confirm that:
+1. The changes have been discussed with the maintainers
+2. A plan has been agreed upon
+3. The related issue has been assigned to you
+-->
+
 ## Description
 
 <!-- Please include a summary of the refactoring changes -->


### PR DESCRIPTION
This PR adds templates to PRs, so that contributors need to follow the indications reported in the templates for the PR to be accepted. 