### PR TITLE
DOC - new example for using PyTorch w/ DataOps via skorch

### DIFF
--- a/examples/data_ops/1160_pytorch.py
+++ b/examples/data_ops/1160_pytorch.py
@@ -1,0 +1,218 @@
+"""
+Using PyTorch (via skorch) in DataOps
+======================================
+
+This example shows how to wrap a PyTorch model with skorch and plug it into a
+skrub DataOps plan.
+
+.. note::
+    This example requires the optional dependencies ``torch`` and ``skorch``.
+
+The main goal here is to show the *integration pattern*:
+
+- **PyTorch** defines the model (an ``nn.Module``)
+- **skorch** wraps it as a scikit-learn compatible estimator
+- **skrub DataOps** builds a plan and can tune skorch (and therefore PyTorch)
+  hyperparameters using the skrub choices.
+"""
+
+# %%
+# Loading the data
+# =================
+#
+# We use scikit-learn's digits dataset because it is small and ships with
+# scikit-learn. Each sample is an 8x8 grayscale image of a
+# handwritten digit, encoded as 64 pixel intensity values and displays a
+# number from 0 to 9.
+from sklearn.datasets import load_digits
+
+digits = load_digits()
+X, y = digits.data, digits.target
+print(f"Dataset shape: {X.shape}")
+print(f"Number of classes: {len(set(y))}")
+
+# %%
+# Start of the DataOps plan
+# ==========================
+#
+# We start the DataOps plan by creating the skrub variables X and y.
+import skrub
+
+X = skrub.X(X)
+y = skrub.y(y)
+
+# %%
+# Data preprocessing
+# ==================
+#
+# We start by normalizing the pixel values to [0, 1] by first
+# computing the global max value and then dividing the pixel values
+# by this max value. Importantly, we freeze the max value (scaling factor)
+# after fitting so that the same rescaling is applied later when we use our
+# dataop for prediction on new (test) data.
+#
+# A convolutional network expects images with shape (N, C, H, W) where:
+#
+# - N: number of samples
+# - C: number of color channels (1 for grayscale)
+# - H, W: image height and width
+#
+# So we reshape the images to (N, 1, 8, 8) for the CNN. The -1 means the first
+# dimension (N) is inferred automatically from the array size.
+#
+# The advantage of using DataOps is that the preprocessing steps are tracked
+# in the plan and will be automatically applied during prediction.
+
+max_value = X.max().skb.freeze_after_fit()
+X_scaled = X / max_value
+X_reshaped = X_scaled.reshape(-1, 1, 8, 8).astype("float32")
+X_reshaped.skb.draw_graph()
+
+
+# %%
+# Building a NN Classifier
+# =========================
+#
+# We'll build a tiny CNN using PyTorch and wrap it with skorch to make it
+# scikit-learn compatible. The architecture uses a single convolution + pooling
+# stage and a small MLP head. The architectural choices below are meant to be:
+#
+# - **standard**: 3x3 convolutions and 2x2 max-pooling are very common
+# - **small**: the dataset and images are tiny, so we keep the model tiny too
+#
+# If you want more background on CNN building blocks and how convolution/pooling
+# changes tensor shapes, see the CS231n notes:
+# https://cs231n.github.io/convolutional-networks/
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+
+class TinyCNN(nn.Module):
+    def __init__(self, conv_channels: int = 8, hidden_units: int = 32):
+        super().__init__()
+        self.conv_channels = conv_channels
+        self.hidden_units = hidden_units
+
+        # 2-level CNN with 2x2 max-pooling
+        self.conv1 = nn.Conv2d(
+            in_channels=1, out_channels=conv_channels, kernel_size=3, padding=1
+        )
+        self.conv2 = nn.Conv2d(conv_channels, conv_channels, kernel_size=3, padding=1)
+        self.pool = nn.MaxPool2d(kernel_size=2)
+
+        # input shape = (8,8) -> conv1: (8,8) -> conv2: (8,8) -> pool: (4,4)
+        image_shape_after_conv = 4 * 4
+
+        # MLP head
+        self.fc1 = nn.Linear(conv_channels * image_shape_after_conv, hidden_units)
+        self.dropout = nn.Dropout(p=0.25)  # Regularization to avoid overfitting
+        self.fc2 = nn.Linear(hidden_units, 10)  # 10 digit classes (0..9)
+
+    def forward(self, x):
+        x = F.relu(self.conv1(x))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.flatten(start_dim=1)
+        x = self.dropout(F.relu(self.fc1(x)))
+        return self.fc2(x)
+
+
+# %%
+# Skorch provides scikit-learn compatible wrappers around torch training loops.
+# That makes the torch model usable by skrub DataOps (and scikit-learn tools in
+# general).
+#
+# We use :func:`skrub.choose_from()` to define hyperparameters that the DataOps
+# grid search will tune: conv_channels, hidden_units, and max_epochs.
+# The other parameters are set to common choices for this task and training data size.
+
+from skorch import NeuralNetClassifier
+
+device = "cpu"  # use "cuda" or "mps" if available
+
+net = NeuralNetClassifier(
+    module=TinyCNN,
+    # These choices are intentionally small so the example runs quickly.
+    module__conv_channels=skrub.choose_from([8, 16], name="conv_channels"),
+    module__hidden_units=skrub.choose_from([8, 16, 32], name="hidden_units"),
+    max_epochs=skrub.choose_from([10, 15], name="max_epochs"),
+    optimizer__lr=0.01,
+    optimizer=optim.Adam,
+    criterion=nn.CrossEntropyLoss,
+    device=device,
+    train_split=None,  # We'll use skrub's grid search for validation
+    verbose=0,
+)
+
+
+# %%
+# Tuning the model's hyperparameters with DataOps
+# ===============================================
+#
+# We integrate the model into the DataOps plan. First, we
+# convert the target labels to integers for the loss computation
+# and apply the model to the preprocessed X and y.
+
+y_int = y.astype("int64")
+predictor = X_reshaped.skb.apply(net, y=y_int)
+predictor.skb.draw_graph()
+
+# %%
+# Finally, we use 4-fold cross-validation for the hyperparameter
+# tuning on our DataOps plan.
+
+from sklearn.model_selection import KFold
+
+cv = KFold(n_splits=4, shuffle=True, random_state=42)
+search = predictor.skb.make_grid_search(
+    cv=cv,
+    fitted=True,
+    n_jobs=-1,
+)
+print("\nSearch results:")
+print(search.results_.to_string(index=False))
+
+# %%
+# Let's take a better look at the well-performing models by looking
+# at the parallel coordinates plot. We filter to models with
+# score >= 0.94 to focus on the top-performing configurations.
+
+fig = search.plot_results(min_score=0.94)
+fig
+
+# %%
+# Interpreting the results
+# ========================
+#
+# Looking at the search results, we can observe several patterns:
+#
+# - **Model capacity matters**: Larger configurations with ``conv_channels=16``
+#   and ``hidden_units=32`` tend to perform best. Smaller models with
+#   ``conv_channels=8`` and/or ``hidden_units=8`` perform significantly worse,
+#   indicating that the task benefits from increased model capacity.
+# - **More epochs generally help**: Configurations with ``max_epochs=15`` tend to
+#   perform slightly better than those with ``max_epochs=10``, though the gains
+#   are modest compared to architectural changes.
+
+# %%
+# Conclusion
+# ==========
+#
+# In this example, we've shown how to use **PyTorch** and **skorch** within
+# skrub DataOps. The key steps were:
+#
+# 1. Define a PyTorch ``nn.Module`` (our ``TinyCNN``)
+# 2. Wrap it with skorch's ``NeuralNetClassifier`` to make it scikit-learn compatible
+# 3. Use :func:`skrub.choose_from()` to specify hyperparameters for tuning
+# 4. Integrate it into a DataOps plan and use grid search to find the best configuration
+#
+# This pattern lets you leverage PyTorch's flexibility for model definition while
+# benefiting from skrub's hyperparameter tuning and data preprocessing capabilities.
+#
+# .. seealso::
+#
+#    * :ref:`example_tuning_pipelines`: Learn more about using
+#      ``skrub.choose_from()`` and other choice objects to tune hyperparameters
+#      in DataOps plans.
+#    * :ref:`example_optuna_choices`: Discover how to use Optuna as a backend
+#      for more sophisticated hyperparameter search strategies with skrub DataOps.

--- a/pixi.lock
+++ b/pixi.lock
@@ -6365,6 +6365,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -6387,6 +6388,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py311h0372a8f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -6764,6 +6766,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -6786,6 +6789,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py311h09efe57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
@@ -7114,6 +7118,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sleef-3.9.0-h67fd636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
@@ -7136,6 +7141,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.6-py311h17033d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh04b8f61_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh6dadd2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -7504,6 +7510,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -7524,6 +7531,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.46-py313h54dd161_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py313h29aa505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -7857,6 +7865,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -7877,6 +7886,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.46-py312hb3ab3e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py312ha11c99a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.5.1-pyhcf101f3_0.conda
@@ -8165,6 +8175,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentence-transformers-5.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.10.2-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sleef-3.9.0-h67fd636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -8185,6 +8196,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/sqlalchemy-2.0.46-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/statsmodels-0.14.6-py313h0591002_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh04b8f61_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh6dadd2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
@@ -32653,10 +32665,27 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/skorch-1.3.1-pyhc455866_0.conda
+  sha256: ef2194a05774ea2a56d2b9f3df49fb2ab274c73cc7b10027e4303d41e83d831a
+  md5: 1909d14f76a90a6d20a65ec3190fed65
+  depends:
+  - numpy >=1.13.3
+  - python >=3.10
+  - pytorch >=2.6.0
+  - scikit-learn >=0.22.0
+  - scipy >=1.1.0
+  - tabulate >=0.7.7
+  - tqdm >=4.14.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/skorch?source=hash-mapping
+  size: 196925
+  timestamp: 1767796288764
 - pypi: ./
   name: skrub
   version: 0.8.dev0
-  sha256: 5ba6bc99fcd773790c57556908c9224c4f1f48355b268ef4bb31ffcef66a6a5c
+  sha256: 000789f33ec92061a2ca3b4ebb18632361f88ba4e6a8cf7fb3d8eea1644beb4c
   requires_dist:
   - numpy>=1.23.5
   - pandas>=1.5.3
@@ -33476,6 +33505,18 @@ packages:
   - pkg:pypi/sympy?source=hash-mapping
   size: 4616621
   timestamp: 1745946173026
+- conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
+  sha256: 795e03d14ce50ae409e86cf2a8bd8441a8c459192f97841449f33d2221066fef
+  md5: de98449f11d48d4b52eefb354e2bfe35
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tabulate?source=hash-mapping
+  size: 40319
+  timestamp: 1765140047040
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
   sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
   md5: 8f7278ca5f7456a974992a8b34284737

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ sphinx-autosummary-accessors = ">=2025.3.1,<2026"
 sphinx-sitemap = "*"
 statsmodels = "*"
 optuna = "*"
+skorch = "*"
 
 [tool.pixi.feature.lint.dependencies]
 black = "==23.3.0"


### PR DESCRIPTION
This PR adds a new documentation example demonstrating how to use PyTorch models with the Skrub DataOps framework by wrapping them with the skorch library. The example fetches the MNIST dataset, defines a small convolutional neural network for digit classification, and integrates it into a DataOps pipeline for training and evaluation. To support this example, the commit adds `skorch` as a new doc dependency. 