### PR TITLE
Included `size on disk` on the california housing dataset

### DIFF
--- a/skrub/datasets/_fetching.py
+++ b/skrub/datasets/_fetching.py
@@ -474,6 +474,7 @@ def fetch_california_housing(data_home=None):
 
         It can be downloaded/loaded using the sklearn.datasets.fetch_california_housing
         function.
+        Size on disk: 1.80MB.
 
     Parameters
     ----------


### PR DESCRIPTION
As @rcap107 pointed out in #1447, both datasets had descriptions, such as dataframe sizes and size on disk, except the `fetch_california_housing`, which was missing the size on disk.  This has now been included. I cross-checked to find that nothing else was missing from the dataset docstrings.