### PR TITLE
DOC: see also pointing to ApplyToCols/Frame

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -211,11 +211,11 @@ class Cleaner(TransformerMixin, BaseEstimator):
 
     ApplyToCols :
         Apply a given transformer separately to each column in a selection of columns.
-        Useful to complement the default heuristics of the Cleaner.
+        Useful to complement the default heuristics of the ``Cleaner``.
 
     ApplyToFrame :
         Apply a given transformer jointly to all columns in a selection of columns.
-        Useful to complement the default heuristics of the Cleaner.
+        Useful to complement the default heuristics of the ``Cleaner``.
 
     Notes
     -----
@@ -539,11 +539,11 @@ class TableVectorizer(TransformerMixin, BaseEstimator):
 
     ApplyToCols :
         Apply a given transformer separately to each column in a selection of columns.
-        Useful to complement the default heuristics of the TableVectorizer.
+        Useful to complement the default heuristics of the ``TableVectorizer``.
 
     ApplyToFrame :
         Apply a given transformer jointly to all columns in a selection of columns.
-        Useful to complement the default heuristics of the TableVectorizer.
+        Useful to complement the default heuristics of the ``TableVectorizer``.
 
     Notes
     -----


### PR DESCRIPTION
Make it easier for people who are using TableVectorizer or Cleaner to discover ApplyToCols/Frame

I'm doing this because I find that these two objects (ApplyToCols / ApplyToFrame) are incredibly useful and we need to help users discovering them.