### PR TITLE
Improved the documentation of Cleaner

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -239,7 +239,7 @@ class Cleaner(TransformerMixin, BaseEstimator):
     - ``CleanNullStrings()``: replace strings used to represent missing values
       with NA markers.
 
-    - ``DropUninformative()``: drop the column if it is considered to be
+    - :class:`DropUninformative`: drop the column if it is considered to be
       "uninformative". A column is considered to be "uninformative" if it contains
       only missing values (``drop_null_fraction``), only a constant value
       (``drop_if_constant``), or if all values are distinct (``drop_if_unique``).


### PR DESCRIPTION
As requested in issue #1785 
I included the  `DropUninformative` in the `see also` section of the Cleaner documentation.
I also built the documentation, and there were no errors.