### PR TITLE
DOC- Let Copilot suggest documentation improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,14 +9,14 @@ Release history
 Ongoing Development
 ===================
 
-New features
+New Features
 ------------
 
 Changes
 -------
 
-Bugfixes
---------
+Bug Fixes
+---------
 
 Release 0.7.2
 =============

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,7 +3,7 @@
 Contributing guide
 ==================
 
-First off, thanks for taking the time to contribute!
+First off, thank you for taking the time to contribute!
 
 Below are some guidelines to help you get started.
 
@@ -20,7 +20,7 @@ What to know before you begin
 -----------------------------
 
 To understand the purpose and goals behind skrub, please read our
-`vision statement. <https://skrub-data.org/stable/vision.html>`_
+`vision statement <https://skrub-data.org/stable/vision.html>`_.
 
 If you're interested in the research behind skrub,
 we encourage you to explore these papers:

--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,10 @@ skrub
 
 
 **skrub** (formerly *dirty_cat*) is a Python
-library that facilitates doing machine learning with dataframes.
+library that facilitates machine learning with dataframes.
 
 If you like the package, spread the word and ⭐ this repository!
-You can also join the `discord server <https://discord.gg/ABaPnm7fDC>`_.
+You can also join the `Discord server <https://discord.gg/ABaPnm7fDC>`_.
 
 Website: https://skrub-data.org/
 

--- a/RELEASE_PROCESS.rst
+++ b/RELEASE_PROCESS.rst
@@ -19,7 +19,7 @@ conda-forge project page.
      the last stable version. These releases are numbered X.Y.Z.
 
 To release a new minor version of skrub (e.g., from 0.1.0 to 0.2.0), here are the main
-steps and appropriate resources: the main steps and appropriate resources:
+steps and appropriate resources:
 
 Preparing the release branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/about.rst
+++ b/doc/about.rst
@@ -6,13 +6,13 @@ skrub shares much of its DNA with `scikit-learn
 <https://scikit-learn.org>`__.
 
 skrub is the continuation of `dirty-cat <http://dirty-cat.github.io>`_
-with a broader scope and a broader ambition.
+with a broader scope and greater ambition.
 
-skrub is a fairly young project born from research. We are happy to get feedback
-on successes and failures with the different techniques on real world data, or
-learn about open datasets on which we can do better examples and empirical work.
+skrub is a young project born from research. We welcome feedback
+on successes and failures with the different techniques on real-world data, or
+suggestions for open datasets on which we can do better examples and empirical work.
 
 skrub received funding from French research projects: `DirtyData
 <https://project.inria.fr/dirtydata/>`_ (ANR-17-CE23-0018), `LearnI
-<https://anr.fr/Projet-ANR-20-CHIA-0026>`_ (ANR-20-CHIA-0026) and `P16
+<https://anr.fr/Projet-ANR-20-CHIA-0026>`_ (ANR-20-CHIA-0026), and `P16
 <https://p16.inria.fr/fr/>`_.

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -3,8 +3,8 @@
 Development
 ===========
 
-While ``skrub`` is still being born, we believe in openness and community
-development from the start. Join us in building a great package to
+While ``skrub`` is still in its early stages, we believe in openness and
+community development from the start. Join us in building a great package to
 facilitate learning on databases.
 
 .. include:: includes/big_toc_css.rst

--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -4,7 +4,7 @@ User Guide
 ==========
 
 Skrub is a Python library that facilitates machine learning with tabular data
-(dataframes, as with pandas and polars) using a scikit-learn–compatible API.
+(dataframes, such as pandas and polars) using a scikit-learn-compatible API.
 
 Use the sections below to navigate the guide. For runnable code, see the
 :doc:`Example gallery <auto_examples/index>`. For class and function details, see

--- a/doc/vision.rst
+++ b/doc/vision.rst
@@ -1,27 +1,27 @@
 ===============================
-Vision: where is skrub heading?
+Vision: Where is skrub heading?
 ===============================
 
 .. currentmodule:: skrub
 
-Vision statement
+Vision Statement
 ================
 
 The goal of skrub is to facilitate machine learning on tables:
 `pandas <https://pandas.pydata.org>`__
-and `polars <https://pola.rs>`__ dataframes, SQL databases...
+and `polars <https://pola.rs>`__ dataframes, SQL databases, and more.
 
 |
 
-Skrub is high-level, with a philosophy and an API matching that of
+Skrub is high-level, with a philosophy and API matching that of
 `scikit-learn <http://scikit-learn.org>`_. It strives to bridge the world
-of databases to that of machine-learning, **enabling imperfect assembly and
-representations of the data when it is noisy**, using the downstream
-target to predict to guide assembly when possible (supervised learning for
+of databases and machine learning, **enabling imperfect assembly and
+representation of data when it is noisy**, using the downstream
+target to guide assembly when possible (supervised learning for
 data assembly).
 
 In the long term, as skrub is built on higher-level APIs, it will make it
-easier for data-scientists to use efficient database patterns and
+easier for data scientists to use efficient database patterns and
 backends.
 
 Skrub seeks tradeoffs in terms of flexibility: its high-level APIs are by


### PR DESCRIPTION
This is the result of asking Copilot to improve the documentation
```
Please fix the documentation, starting with small issues: grammar, typos, format, clarity. 
```

I had to revert a few Copilot suggestions, but overall they made sense. This is a manual PR, but obviously this could be automated using a GitHub workflow. Probably no need to run the workflow on every PR, rather once every N months or before minor/major releases.