### PR TITLE
DOC: Shorten User Guide index and improve navigation

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -4,7 +4,7 @@ User Guide
 ==========
 
 Skrub is a Python library that facilitates machine learning with tabular data
-(pandas and polars dataframes) using a scikit-learn–compatible API.
+(dataframes, as with pandas and polars) using a scikit-learn–compatible API.
 
 Use the sections below to navigate the guide. For runnable code, see the
 :doc:`Example gallery <auto_examples/index>`. For class and function details, see


### PR DESCRIPTION
Fixes: #1886 

## Summary 

Shortened the intro, removed the final pandas/polars paragraph and the many inline links (TableReport, Cleaner, encoders, Data Ops, etc.)
Replaced them with a short blurb pointing to the sections below, Example gallery, and API Reference. The toctree and `.. _user_guide:` label are unchanged. 

Links: API Reference uses `:ref:`api_ref``; Example gallery uses `:doc:`auto_examples/index`` (same as main index toctree).

Full doc build was run locally and completed successfully; both links resolve correctly in the built HTML.

@rcap107  Please check whether these changes look correct. If you would like anything changed or added, please specify your preferred option.

