### PR TITLE
FIX - Improving the error message raised when the TableReport is called on a lazy polars dataframe

### DIFF
--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -25,7 +25,6 @@ def _check_max_cols(max_plot_columns, max_association_columns):
             "'max_plot_columns' must be a positive scalar or 'all', got"
             f" {max_plot_columns!r}."
         )
-
     max_association_columns = (
         max_association_columns
         if max_association_columns is not None
@@ -42,6 +41,11 @@ def _check_max_cols(max_plot_columns, max_association_columns):
 
     return max_plot_columns, max_association_columns
 
+def lazy_dataframe_exception(dataframe):
+    if sbd.is_polars(dataframe) and sbd.is_lazyframe(dataframe):
+        raise ValueError(
+            "Cannot automatically collect a lazyframe, this might lead to issues!"
+        )
 
 class TableReport:
     r"""Summarize the contents of a dataframe.
@@ -203,6 +207,7 @@ class TableReport:
         self.dataframe = (
             sbd.to_frame(dataframe) if sbd.is_column(dataframe) else dataframe
         )
+        lazy_dataframe_exception(self.dataframe)
         self.n_columns = sbd.shape(self.dataframe)[1]
 
     def _set_minimal_mode(self):


### PR DESCRIPTION
This pull request aims to fix the polars exception issue #1675.

Through out this pull request, I have edited these files:
**- skrub/_reporting/_table_report.py:** In this file I created a function ( lazy_dataframe_exception) checks if a Dataframe is both a polar and Lazyframe, if so an exception is raised. Then, I add a line within the "class TableReport" that eventually checks if the dataframe is polar and lazyframe.
**- skrub/_reporting/tests/test_table_report.py:** Within this file, I import the polars library while also adding a test. 


--> Let me know if this is a good solution.