### PR TITLE
Fix - set random seed in optuna example

### DIFF
--- a/examples/data_ops/1131_optuna_choices.py
+++ b/examples/data_ops/1131_optuna_choices.py
@@ -81,7 +81,9 @@ cv = KFold(n_splits=4, shuffle=True, random_state=0)
 # the User Guide for an example.
 
 # %%
-search = pred.skb.make_randomized_search(backend="optuna", cv=cv, n_iter=10)
+search = pred.skb.make_randomized_search(
+    backend="optuna", cv=cv, n_iter=10, random_state=10
+)
 search.fit(env)
 search.results_
 


### PR DESCRIPTION
The optuna example can fail if the random seed does not pick the ExtraTreeRegressor, which means that the line 

```python
optuna.visualization.plot_slice(search.study_, params=["0:min_samples_leaf"])
```

raises an exception since `0:min_samples_leaf` does not exist. 

This PR addresses the problem by fixing the seed of the randomized search in the optuna example.