### PR TITLE
FEAT - add new apply to cols

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,10 +23,11 @@ New Features
 Changes
 -------
 - :class:`ApplyToCols` has been modified so that now it can detect automatically
-  whether the provided transformer should be applied on each column, or on the
-  entire dataframe. In most cases, this replaces the original ``ApplyToCols``
-  and ``ApplyToFrame``. As a result, ``ApplyToCols`` and ``ApplyToFrame`` have
-  been renamed :class:`ApplyToEachCol` and :class:`ApplyToSubFrame` respectively.
+  whether the provided transformer should be applied independently on each column,
+  or on all selected columns as a single dataframe. In most cases, this replaces
+  the original ``ApplyToCols`` and ``ApplyToFrame``. As a result, ``ApplyToCols``
+  and ``ApplyToFrame`` have been renamed :class:`ApplyToEachCol` and
+  :class:`ApplyToSubFrame` respectively.
   The behavior of the old ``ApplyToCols`` can be replicated by setting the parameter
   ``how`` to ``cols``.
   :pr:`1913` and :pr:`1919` by :user:`Riccardo Cappuzzo <rcap107>`.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Changes
   and ``ApplyToFrame``. As a result, ``ApplyToCols`` and ``ApplyToFrame`` have
   been renamed :class:`ApplyToEachCol` and :class:`ApplyToSubFrame` respectively.
   The behavior of the old ``ApplyToCols`` can be replicated by setting the parameter
-  ``columnwise`` to ``True``.
+  ``how`` to ``cols``.
   :pr:`1913` and :pr:`1919` by :user:`Riccardo Cappuzzo <rcap107>`.
 
 Bug Fixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,9 +22,14 @@ New Features
 
 Changes
 -------
-- ``ApplyToCols`` and ``ApplyToFrame`` have been renamed :class:`ApplyToEachCol`
-  and :class:`ApplyToSubFrame` respectively.
-  :pr:`1913` by :user:`Riccardo Cappuzzo <rcap107>`.
+- :class:`ApplyToCols` has been modified so that now it can detect automatically
+  whether the provided transformer should be applied on each column, or on the
+  entire dataframe. In most cases, this replaces the original ``ApplyToCols``
+  and ``ApplyToFrame``. As a result, ``ApplyToCols`` and ``ApplyToFrame`` have
+  been renamed :class:`ApplyToEachCol` and :class:`ApplyToSubFrame` respectively.
+  The behavior of the old ``ApplyToCols`` can be replicated by setting the parameter
+  ``columnwise`` to ``True``.
+  :pr:`1913` and :pr:`1919` by :user:`Riccardo Cappuzzo <rcap107>`.
 
 Bug Fixes
 --------

--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -66,6 +66,7 @@ API_REFERENCE = {
                     "TableVectorizer",
                     "SelectCols",
                     "DropCols",
+                    "ApplyToCols",
                     "ApplyToEachCol",
                     "ApplyToSubFrame",
                 ],

--- a/examples/0090_apply_to_cols.py
+++ b/examples/0090_apply_to_cols.py
@@ -7,6 +7,19 @@ In previous examples, we saw how skrub provides powerful abstractions like
 
 In this new example, we show how to create more flexible pipelines by selecting
 and transforming dataframe columns using arbitrary logic.
+
+.. |ApplyToCols| replace:: :class:`~skrub.ApplyToCols`
+.. |ApplyToEachCol| replace:: :class:`~skrub.ApplyToEachCol`
+.. |ApplyToSubFrame| replace:: :class:`~skrub.ApplyToSubFrame`
+.. |StringEncoder| replace:: :class:`~skrub.StringEncoder`
+.. |SelectCols| replace:: :class:`~skrub.SelectCols`
+.. |DropCols| replace:: :class:`~skrub.DropCols`
+.. |TableVectorizer| replace:: :class:`~skrub.TableVectorizer`
+.. |OrdinalEncoder| replace:: :class:`~sklearn.preprocessing.OrdinalEncoder`
+.. |PCA| replace:: :class:`~sklearn.decomposition.PCA`
+.. |Pipeline| replace:: :class:`~sklearn.pipeline.Pipeline`
+.. |ColumnTransformer| replace:: :class:`~sklearn.compose.ColumnTransformer`
+
 """
 
 # %%
@@ -21,21 +34,21 @@ X, y = data.X, data.y
 X
 
 # %%
-# Our goal is now to apply a :class:`~skrub.StringEncoder` to two columns of our
+# Our goal is now to apply a |StringEncoder| to two columns of our
 # choosing: ``division`` and ``employee_position_title``.
 #
-# We can achieve this using :class:`~skrub.ApplyToEachCol`, whose job is to apply a
+# We can achieve this using |ApplyToCols|, whose job is to apply a
 # transformer to multiple columns independently, and let unmatched columns through
 # without changes.
 # This can be seen as a handy drop-in replacement of the
-# :class:`~sklearn.compose.ColumnTransformer`.
+# |ColumnTransformer|.
 #
 # Since we selected two columns and set the number of components to ``30`` each,
-# :class:`~skrub.ApplyToEachCol` will create ``2*30`` embedding columns in the dataframe
+# |ApplyToCols| will create ``2*30`` embedding columns in the dataframe
 # ``Xt``, which we prefix with ``lsa_``.
-from skrub import ApplyToEachCol, StringEncoder
+from skrub import ApplyToCols, StringEncoder
 
-apply_string_encoder = ApplyToEachCol(
+apply_string_encoder = ApplyToCols(
     StringEncoder(n_components=30),
     cols=["division", "employee_position_title"],
     rename_columns="lsa_{}",
@@ -44,30 +57,40 @@ Xt = apply_string_encoder.fit_transform(X)
 Xt
 
 # %%
-# In addition to the :class:`~skrub.ApplyToEachCol` class, the
-# :class:`~skrub.ApplyToSubFrame` class is useful for transformers that work on multiple
-# columns at once, such as the :class:`~sklearn.decomposition.PCA` which reduces the
-# number of components.
-#
+# The |ApplyToCols| class can detect automatically whether the transformer is a
+# ``SingleColumnTransformer`` (i.e., it can only be applied to one column at a time)
+# or not, and apply it accordingly. The |StringEncoder| is a ``SingleColumnTransformer``
+# and thus applied to each column independently.
+
+# %%
+# The |ApplyToCols| class can also be used with transformers that
+# can be applied to multiple columns at once, such as the |PCA|.
+# Here, we want to use PCA to reduce the number of dimensions of the new ``lsa_``
+# columns.
+
 # To select columns without hardcoding their names, we introduce
 # :ref:`selectors<user_guide_selectors>`, which allow for flexible matching pattern
 # and composable logic.
 #
 # The regex selector below will match all columns prefixed with ``"lsa"``, and pass them
-# to :class:`~skrub.ApplyToSubFrame` which will assemble these columns into a dataframe
-# and finally pass it to the PCA.
+# to |ApplyToCols| which will assemble these columns into a dataframe
+# and finally pass it to the PCA
+#
+# Note that |ApplyToCols| will automatically detect that PCA is not a
+# ``SingleColumnTransformer``
+# and apply it to the whole sub-dataframe of columns chosen by the selector at once.
+
 from sklearn.decomposition import PCA
 
-from skrub import ApplyToSubFrame
 from skrub import selectors as s
 
-apply_pca = ApplyToSubFrame(PCA(n_components=8), cols=s.regex("lsa"))
+apply_pca = ApplyToCols(PCA(n_components=8), cols=s.regex("lsa"))
 Xt = apply_pca.fit_transform(Xt)
 Xt
 
 # %%
 # These two selectors are scikit-learn transformers and can be chained together within
-# a :class:`~sklearn.pipeline.Pipeline`.
+# a |Pipeline|.
 from sklearn.pipeline import make_pipeline
 
 model = make_pipeline(
@@ -76,8 +99,17 @@ model = make_pipeline(
 ).fit_transform(X)
 
 # %%
+# .. dropdown:: Under the hood of |ApplyToCols|
+# |ApplyToCols| is implemented using the |ApplyToEachCol| and |ApplyToSubFrame|
+# classes.
+# The former applies a transformer to each column independently, while the latter
+# applies a transformer to a sub-dataframe.
+# Normally, users don't need to worry about these two classes, but they can be useful
+# when more control is needed.
+
+# %%
 # Note that selectors also come in handy in a pipeline to select or drop columns, using
-# :class:`~skrub.SelectCols` and :class:`~skrub.DropCols`!
+# |SelectCols| and |DropCols|!
 from sklearn.preprocessing import StandardScaler
 
 from skrub import SelectCols
@@ -91,7 +123,7 @@ pipeline.fit_transform(Xt)
 
 # %%
 # Let's run through one more example to showcase the expressiveness of the selectors.
-# Suppose we want to apply an :class:`~sklearn.preprocessing.OrdinalEncoder` on
+# Suppose we want to apply an |OrdinalEncoder| on
 # categorical columns with low cardinality (e.g., fewer than ``40`` unique values).
 #
 # We define a column filter using skrub selectors with a lambda function. Note that
@@ -100,7 +132,7 @@ pipeline.fit_transform(Xt)
 from sklearn.preprocessing import OrdinalEncoder
 
 low_cardinality = s.filter(lambda col: col.nunique() < 40)
-ApplyToEachCol(OrdinalEncoder(), cols=s.string() & low_cardinality).fit_transform(X)
+ApplyToCols(OrdinalEncoder(), cols=s.string() & low_cardinality).fit_transform(X)
 
 # %%
 # Notice how we composed the selector with :func:`~skrub.selectors.string()`
@@ -108,17 +140,17 @@ ApplyToEachCol(OrdinalEncoder(), cols=s.string() & low_cardinality).fit_transfor
 # columns with cardinality below ``40``.
 #
 # We can also define the opposite selector ``high_cardinality`` using the negation
-# operator ``~`` and apply a :class:`skrub.StringEncoder` to vectorize those
+# operator ``~`` and apply a |StringEncoder| to vectorize those
 # columns.
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 high_cardinality = ~low_cardinality
 pipeline = make_pipeline(
-    ApplyToEachCol(
+    ApplyToCols(
         OrdinalEncoder(),
         cols=s.string() & low_cardinality,
     ),
-    ApplyToEachCol(
+    ApplyToCols(
         StringEncoder(),
         cols=s.string() & high_cardinality,
     ),
@@ -128,10 +160,10 @@ pipeline
 
 # %%
 # Interestingly, the pipeline above is similar to the datatype dispatching performed by
-# :class:`~skrub.TableVectorizer`, also used in :func:`~skrub.tabular_pipeline`.
+# |TableVectorizer|, also used in :func:`~skrub.tabular_pipeline`.
 #
 # Click on the dropdown arrows next to the datatype to see the columns are mapped to
-# the different transformers in :class:`~skrub.TableVectorizer`.
+# the different transformers in |TableVectorizer|.
 from skrub import tabular_pipeline
 
 tabular_pipeline("regressor").fit(X, y)

--- a/examples/0090_apply_to_cols.py
+++ b/examples/0090_apply_to_cols.py
@@ -67,7 +67,7 @@ Xt
 # can be applied to multiple columns at once, such as the |PCA|.
 # Here, we want to use PCA to reduce the number of dimensions of the new ``lsa_``
 # columns.
-
+#
 # To select columns without hardcoding their names, we introduce
 # :ref:`selectors<user_guide_selectors>`, which allow for flexible matching pattern
 # and composable logic.

--- a/examples/0090_apply_to_cols.py
+++ b/examples/0090_apply_to_cols.py
@@ -99,13 +99,15 @@ model = make_pipeline(
 ).fit_transform(X)
 
 # %%
-# .. dropdown:: Under the hood of |ApplyToCols|
-# |ApplyToCols| is implemented using the |ApplyToEachCol| and |ApplyToSubFrame|
-# classes.
-# The former applies a transformer to each column independently, while the latter
-# applies a transformer to a sub-dataframe.
-# Normally, users don't need to worry about these two classes, but they can be useful
-# when more control is needed.
+# .. admonition:: Under the hood of |ApplyToCols|
+#   :collapsible: closed
+#
+#    |ApplyToCols| is implemented using the |ApplyToEachCol| and |ApplyToSubFrame|
+#    classes.
+#    The former applies a transformer to each column independently, while the latter
+#    applies a transformer to a sub-dataframe.
+#    Normally, users don't need to worry about these two classes, but they can be useful
+#    when more control is needed.
 
 # %%
 # Note that selectors also come in handy in a pipeline to select or drop columns, using

--- a/examples/0090_apply_to_cols.py
+++ b/examples/0090_apply_to_cols.py
@@ -102,16 +102,16 @@ model = make_pipeline(
 # .. admonition:: Under the hood of |ApplyToCols|
 #   :collapsible: closed
 #
-#    |ApplyToCols| is implemented using the |ApplyToEachCol| and |ApplyToSubFrame|
-#    classes.
-#    The former applies a transformer to each column independently, while the latter
-#    applies a transformer to a sub-dataframe.
-#    Normally, users don't need to worry about these two classes, but they can be useful
-#    when more control is needed.
+#   |ApplyToCols| is implemented using the |ApplyToEachCol| and |ApplyToSubFrame|
+#   classes.
+#   The former applies a transformer to each column independently, while the latter
+#   applies a transformer to a sub-dataframe.
+#   Normally, users don't need to worry about these two classes, but they can be useful
+#   when more control is needed.
 
 # %%
 # Note that selectors also come in handy in a pipeline to select or drop columns, using
-# |SelectCols| and |DropCols|!
+# |SelectCols| and |DropCols|.
 from sklearn.preprocessing import StandardScaler
 
 from skrub import SelectCols

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -8,6 +8,7 @@ from . import selectors
 from ._agg_joiner import AggJoiner, AggTarget
 from ._apply_on_each_col import ApplyToEachCol
 from ._apply_sub_frame import ApplyToSubFrame
+from ._apply_to_cols import ApplyToCols
 from ._column_associations import column_associations
 from ._config import config_context, get_config, set_config
 from ._data_ops import (
@@ -104,5 +105,6 @@ __all__ = [
     "config_context",
     "ApplyToEachCol",
     "ApplyToSubFrame",
+    "ApplyToCols",
     "ToFloat",
 ]

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -36,6 +36,21 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
     allow_reject : bool, default=False
         Whether to allow rejecting all columns. See the documentation of
         ``ApplyToEachCol`` for details.
+
+    columnwise : 'auto' or bool, default='auto'
+        Whether to apply the transformer to each selected column independently
+        (equivalent to using ``ApplyToEachCol``) or to the whole sub-dataframe of
+        selected columns at once (equivalent to using ``ApplyToSubFrame``). By
+        default, ``ApplyToEachCol`` is used if the transformer has a
+        ``__single_column_transformer__`` attribute and ``ApplyToSubFrame``
+        otherwise. Pass ``columnwise=True`` to force using ``ApplyToEachCol`` and
+        ``columnwise=False`` to force using ``ApplyToSubFrame``.
+        Note that forcing
+        ``columnwise=False`` for a single-column transformer will most likely
+        cause an error during ``fit``, and forcing ``columnwise=True`` for a
+        regular transformer is only appropriate if the transformer can be
+        fitted on a dataframe with only one column (this is the case for most
+        preprocessors such as ``OrdinalEncoder`` or ``StandardScaler``).
     """
 
     def __init__(

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -3,7 +3,7 @@ ApplyToCols selects the correct transformer between ApplyToEachCol and ApplyToSu
 based on the type of the transformer passed to it.
 """
 
-from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.base import BaseEstimator, TransformerMixin, check_is_fitted
 
 from . import selectors
 from ._apply_on_each_col import ApplyToEachCol
@@ -42,7 +42,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         How the transformer is applied. In most cases the default "auto"
         is appropriate.
         - "cols" means `transformer` is wrapped in a :class:`ApplyToEachCol`
-            transformer, which fits a separate clone of `transformer` each
+            transformer, which fits a separate clone of `transformer` to each
             column in `cols`.
         - "frame" means `transformer` is wrapped in a :class:`ApplyToSubFrame`
             transformer, which fits a single clone of `transformer` to the
@@ -79,11 +79,57 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         self.n_jobs = n_jobs
         self.how = how
 
-    def fit(self, X, y=None):
-        self.fit_transform(X, y)
+    def fit(self, X, y=None, **kwargs):
+        """Fit the transformer to the data.
+
+        If the transformer is a SingleColumnTransformer or if how="cols",
+        the transformer is wrapped in an ApplyToEachCol. Otherwise, it is wrapped
+        in an ApplyToSubFrame.
+
+        Parameters
+        ----------
+        X : Pandas or Polars DataFrame
+            The data to transform.
+
+        y : Pandas or Polars Series or DataFrame, default=None
+            The target data.
+
+        **kwargs
+            Extra named arguments are passed to the ``fit_transform()`` method of
+            the individual column transformers (the clones of ``self.transformer``).
+
+        Returns
+        -------
+        ApplyToCols
+            The transformer itself.
+        """
+        self.fit_transform(X, y, **kwargs)
         return self
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y=None, **kwargs):
+        """Fit the transformer on all columns and transform X.
+
+        If the transformer is a SingleColumnTransformer or if how="cols",
+        the transformer is wrapped in an ApplyToEachCol. Otherwise, it is wrapped
+        in an ApplyToSubFrame.
+
+        Parameters
+        ----------
+        X : Pandas or Polars DataFrame
+            The data to transform.
+
+        y : Pandas or Polars Series or DataFrame, default=None
+            The target data.
+
+        **kwargs
+            Extra named arguments are passed to the ``fit_transform()`` method
+            of ``self.transformer``.
+
+        Returns
+        -------
+        result : Pandas or Polars DataFrame
+            The transformed data.
+        """
         if self.how not in ("auto", "cols", "frame"):
             raise ValueError(
                 f"Invalid value for 'how': {self.how}. "
@@ -112,7 +158,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
             n_jobs=self.n_jobs,
             columnwise=columnwise,
         )
-        X_transformed = self._wrapped_transformer.fit_transform(X, y)
+        X_transformed = self._wrapped_transformer.fit_transform(X, y, **kwargs)
 
         if isinstance(self._wrapped_transformer, ApplyToEachCol):
             self.transformers_ = self._wrapped_transformer.transformers_
@@ -122,4 +168,39 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         return X_transformed
 
     def transform(self, X):
+        """Transform a dataframe.
+
+        Parameters
+        ----------
+        X : Pandas or Polars DataFrame
+            The column to transform.
+
+        **kwargs
+            Extra named arguments are passed to the ``transform()``.
+
+        Returns
+        -------
+        result : Pandas or Polars DataFrame
+            The transformed data.
+        """
+        if isinstance(self._wrapped_transformer, ApplyToEachCol):
+            check_is_fitted(self, "transformers_")
+        else:
+            check_is_fitted(self, "transformer_")
+
         return self._wrapped_transformer.transform(X)
+
+    def get_feature_names_out(self, input_features=None):
+        """Get output feature names for transformation.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored.
+
+        Returns
+        -------
+        feature_names_out : ndarray of str objects
+            Transformed feature names.
+        """
+        return self._wrapped_transformer.get_feature_names_out(input_features)

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -3,7 +3,6 @@ ApplyToCols selects the correct transformer between ApplyToEachCol and ApplyToSu
 based on the type of the transformer passed to it.
 """
 
-import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
 
 from . import selectors
@@ -91,12 +90,12 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
                 "Expected one of 'auto', 'cols', or 'frame'."
             )
 
-        if not isinstance(self.allow_reject, (bool, np.bool_)):
+        if not isinstance(self.allow_reject, bool):
             raise TypeError(
                 f"Invalid value for 'allow_reject': {self.allow_reject}. "
                 "Expected a boolean."
             )
-        if not isinstance(self.keep_original, (bool, np.bool_)):
+        if not isinstance(self.keep_original, bool):
             raise TypeError(
                 f"Invalid value for 'keep_original': {self.keep_original}. "
                 "Expected a boolean."

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -1,0 +1,75 @@
+"""
+ApplyToCols selects the correct transformer between ApplyToEachCol and ApplyToSubFrame
+based on the type of the transformer passed to it.
+"""
+
+from sklearn.base import BaseEstimator, TransformerMixin
+
+from ._apply_on_each_col import ApplyToEachCol
+from ._wrap_transformer import wrap_transformer
+
+
+class ApplyToCols(BaseEstimator, TransformerMixin):
+    """
+    Wrapper that applies a transformer to columns selected by a selector. The
+    wrapper automatically selects the correct class between ``ApplyToEachCol`` and
+    ``ApplyToSubFrame`` based on the type of the input transformer, but this can
+    be overridden with the ``columnwise`` parameter.
+
+    Parameters
+    ----------
+    transformer : transformer instance
+        The transformer to apply to the selected columns.
+
+    selector : selector specifier, default=s.all()
+        The columns to which the transformer will be applied. See the documentation of
+        ``ApplyToEachCol`` or ``ApplyToSubFrame`` for details.
+
+    allow_reject : bool, default=False
+        Whether to allow rejecting all columns. See the documentation of
+        ``ApplyToEachCol`` for details.
+    """
+
+    def __init__(
+        self,
+        transformer,
+        selector="all",
+        allow_reject=False,
+        keep_original=False,
+        rename_columns="{}",
+        columnwise="auto",
+        n_jobs=None,
+    ):
+        self.transformer = transformer
+        self.selector = selector
+        self.allow_reject = allow_reject
+        self.keep_original = keep_original
+        self.rename_columns = rename_columns
+        self.n_jobs = n_jobs
+        self.columnwise = columnwise
+
+    def fit(self, X, y=None):
+        self.fit_transform(X, y)
+        return self
+
+    def fit_transform(self, X, y=None):
+        self._wrapped_transformer = wrap_transformer(
+            self.transformer,
+            self.selector,
+            allow_reject=self.allow_reject,
+            keep_original=self.keep_original,
+            rename_columns=self.rename_columns,
+            n_jobs=self.n_jobs,
+            columnwise=self.columnwise,
+        )
+        X_transformed = self._wrapped_transformer.fit_transform(X, y)
+
+        if isinstance(self._wrapped_transformer, ApplyToEachCol):
+            self.transformers_ = self._wrapped_transformer.transformers_
+        else:
+            self.transformer_ = self._wrapped_transformer.transformer_
+
+        return X_transformed
+
+    def transform(self, X):
+        return self._wrapped_transformer.transform(X)

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -52,9 +52,7 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
             selected part of the input dataframe. `transformer` must be a
             transformer.
         - "auto" chooses the wrapping depending on the input and transformer.
-            If the input is not a dataframe or the transformer is not a
-            transformer, the "no_wrap" strategy is chosen. Otherwise if the
-            transformer has a ``__single_column_transformer__`` attribute,
+            If the transformer has a ``__single_column_transformer__`` attribute,
             "cols" is chosen. Otherwise "frame" is chosen.
 
     Notes

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -12,7 +12,7 @@ from ._wrap_transformer import wrap_transformer
 _SELECT_ALL_COLUMNS = selectors.all()
 
 
-class ApplyToCols(BaseEstimator, TransformerMixin):
+class ApplyToCols(TransformerMixin, BaseEstimator):
     """
     Map a transformer to columns in a dataframe.
 

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -5,8 +5,11 @@ based on the type of the transformer passed to it.
 
 from sklearn.base import BaseEstimator, TransformerMixin
 
+from . import selectors
 from ._apply_on_each_col import ApplyToEachCol
 from ._wrap_transformer import wrap_transformer
+
+_SELECT_ALL_COLUMNS = selectors.all()
 
 
 class ApplyToCols(BaseEstimator, TransformerMixin):
@@ -21,9 +24,14 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
     transformer : transformer instance
         The transformer to apply to the selected columns.
 
-    selector : selector specifier, default=s.all()
-        The columns to which the transformer will be applied. See the documentation of
-        ``ApplyToEachCol`` or ``ApplyToSubFrame`` for details.
+    cols : str, sequence of str, or skrub selector, optional
+        The columns to attempt to transform. Only the selected columns will have
+        the transformer applied. Columns outside this selection are passed
+        through unchanged (``fit_transform`` is not called on them) and remain
+        unmodified in the output. The default is to attempt transforming all
+        columns.
+        See the documentation of
+        :class:`ApplyToEachCol` or :class:`ApplyToSubFrame` for details.
 
     allow_reject : bool, default=False
         Whether to allow rejecting all columns. See the documentation of
@@ -33,7 +41,7 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
     def __init__(
         self,
         transformer,
-        selector="all",
+        cols=_SELECT_ALL_COLUMNS,
         allow_reject=False,
         keep_original=False,
         rename_columns="{}",
@@ -41,7 +49,7 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
         n_jobs=None,
     ):
         self.transformer = transformer
-        self.selector = selector
+        self.cols = cols
         self.allow_reject = allow_reject
         self.keep_original = keep_original
         self.rename_columns = rename_columns
@@ -55,7 +63,7 @@ class ApplyToCols(BaseEstimator, TransformerMixin):
     def fit_transform(self, X, y=None):
         self._wrapped_transformer = wrap_transformer(
             self.transformer,
-            self.selector,
+            self.cols,
             allow_reject=self.allow_reject,
             keep_original=self.keep_original,
             rename_columns=self.rename_columns,

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -1,0 +1,162 @@
+import datetime
+
+import numpy as np
+import pytest
+from sklearn.preprocessing import OrdinalEncoder, StandardScaler
+
+from skrub import ApplyToCols, ApplyToEachCol
+from skrub import _dataframe as sbd
+from skrub import selectors as s
+from skrub._apply_sub_frame import ApplyToSubFrame
+from skrub._to_datetime import ToDatetime
+
+
+def test_single_column_transformer_becomes_apply_to_each_col(df_module):
+    """SingleColumnTransformer should be wrapped as ApplyToEachCol."""
+    at = ApplyToCols(ToDatetime(), cols=s.all())
+    X = df_module.make_dataframe({"date_col": ["2020-01-01", "2020-01-02"]})
+    at.fit(X)
+    assert isinstance(at._wrapped_transformer, ApplyToEachCol)
+
+
+def test_non_single_column_transformer_becomes_apply_to_subframe(df_module):
+    """Non-SingleColumnTransformer should be wrapped as ApplyToSubFrame."""
+    at = ApplyToCols(OrdinalEncoder(), cols=s.all())
+    X = df_module.make_dataframe({"col1": ["a", "b"], "col2": ["x", "y"]})
+    at.fit(X)
+    assert isinstance(at._wrapped_transformer, ApplyToSubFrame)
+
+
+def test_columnwise_override_forces_apply_to_each_col(df_module):
+    """
+    columnwise=True should force ApplyToEachCol even
+    for non-SingleColumnTransformer.
+    """
+    at = ApplyToCols(OrdinalEncoder(), cols=s.all(), columnwise=True)
+    X = df_module.make_dataframe({"col1": ["a", "b"], "col2": ["x", "y"]})
+    at.fit(X)
+    assert isinstance(at._wrapped_transformer, ApplyToEachCol)
+
+
+def test_invalid_parameters():
+    """all these parameters should be boolean."""
+
+    X = None  # Placeholder for the dataframe, not used in this test
+
+    with pytest.raises((TypeError, ValueError)):
+        at = ApplyToCols(ToDatetime(), allow_reject="yes")
+        at.fit_transform(X)
+    with pytest.raises((TypeError, ValueError)):
+        at = ApplyToCols(ToDatetime(), keep_original="no")
+        at.fit_transform(X)
+    with pytest.raises((TypeError, ValueError)):
+        at = ApplyToCols(ToDatetime(), columnwise="maybe")
+        at.fit_transform(X)
+
+
+def test_to_datetime_transformation(df_module):
+    """Test transformation with ToDatetime (SingleColumnTransformer)."""
+    at = ApplyToCols(ToDatetime(), cols=s.all(), allow_reject=True)
+    X = df_module.make_dataframe(
+        {"date": ["2020-01-01", "2020-01-02"], "value": [1, 2]}
+    )
+    X_transformed = at.fit_transform(X)
+
+    # Check that date column was transformed to datetime
+    assert sbd.is_any_date(sbd.col(X_transformed, "date"))
+    # Check that value column was unchanged
+    assert sbd.to_list(sbd.col(X_transformed, "value")) == [1, 2]
+
+
+def test_ordinal_encoder_transformation(df_module):
+    """Test transformation with OrdinalEncoder (non-SingleColumnTransformer)."""
+    at = ApplyToCols(OrdinalEncoder(), cols=s.all())
+    X = df_module.make_dataframe({"col1": ["a", "b", "c"], "col2": ["x", "y", "z"]})
+    X_transformed = at.fit_transform(X)
+
+    # Check that data was encoded properly
+    assert np.array_equal(sbd.col(X_transformed, "col1"), [0, 1, 2])
+    assert np.array_equal(sbd.col(X_transformed, "col2"), [0, 1, 2])
+
+
+def test_column_selection_with_selector(df_module):
+    """Test that only selected columns are transformed."""
+    at = ApplyToCols(OrdinalEncoder(), cols=s.string())
+    X = df_module.make_dataframe(
+        {
+            "numeric1": [1.0, 2.0, 3.0],
+            "numeric2": [10.0, 20.0, 30.0],
+            "string_col": ["a", "b", "c"],
+        }
+    )
+    X_transformed = at.fit_transform(X)
+
+    # Check that only string_col was transformed
+    assert np.array_equal(sbd.col(X_transformed, "string_col"), [0, 1, 2])
+    # Check that numeric columns were unchanged
+    assert np.array_equal(sbd.col(X_transformed, "numeric1"), [1.0, 2.0, 3.0])
+    assert np.array_equal(sbd.col(X_transformed, "numeric2"), [10.0, 20.0, 30.0])
+
+
+def test_fit_and_transform_separate(df_module):
+    """Test that fit and transform can be called separately."""
+    at = ApplyToCols(OrdinalEncoder(), cols=s.string())
+    X_train = df_module.make_dataframe(
+        {"col1": ["a", "b", "c"], "col2": ["x", "y", "z"]}
+    )
+    X_test = df_module.make_dataframe({"col1": ["a", "b"], "col2": ["x", "y"]})
+
+    at.fit(X_train)
+    X_train_transformed = at.transform(X_train)
+    X_test_transformed = at.transform(X_test)
+
+    assert sbd.shape(X_train_transformed) == (3, 2)
+    assert sbd.shape(X_test_transformed) == (2, 2)
+
+
+def test_correct_transformer_attributes(df_module):
+    """Test that transformer attributes are correctly set after fit."""
+    at = ApplyToCols(StandardScaler(), cols=s.numeric())
+    X = df_module.make_dataframe(
+        {
+            "col1": [1.0, 2.0, 3.0],
+            "col2": [10.0, 20.0, 30.0],
+            "date_col": ["2020-01-01", "2020-01-02", "2020-01-03"],
+        }
+    )
+    at.fit(X)
+
+    # For non-SingleColumnTransformer, transformer_ should be set
+    assert hasattr(at, "transformer_")
+    assert isinstance(at.transformer_, StandardScaler)
+
+    # For SingleColumnTransformer, transformers_ should be set
+    at_single = ApplyToCols(ToDatetime(), cols="date_col")
+    at_single.fit(X)
+    assert hasattr(at_single, "transformers_")
+    assert isinstance(at_single.transformers_, dict)
+
+
+def test_reject_column(df_module):
+    at = ApplyToCols(ToDatetime(), cols=s.all(), allow_reject=True)
+    X = df_module.make_dataframe(
+        {"date": ["2020-01-01", "2020-01-02"], "value": [1, 2]}
+    )
+    X_transformed = at.fit_transform(X)
+
+    X_expected = df_module.make_dataframe(
+        {
+            "date": [datetime.datetime(2020, 1, 1), datetime.datetime(2020, 1, 2)],
+            "value": [1, 2],
+        }
+    )
+
+    df_module.assert_frame_equal(X_transformed, X_expected)
+
+    # A RejectColumn exception should be raised
+    with pytest.raises(ValueError):
+        at = ApplyToCols(ToDatetime(), cols=s.all(), allow_reject=False)
+        X = df_module.make_dataframe(
+            {"date": ["2020-01-01", "2020-01-02"], "value": [1, 2]}
+        )
+        at.fit(X)

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -177,6 +177,43 @@ def test_check_is_fitted_transform(df_module, transformer, data):
     # Should raise NotFittedError when calling transform before fit
     with pytest.raises(NotFittedError):
         at.transform(X)
+
+
+def test_check_is_fitted_get_feature_names_out():
+    """Test that get_feature_names_out raises NotFittedError before fitting."""
+    at = ApplyToCols(ToDatetime(), cols=s.all())
+
     # Should raise NotFittedError when calling get_feature_names_out before fit
+    with pytest.raises(NotFittedError):
+        at.get_feature_names_out()
+
+
+# This test is needed to make coverage happy
+@pytest.mark.parametrize(
+    "transformer,expected_attr",
+    [
+        (ToDatetime(), "transformers_"),
+        (OrdinalEncoder(), "transformer_"),
+    ],
+)
+def test_check_is_fitted_missing_fitted_attribute_transform(
+    df_module, transformer, expected_attr
+):
+    """Test check_is_fitted in transform when fitted attributes are missing."""
+    at = ApplyToCols(transformer, cols=s.all())
+    X = df_module.make_dataframe({"col": ["2020-01-01", "2020-01-02"]})
+
+    # Fit the estimator
+    at.fit(X)
+
+    # Artificially remove the fitted attribute to test check_is_fitted
+    if hasattr(at, expected_attr):
+        delattr(at, expected_attr)
+
+    # Should raise NotFittedError when fitted attribute is missing
+    with pytest.raises(NotFittedError):
+        at.transform(X)
+
+    # Should raise NotFittedError when fitted attribute is missing
     with pytest.raises(NotFittedError):
         at.get_feature_names_out()

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -2,6 +2,7 @@ import datetime
 
 import numpy as np
 import pytest
+from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 
 from skrub import ApplyToCols
@@ -159,3 +160,23 @@ def test_reject_column(df_module):
             {"date": ["2020-01-01", "2020-01-02"], "value": [1, 2]}
         )
         at.fit(X)
+
+
+@pytest.mark.parametrize(
+    "transformer,data",
+    [
+        (ToDatetime(), {"date_col": ["2020-01-01", "2020-01-02"]}),
+        (OrdinalEncoder(), {"col1": ["a", "b"], "col2": ["x", "y"]}),
+    ],
+)
+def test_check_is_fitted_transform(df_module, transformer, data):
+    """Test that transform raises NotFittedError before fitting."""
+    at = ApplyToCols(transformer, cols=s.all())
+    X = df_module.make_dataframe(data)
+
+    # Should raise NotFittedError when calling transform before fit
+    with pytest.raises(NotFittedError):
+        at.transform(X)
+    # Should raise NotFittedError when calling get_feature_names_out before fit
+    with pytest.raises(NotFittedError):
+        at.get_feature_names_out()

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -15,7 +15,7 @@ def test_single_column_transformer_becomes_apply_to_each_col(df_module):
     at = ApplyToCols(ToDatetime(), cols=s.all())
     X = df_module.make_dataframe({"date_col": ["2020-01-01", "2020-01-02"]})
     at.fit(X)
-    assert hasattr(at._wrapped_transformer, "transformers_")
+    assert hasattr(at, "transformers_")
 
 
 def test_non_single_column_transformer_becomes_apply_to_subframe(df_module):
@@ -23,7 +23,7 @@ def test_non_single_column_transformer_becomes_apply_to_subframe(df_module):
     at = ApplyToCols(OrdinalEncoder(), cols=s.all())
     X = df_module.make_dataframe({"col1": ["a", "b"], "col2": ["x", "y"]})
     at.fit(X)
-    assert hasattr(at._wrapped_transformer, "transformer_")
+    assert hasattr(at, "transformer_")
 
 
 def test_columnwise_override_forces_apply_to_each_col(df_module):
@@ -34,7 +34,7 @@ def test_columnwise_override_forces_apply_to_each_col(df_module):
     at = ApplyToCols(OrdinalEncoder(), cols=s.all(), how="cols")
     X = df_module.make_dataframe({"col1": ["a", "b"], "col2": ["x", "y"]})
     at.fit(X)
-    assert hasattr(at._wrapped_transformer, "transformers_")
+    assert hasattr(at, "transformers_")
 
 
 def test_invalid_parameters():


### PR DESCRIPTION
This PR adds a generic ApplyToCols that automatically chooses between ApplyToEachCol (the old ApplyToCols) and ApplyToSubFrame (the old (ApplyToFrame). 

This addresses #1754 and is a follow up to  #1913