### PR TITLE
DOC: Move to_datetime to cleaning section in API reference

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -124,7 +124,7 @@ API_REFERENCE = {
                     "deduplicate",
                     "Cleaner",
                     "DropUninformative",
-                     "to_datetime",
+                    "to_datetime",
                 ],
             },
         ],


### PR DESCRIPTION
Fixes #1887

## Description

Move `skrub.to_datetime` from encoders to cleaning in the API reference, as it is a cleaning utility.

## Changes

* **doc/api_reference.py**: Removed from encoders autosummary and added to cleaning autosummary.