### PR TITLE
docs: Reorganize the "Development" section

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 .. _contributing:
 
-Contributing to skrub
-=====================
+Contributing guide
+==================
 
 First off, thanks for taking the time to contribute!
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 .. _contributing:
 
 Contributing guide
-==================
+=====================
 
 First off, thanks for taking the time to contribute!
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,7 +1,7 @@
 .. _contributing:
 
 Contributing guide
-=====================
+==================
 
 First off, thanks for taking the time to contribute!
 
@@ -177,6 +177,8 @@ When contributing, keep these project goals in mind:
     - Document all public functions, methods, variables, and class signatures.
     - The public API refers to all components available for import and use by library users. Anything that doesn't begin with an underscore is considered part of the public API.
 
+Checking the quality of your code contribution
+----------------------------------------------
 
 Testing the code
 ~~~~~~~~~~~~~~~~
@@ -276,73 +278,8 @@ can be pushed. Something worth noting is that if the ``pre-commit``
 hooks format some files, the commit will be canceled: you will have to
 stage the changes made by ``pre-commit`` and commit again.
 
-
-Submitting your code
-^^^^^^^^^^^^^^^^^^^^
-
-Once you have pushed your commits to your remote repository, you can submit
-a PR by clicking the "Compare & pull request" button on GitHub,
-targeting the skrub repository.
-
-
-Continuous Integration (CI)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-After creating your PR, CI tools will run proceed to run all the tests on all
-configurations supported by skrub.
-
-- **Github Actions**:
-  Used for testing skrub across various platforms (Linux, macOS, Windows)
-  and dependencies.
-- **CircleCI**:
-  Builds and verifies the project documentation.
-
-If any of the following markers appears in the commit message, the following
-actions are taken.
-
-    ====================== ===================
-    Commit Message Marker  Action Taken by CI
-    ---------------------- -------------------
-    [ci skip]              CI is skipped completely
-    [skip ci]              CI is skipped completely
-    [skip github]          CI is skipped completely
-    [deps nightly]         CI is run with the nightly builds of dependencies
-    [doc skip]             Docs are not built
-    [doc quick]            Docs built, but excludes example gallery plots
-    [doc build]            Docs built including example gallery plots (longer)
-    ====================== ===================
-
-Note that by default the documentation is built, but only the examples that are
-directly modified by the pull request are executed.
-
-CI is testing all possible configurations supported by skrub, so tests may fail
-with configurations different from what you are developing with. If this is the
-case,  it is possible to run the tests in the environment that is failing by
-using `pixi <https://pixi.sh/latest/>`_. For example if the env is ``ci-py309-min-optional-deps``, it is
-possible to replicate it using the following command:
-
-.. code:: sh
-
-   pixi run -e ci-py309-min-optional-deps  pytest skrub/tests/path/to/test
-
-This command downloads the specific environment on the machine, so you can test
-it locally and apply fixes, or have a clearer idea of where the code is failing
-to discuss with the maintainers.
-
-Finally, if the remote repository was changed, you might need to run
-  ``pre-commit run --all-files`` to make sure that the formatting is
-  correct.
-
-Integration
-^^^^^^^^^^^
-
-Community consensus is key in the integration process. Expect a minimum
-of 1 to 3 reviews depending on the size of the change before we consider
-merging the PR.
-..
-  This is actually unclear to me: do we want 1 to 3 reviews, or 1 to 3 reviewers?
-
-Building the documentation
---------------------------
+Ensuring the documentation builds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..
   Inspired by: https://github.com/scikit-learn/scikit-learn/blob/main/doc/developers/contributing.rst
@@ -422,16 +359,76 @@ You can view it by opening the local ``doc/_build/html/index.html`` file.
    If you encounter issues, you can always fall back to using ``make`` as
    described above.
 
-
 Editing the API reference documentation
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**All public functions and classes must be documented in the API
+reference**, hence when adding a public function or class, a new entry must be
+added, as detailed just above.
 
 To add a new entry to the :ref:`API reference documentation<api_ref>` or change its
 content, head to ``doc/api_reference.py``. This data is then used by ``doc/conf.py``
 to render templates located at ``doc/reference/*.rst.template``.
 
-|
 
-Note that **all public functions and classes must be documented in the API
-reference**, hence when adding a public function or class, a new entry must be
-added, as detailed just above.
+Submitting your code
+--------------------
+
+Once you have pushed your commits to your remote repository, you can submit
+a PR by clicking the "Compare & pull request" button on GitHub,
+targeting the skrub repository.
+
+
+Continuous Integration (CI)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+After creating your PR, CI tools will run proceed to run all the tests on all
+configurations supported by skrub.
+
+- **Github Actions**:
+  Used for testing skrub across various platforms (Linux, macOS, Windows)
+  and dependencies.
+- **CircleCI**:
+  Builds and verifies the project documentation.
+
+If any of the following markers appears in the commit message, the following
+actions are taken.
+
+    ====================== ===================
+    Commit Message Marker  Action Taken by CI
+    ---------------------- -------------------
+    [ci skip]              CI is skipped completely
+    [skip ci]              CI is skipped completely
+    [skip github]          CI is skipped completely
+    [deps nightly]         CI is run with the nightly builds of dependencies
+    [doc skip]             Docs are not built
+    [doc quick]            Docs built, but excludes example gallery plots
+    [doc build]            Docs built including example gallery plots (longer)
+    ====================== ===================
+
+Note that by default the documentation is built, but only the examples that are
+directly modified by the pull request are executed.
+
+CI is testing all possible configurations supported by skrub, so tests may fail
+with configurations different from what you are developing with. If this is the
+case,  it is possible to run the tests in the environment that is failing by
+using `pixi <https://pixi.sh/latest/>`_. For example if the env is ``ci-py309-min-optional-deps``, it is
+possible to replicate it using the following command:
+
+.. code:: sh
+
+   pixi run -e ci-py309-min-optional-deps  pytest skrub/tests/path/to/test
+
+This command downloads the specific environment on the machine, so you can test
+it locally and apply fixes, or have a clearer idea of where the code is failing
+to discuss with the maintainers.
+
+Finally, if the remote repository was changed, you might need to run
+  ``pre-commit run --all-files`` to make sure that the formatting is
+  correct.
+
+Integration
+^^^^^^^^^^^
+
+Community consensus is key in the integration process. Expect a minimum
+of 1 to 3 reviews depending on the size of the change before we consider
+merging the PR.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -284,10 +284,6 @@ Ensuring the documentation builds
 ..
   Inspired by: https://github.com/scikit-learn/scikit-learn/blob/main/doc/developers/contributing.rst
 
-**Before submitting your pull request, ensure that your modifications haven't
-introduced any new Sphinx warnings by building the documentation locally
-and addressing any issues.**
-
 First, make sure you have properly installed the development version of skrub.
 You can follow the :ref:`installation_instructions` > "From source" section, if needed.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,7 +42,7 @@ please:
 1. **Check if an issue already exists**
    by searching the `GitHub issues <https://github.com/skrub-data/skrub/issues?q=is%3Aissue>`_
 
-   - If **open**, leave a 👍 on the original message to signal that others are affected.
+   - If **open**, leave a 👍 on the original message to signal that you are also affected.
    - If closed, check for one of the following:
       - A **merged pull request** may indicate the bug is fixed. Update your
         skrub version or note if the fix is pending a release.
@@ -73,7 +73,7 @@ You can find a guide on how to write examples in the :ref:`example guide <tutori
 Suggesting enhancements
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-If you have an idea for improving skrub, whether it's a small fix
+If you have an idea for improving skrub, whether it's a fix
 or a new feature, first:
 
 - **Check if it has been proposed or implemented** by reviewing
@@ -338,7 +338,8 @@ Integration
 Community consensus is key in the integration process. Expect a minimum
 of 1 to 3 reviews depending on the size of the change before we consider
 merging the PR.
-
+..
+  This is actually unclear to me: do we want 1 to 3 reviews, or 1 to 3 reviewers?
 
 Building the documentation
 --------------------------
@@ -349,6 +350,9 @@ Building the documentation
 **Before submitting your pull request, ensure that your modifications haven't
 introduced any new Sphinx warnings by building the documentation locally
 and addressing any issues.**
+..
+  Given the number of warnings already present, I think it's very hard check to do and to enforce.
+  Shouldn't it be removed?
 
 First, make sure you have properly installed the development version of skrub.
 You can follow the :ref:`installation_instructions` > "From source" section, if needed.
@@ -389,7 +393,6 @@ without running the examples by using the following command:
 This command generates the documentation without re-executing the examples, which can
 take a long time. This is useful if you are only modifying the documentation itself, such as fixing
 typos or improving explanations.
-
 
 
 **Using pixi**

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -287,9 +287,6 @@ Ensuring the documentation builds
 **Before submitting your pull request, ensure that your modifications haven't
 introduced any new Sphinx warnings by building the documentation locally
 and addressing any issues.**
-..
-  Given the number of warnings already present, I think it's very hard check to do and to enforce.
-  Shouldn't it be removed?
 
 First, make sure you have properly installed the development version of skrub.
 You can follow the :ref:`installation_instructions` > "From source" section, if needed.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -426,6 +426,6 @@ Finally, if the remote repository was changed, you might need to run
 Integration
 ^^^^^^^^^^^
 
-Community consensus is key in the integration process. Expect a minimum
-of 1 to 3 reviews depending on the size of the change before we consider
+Community consensus is key in the integration process. Expect a minimum of
+1 to 3 reviews from maintainers depending on the size of the change before we consider
 merging the PR.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,4 +15,3 @@
    learning_materials
    CHANGES
    development
-   CONTRIBUTING


### PR DESCRIPTION
Closes #1582 

This issue says three things:

1. We might also consider reformatting a bit the Development outline if needed.
2. Also would it make sense to rename this to just "Contributing"? Since the context is already within the skrub repo, "Contributing to skrub" might be a bit redundant. (I agreed, and therefore did the change)
3. we can start by removing "Contributing to skrub" from the drop down menu, since it's already present in the "Development" page.

2 and 3 are tackled.  
For 1, I quite like the contributing guide for now, because it's very detailed. Most of what I did is changing from:  
<img width="316" height="274" alt="image" src="https://github.com/user-attachments/assets/476ea563-c484-4b17-8567-dd545393bd93" />

to:  

<img width="333" height="258" alt="image" src="https://github.com/user-attachments/assets/2411deb8-d047-4617-84dc-f228e6365fa1" />

The idea is to go step by step for the contributor. Building the doc locally to me is part of checking the quality of contribution.