### PR TITLE
Fix numpydoc validation errors for DataOps and Drop

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,38 @@
+# TODO: Fix Failing Doctests in skrub
+
+## Step 1: Fix Docstrings (Complete)
+
+- [x] Fix SkrubLearner docstring in skrub/_data_ops/_estimator.py
+- [x] Fix ParamSearch docstring in skrub/_data_ops/_estimator.py
+- [x] Fix OptunaParamSearch docstring in skrub/_data_ops/_optuna.py
+- [x] Fix Drop class docstring in skrub/_select_cols.py
+
+## Step 2: Update DOCSTRING_TEMP_IGNORE_SET (Complete)
+
+- [x] Remove fixed entries from DOCSTRING_TEMP_IGNORE_SET in skrub/tests/test_docstrings.py
+
+## Step 3: Verify Fixes (Complete)
+
+- [x] Run the doctest suite to ensure fixes pass
+
+## Summary of Changes
+
+### Files Modified:
+
+1. **skrub/_data_ops/_estimator.py**
+   - Added `Parameters` section to `SkrubLearner` class docstring
+   - Added `Parameters` section to `ParamSearch` class docstring
+
+2. **skrub/_data_ops/_optuna.py**
+   - Added comprehensive `Parameters` section to `OptunaParamSearch` class docstring
+
+3. **skrub/_select_cols.py**
+   - Added class docstring to `Drop` class
+   - Added docstrings to `fit_transform` and `transform` methods
+
+4. **skrub/tests/test_docstrings.py**
+   - Removed `"skrub._data_ops._estimator"` from DOCSTRING_TEMP_IGNORE_SET
+   - Removed `"skrub._data_ops._optuna"` from DOCSTRING_TEMP_IGNORE_SET
+   - Removed `"skrub._select_cols.Drop"` from DOCSTRING_TEMP_IGNORE_SET
+
+All docstring validations now pass for the fixed classes.

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -97,9 +97,15 @@ class SkrubLearner(_CloudPickleDataOp, BaseEstimator):
     This class is not meant to be instantiated manually, ``SkrubLearner``
     objects are created by calling :meth:`DataOp.skb.make_learner()` on a
     DataOp.
+
+    Parameters
+    ----------
+    data_op : DataOp
+        The DataOp to evaluate.
     """
 
     def __init__(self, data_op):
+
         self.data_op = data_op
 
     def __skrub_to_Xy_pipeline__(self, environment):
@@ -942,9 +948,19 @@ class ParamSearch(_BaseParamSearch):
     This class is not meant to be instantiated manually, ``ParamSearch``
     objects are created by calling :meth:`DataOp.skb.make_grid_search()` or
     :meth:`DataOp.skb.make_randomized_search()` on a DataOp.
+
+    Parameters
+    ----------
+    data_op : DataOp
+        The DataOp to evaluate with hyperparameter tuning.
+
+    search : BaseSearchCV
+        The scikit-learn search object (GridSearchCV or RandomizedSearchCV)
+        to use for hyperparameter tuning.
     """
 
     def __init__(self, data_op, search):
+
         self.data_op = data_op
         self.search = search
 

--- a/skrub/_data_ops/_optuna.py
+++ b/skrub/_data_ops/_optuna.py
@@ -147,6 +147,59 @@ class OptunaParamSearch(_BaseParamSearch):
     Attributes of interest are ``best_learner_``, ``best_score_``,
     ``results_``, ``detailed_results_``, and ``study_`` (the Optuna study used
     to find hyperparameters).
+
+    Parameters
+    ----------
+    data_op : DataOp
+        The DataOp to evaluate with hyperparameter tuning.
+
+    n_iter : int, default=10
+        Number of parameter settings that are sampled.
+
+    scoring : str, callable, list, tuple or dict, default=None
+        Strategy to evaluate the performance of the cross-validated model on
+        the test set.
+
+    n_jobs : int, default=None
+        Number of jobs to run in parallel.
+
+    refit : bool or str, default=True
+        Refit an estimator using the best found parameters on the whole
+        dataset.
+
+    cv : int, cross-validation generator or iterable, default=None
+        Determines the cross-validation splitting strategy.
+
+    verbose : int, default=0
+        Controls the verbosity.
+
+    pre_dispatch : str, default="2*n_jobs"
+        Controls the number of jobs that get dispatched during parallel
+        execution.
+
+    random_state : int, RandomState instance or None, default=None
+        Pseudo random number generator state used for random uniform sampling
+        from lists of possible values instead of scipy.stats distributions.
+
+    error_score : 'raise' or numeric, default=np.nan
+        Value to assign to the score if an error occurs in estimator fitting.
+
+    return_train_score : bool, default=False
+        If ``False``, the ``cv_results_`` attribute will not include training
+        scores.
+
+    storage : str or None, default=None
+        Database URL for Optuna storage. If None, a temporary journal file
+        storage is used.
+
+    study_name : str or None, default=None
+        Name of the Optuna study. If None, a unique name is generated.
+
+    sampler : optuna.samplers.BaseSampler or None, default=None
+        Optuna sampler to use. If None, TPESampler is used.
+
+    timeout : float or None, default=None
+        Stop study after the given number of seconds.
     """
 
     def __init__(
@@ -168,6 +221,7 @@ class OptunaParamSearch(_BaseParamSearch):
         sampler=None,
         timeout=None,
     ):
+
         self.data_op = data_op
         self.n_iter = n_iter
         self.scoring = scoring

--- a/skrub/_select_cols.py
+++ b/skrub/_select_cols.py
@@ -197,9 +197,52 @@ class DropCols(TransformerMixin, BaseEstimator):
 
 
 class Drop(SingleColumnTransformer):
+    """Drop a column by returning an empty list.
+
+    This transformer is used internally to drop columns during processing.
+    It returns an empty list for both fit_transform and transform operations,
+    effectively removing the column from the output.
+
+    Examples
+    --------
+    >>> from skrub import Drop
+    >>> drop = Drop()
+    >>> drop.fit_transform([1, 2, 3])
+    []
+    >>> drop.transform([1, 2, 3])
+    []
+    """
+
     def fit_transform(self, column, y=None):
+        """Fit to data, then transform it.
+
+        Parameters
+        ----------
+        column : array-like
+            The column to drop.
+
+        y : None
+            Unused.
+
+        Returns
+        -------
+        list
+            An empty list.
+        """
         self.all_outputs_ = []
         return []
 
     def transform(self, column):
+        """Transform the column by dropping it.
+
+        Parameters
+        ----------
+        column : array-like
+            The column to drop.
+
+        Returns
+        -------
+        list
+            An empty list.
+        """
         return []

--- a/skrub/tests/test_docstrings.py
+++ b/skrub/tests/test_docstrings.py
@@ -20,11 +20,9 @@ DOCSTRING_TEMP_IGNORE_SET = {
     "skrub._data_ops",
     "skrub._data_ops._data_ops",
     "skrub._data_ops._choosing",
-    "skrub._data_ops._estimator",
-    "skrub._data_ops._optuna",
-    "skrub._select_cols.Drop",
     "skrub._table_vectorizer.SuperVectorizer",
     "skrub._single_column_transformer.RejectColumn",
+
     # The following are not documented in skrub (and thus are out of scope)
     # They are usually inherited from other libraries.
     "skrub._table_vectorizer.TableVectorizer.fit",


### PR DESCRIPTION
## Summary

This PR fixes numpydoc validation errors introduced by stricter checks in #1753.

## Changes

- Added missing `Parameters` sections to:
  - `SkrubLearner`
  - `ParamSearch`
  - `OptunaParamSearch`
- Added complete class and method docstrings to `Drop`
- Documented all constructor parameters to comply with numpydoc standards
- Removed corresponding entries from `DOCSTRING_TEMP_IGNORE_SET`

## Validation

- All updated docstrings pass `numpydoc.validate`
- `pytest skrub/tests/test_docstrings.py` passes locally

This ensures the affected classes now fully comply with numpydoc validation requirements.
