### PR TITLE
MAINT - fixing some typos in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,14 +24,14 @@ New features
   named dataops, in a :class:`DataOp`. This lets us easily know what keys should
   be present in the ``environment`` dictionary we pass to
   :meth:`DataOp.skb.eval` or to :meth:`SkrubLearner.fit`,
-  :meth:`SkrubLearner.predict`, etc. .
+  :meth:`SkrubLearner.predict`, etc.
   :pr:`1646` by :user:`Jérôme Dockès <jeromedockes>`.
 - :meth:`DataOp.skb.iter_cv_splits` iterates over the training and testing
   environments produced by a CV splitter -- similar to
   :meth:`DataOp.skb.train_test_split` but for multiple cross-validation splits.
   :pr:`1653` by :user:`Jérôme Dockès <jeromedockes>`.
-- :class:`TableReport` now supports ``np.array``. :pr:`1676` by :user: `Nisma Amjad <Nismamjad1>`.
-- :meth:`DataOp.skb.full_report` now accepts a new parameter, title, that is displayed
+- :class:`TableReport` now supports ``np.array``. :pr:`1676` by :user:`Nisma Amjad <Nismamjad1>`.
+- :meth:`DataOp.skb.full_report` now accepts a new parameter, ``title``, that is displayed
   in the html report.
   :pr:`1654` by :user:`Marie Sacksick <MarieSacksick>`.
 - :class:`TableReport` now includes the ``open_tab`` parameter, which lets the
@@ -44,29 +44,29 @@ Changes
   the minimum supported versions of scikit-learn and requests are 1.4.2 and 2.27.1
   respectively. Support for python 3.14 has been added.
   :pr:`1572` by :user:`Riccardo Cappuzzo<rcap107>`.
-- The :meth: `DataOp.skb.full_report` method now deletes reports created with
-  ``output_dir=None`` after 7 days. :pr:`1657` by :user: `Simon Dierickx <simon.dierickx>`.
-- The :func: `tabular_pipeline` uses a :class:`SquashingScaler` instead of a
+- The :meth:`DataOp.skb.full_report` method now deletes reports created with
+  ``output_dir=None`` after 7 days. :pr:`1657` by :user:`Simon Dierickx <simon.dierickx>`.
+- The :func:`tabular_pipeline` uses a :class:`SquashingScaler` instead of a
   :class:`StandardScaler` for centering and scaling numerical features
   when linear models are used.
   :pr:`1644` by :user:`Simon Dierickx <dierickxsimon>`
-- The transformer :class:`ToFloat`, previously called `ToFloat32`, is now public.
+- The transformer :class:`ToFloat`, previously called ``ToFloat32``, is now public.
   :pr:`1687` by :user:`Marie Sacksick <MarieSacksick>`.
 - Improved the error message raised when a Polars lazyframe is passed to
-  :class:`TableReport`, clarifying that `.collect()` must be called first.
-  :pr:`1767` by :user:`Fatima Ben Kadour <fatiben2002>`
-- Computing the associations in `TableReport` is now deterministic and can be controlled
-  by the new parameter ``subsampling_seed`` of the global configuration.
+  :class:`TableReport`, clarifying that ``.collect()`` must be called first.
+  :pr:`1767` by :user:`Fatima Ben Kadour <fatiben2002>`.
+- Computing the associations in :class:`TableReport` is now deterministic and can
+  be controlled by the new parameter ``subsampling_seed`` of the global configuration.
   :pr:`1775` by :user:`Thomas S. <thomass-dev>`.
 - Added ``cast_to_str`` parameter to :class:`Cleaner` to prevent unintended
   conversion of list/object-like columns to strings unless explicitly enabled.
-  :pr:`1789` by :user:`PilliSiddharth`
+  :pr:`1789` by :user:`PilliSiddharth`.
 
 Bugfixes
 --------
 - The :meth:`skrub.cross_validate` function now raises a specific exception if the wrong variable
   type is passed.
-  :pr:`1799` by :user: `Eloi Massoulié<emassoulie>`
+  :pr:`1799` by :user:`Eloi Massoulié<emassoulie>`
 - Fixed various issues with some transformers by adding ``get_feature_names_out``
   to all single column transformers.
   :pr:`1666` by :user:`Riccardo Cappuzzo<rcap107>`.
@@ -99,7 +99,7 @@ Bugfixes
   ``.skb.mark_as_y()`` used to raise an error, this has been fixed in :pr:`1782`
   by :user:`Jérôme Dockès <jeromedockes>`.
 - Fixed potential issues that could arise in :meth:`ParamSearch.plot_results`
-  when NaN values were present in the crossvalidation results.
+  when NaN values were present in the cross-validation results.
   :pr:`1800` by :user:`Riccardo Cappuzzo <rcap107>`.
 
 Release 0.6.2


### PR DESCRIPTION
Some of the changelog entries were not formatted correctly, this PR fixes the problem