### PR TITLE
FIX -  CI doc push issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run: ls -ltrh doc/_build/html
       - deploy:
           command: |
-            if [[ "${CIRCLE_BRANCH}" =~ ^main$|^[0-9]+\.[0-9]+\.X$|fix-ci-push-pull ]]; then
+            if [[ "${CIRCLE_BRANCH}" =~ ^main$|^[0-9]+\.[0-9]+\.X$ ]]; then
               bash build_tools/circle/push_doc.sh doc/_build/html
             fi
 


### PR DESCRIPTION
This PR is trying to fix an issue with the CI, which seems to be failing due to a race condition in the generation of docs. 

I asked Claude how to fix this, and the solution I went for was 
https://github.com/skrub-data/skrub/pull/1840/files#diff-2ea68c31a830f2919d6a029ff2ecd79b451f42d55fa05292d64b46066d363d16R63

To test that this works, I then **temporarily** updated the regex used to trigger the CI so that it would also run for this specific PR. As far as I can tell, the CI has run as intended. 

This is the full exchange with Claude:

<details>
<summary>Details</summary>
User: read the circleci configuration for context, then explain to me why the ci is failing with this error

[main 5b6a89d43] Pushing the docs to dev/ for branch: main, commit 6d57ffa92a42b16378a4d0349f82ea3f3a30aa05
 215 files changed, 43873 insertions(+), 43859 deletions(-)
To github.com:skrub-data/skrub-data.github.io.git
 ! [rejected]            main -> main (fetch first)
error: failed to push some refs to 'github.com:skrub-data/skrub-data.github.io.git'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.

Exited with code exit status 1

GitHub Copilot: I'll read the CircleCI configuration to understand the CI setup and explain why this error is occurring. 

Searched for files matching `**/.circleci/config.yml`, 1 match

Searched for files matching `**/.circleci/*.yml`, 1 match

Read [](file:///Users/rcap/work/skrub/.circleci/config.yml)

Read [](file:///Users/rcap/work/skrub/build_tools/circle/push_doc.sh)

Now I understand the issue. Let me explain why the CI is failing:

## The Problem: Race Condition in Documentation Deployment

The CI is failing due to a **race condition** when multiple CircleCI jobs try to push documentation to the same `skrub-data.github.io` repository simultaneously.

### What's happening:

1. **Multiple concurrent builds**: When multiple commits are pushed to `main` (or version branches like `0.7.X`), CircleCI triggers separate workflows for each commit.

2. **Each workflow pushes docs independently**: The push_doc.sh script does the following for each build:
   - Clones the docs repo fresh
   - Resets to `origin/main` 
   - Replaces the `dev/` directory with new docs
   - Commits and pushes to `main`

3. **The race condition**: When Job A and Job B run concurrently:
   - Job A: clones → resets to `origin/main` (commit X) → builds docs → pushes successfully
   - Job B: clones → resets to `origin/main` (commit X) → builds docs → tries to push
   - **Job B fails** because the remote now has Job A's commit, which Job B doesn't have locally

### The specific failure:

The error `[rejected] main -> main (fetch first)` indicates that between when Job B ran `git reset --hard origin/main` (line 52) and when it tried to `git push` (line 65), another job had already pushed new commits to the remote.

### Solutions:

1. **Add `git pull --rebase`** before pushing to handle concurrent updates
2. **Use CircleCI's auto-cancel redundant builds** feature to prevent multiple builds of the same branch
3. **Add retry logic** with exponential backoff
4. **Use force push with lease**: `git push --force-with-lease` (though this could lose docs if not careful)

The most robust solution would be adding a pull-rebase before the push at push_doc.sh:

```bash
git pull --rebase origin main
git push
```

User: How can I test that this works in a PR? 

GitHub Copilot: Testing this in a PR is tricky because the deploy step in .circleci/config.yml only runs on `main` or version branches (like `0.7.X`), not on PR branches.

Here are your testing options:

## 1. **Temporarily modify the branch regex (Recommended for testing)**

Modify the condition in .circleci/config.yml to include your PR branch:

```yaml
if [[ "${CIRCLE_BRANCH}" =~ ^main$|^[0-9]+\.[0-9]+\.X$|^bump-js-version$ ]]; then
```

This will trigger the deploy step for your PR, allowing you to see if the fix works. **Remember to revert this change before merging.**

## 2. **Test locally with a dummy repo**

Create a test repository and simulate the race condition:

```bash
# Create a test docs repo
cd /tmp
git init test-docs-repo
cd test-docs-repo
git config user.name "Test User"
git config user.email "test@test.com"
mkdir dev
echo "test" > dev/index.html
git add .
git commit -m "Initial commit"

# In another terminal, simulate concurrent pushes
# Terminal 1: Run the script with your changes
# Terminal 2: Make a competing commit and push

# Clean up when done
```

## 3. **Code review approach (Simplest)**

Since this is a well-known Git issue with an established solution (pull before push), you could:
- Get the code reviewed
- Merge to main
- Monitor the next few CI runs to confirm it works

## 4. **Test the git commands manually**

You can test the core logic without the full CI:

```bash
cd /tmp
git clone git@github.com:skrub-data/skrub-data.github.io.git test-docs
cd test-docs
# Simulate what the script does
git reset --hard origin/main
# Make a change in another window to origin/main
# Then try: git pull --rebase origin main && git push
```

**My recommendation**: Option 1 (temporarily modify the regex) is the most thorough way to test in the actual CI environment, just remember to remove that change before merging.

</details>


