### PR TITLE
Updating the contributing doc to explain how to write a changelog entry

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -340,7 +340,8 @@ You can download and install pixi from `here <https://pixi.sh/latest/>`_.
 
 From the repository root:
 
-y
+.. code:: bash
+
     # Build documentation without running examples (faster)
     pixi run build-doc-quick
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -340,8 +340,7 @@ You can download and install pixi from `here <https://pixi.sh/latest/>`_.
 
 From the repository root:
 
-.. code:: bash
-
+y
     # Build documentation without running examples (faster)
     pixi run build-doc-quick
 
@@ -380,6 +379,41 @@ Once you have pushed your commits to your remote repository, you can submit
 a PR by clicking the "Compare & pull request" button on GitHub,
 targeting the skrub repository.
 
+Updating the changelog
+~~~~~~~~~~~~~~~~~~~~~~
+Any user-facing change to the codebase needs to be reported in the changelog,
+found in the ``CHANGES.rst`` file in the root of the repository. A user-facing
+change is any change to a functionality of skrub that users are expected to interact
+with: for example, adding or removing a parameter, adding a new transformer,
+deprecating a function, etc.
+
+Changes made in the test suite, or changes made in the
+private parts of the library, should not be reported, unless they bring some benefit
+to the user (such as performance improvements). Normally, changes made to the
+documentation, such as typo or formatting fixes, are not reported either, while
+new examples usually can be added.
+Depending on the nature of the PR, a maintainer may add the "no
+changelog needed" label to skip the corresponding check if a changelog entry isn't
+relevant.
+
+Changelog entries need to follow a specific format: the change should be described
+in sufficient detail for users to understand how they may be affected, and the
+entry must list both the PR number and the GitHub username of the author(s) of the
+PR.
+
+Here is an example:
+
+.. code:: bash
+
+   - :meth:`DataOp.skb.apply` now allows passing extra named arguments to the
+  estimator's methods through the parameters ``fit_kwargs``, ``predict_kwargs``
+  etc. :pr:`1642` by :user:`Jérôme Dockès <jeromedockes>`.
+
+The PR number is reported with the directive ``:pr:`NUMBER```, and the author
+of the PR uses the directive ``:user:`AUTHOR NAME <GITHUB HANDLE>```.
+
+Missing changelog entries, or changelog entries that do not follow the format,
+will fail the changelog check in the CI.
 
 Continuous Integration (CI)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Small addition to the contributing.rst file to explain how to write a changelog entry, the format, and what should get an entry at all. 