### PR TITLE
MAINT - Dependency Groups in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 [tool.setuptools.dynamic]
 version = { file = "skrub/VERSION.txt" }
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
   "ipykernel",
   "ipython",


### PR DESCRIPTION
Compliance with [PEP 735](https://peps.python.org/pep-0735/).