### PR TITLE
DOC: explain unpacking results from deferred functions

### DIFF
--- a/doc/modules/data_ops/basics/control_flow.rst
+++ b/doc/modules/data_ops/basics/control_flow.rst
@@ -42,7 +42,7 @@ see a result for that value:
 <GetAttr 'columns'>
 Result:
 ―――――――
-Index(['item', 'price', 'qty'], dtype='str')
+Index(['item', 'price', 'qty'], dtype=...)
 
 The "result" we see is an *example* result that the computation produces for the
 data we provided. But we want to fit our pipeline and apply it to different


### PR DESCRIPTION
**Goal**
Add a short user‑guide note explaining why deferred functions returning multiple values cannot be unpacked directly, and how to handle it.

**What changed**
Added a small “Unpacking multiple outputs from deferred functions” section to control_flow.rst