### PR TITLE
FIX - do not collect lazyframes in CheckInput

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,9 @@ Bug Fixes
   and :pr:`1900` by :user:`Jérôme Dockès <jeromedockes>`.
 - Errors raised when a polars LazyFrame is passed where an eager DataFrame is
   expected are now clearer. :pr:`1916` by :user:`Jérôme Dockès <jeromedockes>`.
+- :class:`CheckInputDataFrame` no longer collects Polars LazyFrames automatically;
+  a ``TypeError`` is now raised instead, consistent with the rest of the library.
+  :pr:`1941` by :user:`Mudit Atrey <MuditAtrey>`.
 
 Documentation
 -------------

--- a/skrub/_check_input.py
+++ b/skrub/_check_input.py
@@ -64,11 +64,6 @@ def _check_not_pandas_sparse_pandas(df):
 
 
 def _check_is_dataframe(df):
-    if sbd.is_lazyframe(df):
-        warnings.warn(
-            "At the moment, skrub only works on eager DataFrames, calling collect()."
-        )
-        df = sbd.collect(df)
     if not sbd.is_dataframe(df):
         raise TypeError(
             "Only pandas and polars DataFrames are supported. Cannot handle X of"
@@ -95,8 +90,6 @@ class CheckInputDataFrame(TransformerMixin, BaseEstimator):
         - Only applies to pandas; polars column names are always unique strings.
     - The input is not sparse.
         - A TypeError is raised otherwise.
-    - The input is not a ``LazyFrame``.
-        - A ``LazyFrame`` is ``collect``ed with a warning.
     - The column names are the same during ``fit`` and ``transform``.
         - A ValueError is raised otherwise.
 

--- a/skrub/tests/test_check_input.py
+++ b/skrub/tests/test_check_input.py
@@ -79,20 +79,12 @@ def test_input_is_sparse():
 
 def test_input_is_lazy():
     pl = pytest.importorskip("polars")
-    df = pl.DataFrame({"a": [1, 2]})
-    lazy_df = df.lazy()
+    lazy_df = pl.DataFrame({"a": [1, 2]}).lazy()
     check = CheckInputDataFrame()
-    with pytest.warns(UserWarning, match=".*only works on eager"):
-        out = check.fit_transform(lazy_df)
-    assert isinstance(out, pl.DataFrame)
-    from polars.testing import assert_frame_equal
-
-    assert_frame_equal(out, df)
-
-    with pytest.warns(UserWarning, match=".*only works on eager"):
-        out = check.transform(lazy_df)
-    assert isinstance(out, pl.DataFrame)
-    assert_frame_equal(out, df)
+    with pytest.raises(
+        TypeError, match="Only pandas and polars DataFrames are supported"
+    ):
+        check.fit_transform(lazy_df)
 
 
 def test_column_names_changed(df_module):


### PR DESCRIPTION
Closes #1925
Removes the automatic collection of Polars LazyFrames in `_check_is_dataframe.` Preivously, passing a LazyFrame would trigger a warning and call `collect()` automatically. This is now consistent with the rest of the library with no special handling, a `TypeError` is raised instead.
Updated `test_input_is_lazy` to reflect the new behaviour.