### PR TITLE
small implementation simplification

### DIFF
--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -587,7 +587,7 @@ def _compute_Xy(data_op, environment):
             environment,
             msg=msg,
         )
-    return Xy_values["X"], Xy_values.get("y", None)
+    return Xy_values["X"], Xy_values.get("y")
 
 
 def _rename_cv_param_learner_to_estimator(kwargs):


### PR DESCRIPTION
when collecting X and y for splitting, CV etc. they are now computed jointly instead of one after the other with clearing of intermediate results disabled. the result is the same, but it is very slightly simpler and could use less memory in some cases due to turning on the intermediate result garbage collection for this operation