### PR TITLE
FIX - Adding condition and test for Polars dataframes without PyArrow installed in TableReport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ Bugfixes
 - Fixed the use of :class:`TableReport` and :class:`Cleaner` with Polars dataframes
   containing a column with empty string as name.
   :pr:`1722` by :user:`Marie Sacksick <MarieSacksick>`.
+- Fixed an issue where :class:`TableReport` would fail when computing associations
+  for Polars dataframes if PyArrow was not installed.
+  :pr:`1742` by :user:`Riccardo Cappuzzo <rcap107>`.
 
 Release 0.6.2
 =============

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -8,6 +8,15 @@
         </div>
     </div>
 
+    {% elif summary.get("associations_skipped_polars_no_pyarrow", False) %}
+
+    <div id="skipped-associations-polars-pyarrow-alert" class="alert-info-dismissable flex space-between">
+        <div class="alert-content shrinkable-text">
+            Computing pairwise associations is not available for Polars dataframes when PyArrow is not installed.
+            To enable associations, install PyArrow: <code>pip install pyarrow</code>, or use a Pandas dataframe.
+        </div>
+    </div>
+
     {% elif summary["top_associations"] %}
 
     <div class="horizontal-scroll padding-b-s">

--- a/skrub/_reporting/_summarize.py
+++ b/skrub/_reporting/_summarize.py
@@ -6,6 +6,14 @@ from .. import _column_associations, _config
 from .. import _dataframe as sbd
 from . import _plotting, _sample_table, _utils
 
+try:
+    import pyarrow  # noqa F401
+
+    _PYARROW_INSTALLED = True
+except ImportError:
+    _PYARROW_INSTALLED = False
+
+
 _SUBSAMPLE_SIZE = 3000
 _N_TOP_ASSOCIATIONS = 20
 
@@ -112,7 +120,10 @@ def summarize_dataframe(
     summary["n_constant_columns"] = sum(
         c["value_is_constant"] for c in summary["columns"]
     )
-    if with_associations:
+    if not _PYARROW_INSTALLED and summary["dataframe_module"] == "polars":
+        with_associations = False
+        summary["associations_skipped_polars_no_pyarrow"] = True
+    elif with_associations:
         if n_rows and n_columns:
             _add_associations(df, summary)
         else:

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -379,3 +379,43 @@ def test_numpy_array_columns(input_array, expected_columns):
     report = TableReport(input_array, max_association_columns=0)
 
     assert report._summary["n_columns"] == expected_columns
+
+
+def _pyarrow_available():
+    try:
+        import pyarrow  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.xfail(
+    condition=_pyarrow_available(),
+    reason="Test expects pyarrow to not be installed, but it is installed",
+)
+def test_polars_df_no_pyarrow():
+    # Test that when using a Polars dataframe without pyarrow installed,
+    # the appropriate flag is set in the summary and the message appears in the HTML.
+    pl = pytest.importorskip("polars")
+
+    df = pl.DataFrame(
+        {
+            "A": [1, 2, 3, 4, 5],
+            "B": ["a", "b", "c", "d", "e"],
+            "C": [10, 20, 30, 40, 50],
+        }
+    )
+
+    report = TableReport(df, verbose=0)
+    summary = report._summary
+
+    assert summary.get("associations_skipped_polars_no_pyarrow", False) is True
+    assert summary.get("dataframe_module", "") == "polars"
+
+    html_snippet = report.html_snippet()
+    assert (
+        "Computing pairwise associations is not available for Polars dataframes "
+        "when PyArrow is not installed"
+        in html_snippet
+    )


### PR DESCRIPTION
# Bug Fix Pull Request

## Description
The TableReport fails if a polars dataframe is used and pyarrow isn't installed due to how we compute column associations. This PR fixes the problem by disabling associations and adding a message that explains the problem and adds a possible solution. 

Fixes #1738