### PR TITLE
DOC - Fix formatting in the message describing SingleColumnTransformers

### DIFF
--- a/skrub/_single_column_transformer.py
+++ b/skrub/_single_column_transformer.py
@@ -16,15 +16,13 @@ _SINGLE_COL_LINE = (
     " estimators, its ``fit``, ``transform`` and ``fit_transform`` methods expect a"
     " single column (a pandas or polars Series) rather than a full dataframe. To apply"
     " this transformer to one or more columns in a dataframe, use it as a parameter in"
-    " a ``skrub.ApplyToCols`` or a ``skrub.TableVectorizer``."
-    " To apply to all columns::\n\n"
+    " a ``skrub.ApplyToCols`` or a ``skrub.TableVectorizer``.\n\n"
+    "To apply to all columns::\n\n"
     "   ApplyToCol({class_name}())\n\n"
     "To apply to selected columns::\n\n"
     "   ApplyToCols({class_name}(), cols=['col_name_1', 'col_name_2'])"
 )
-_SINGLE_COL_PARAGRAPH = textwrap.fill(
-    _SINGLE_COL_LINE, initial_indent="    ", subsequent_indent="    "
-)
+_SINGLE_COL_PARAGRAPH = textwrap.indent(_SINGLE_COL_LINE, prefix=" " * 4)
 _SINGLE_COL_NOTE = f".. note::\n\n{_SINGLE_COL_PARAGRAPH}\n"
 
 


### PR DESCRIPTION
Fixes #1816

I've used full code blocks to respect the original syntax at best. It could be replaced with inline code blocks if it needs to be more concise

<img width="1320" height="872" alt="image" src="https://github.com/user-attachments/assets/ea693501-9de7-4a54-ab92-787a214b645e" />
