### PR TITLE
Add social-media elements to landing page

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -4,8 +4,8 @@
 {%- block extrahead %}
     {{ super() }}
     {# Add here landing-page specific stuff that goes in the header (eg css) #}
-    <meta property="og:type" content="website"><meta property="og:title" content="Getting Started">
-
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="Skrub">
     <meta property="og:site_name" content="skrub">
     <meta property="og:description" content="Machine learning with dataframes">
     <meta property="og:image" content="https://skrub-data.github.io/stable/_static/skrub.svg">


### PR DESCRIPTION
Implements the OGP standard ( https://ogp.me/ ) in the main index.html. The rest of the library has it thanks to a sphinx plugin, but not the landing page.

Without this PR, the landing page does not render with a summary on social media
<img width="983" height="83" alt="image" src="https://github.com/user-attachments/assets/34c33e64-36eb-4b6d-925f-bab705827bba" />
Contrast with another page:
<img width="1170" height="235" alt="image" src="https://github.com/user-attachments/assets/8f58e65a-9323-44ad-8e36-24525014ec29" />

This PR closes https://github.com/skrub-data/skrub/issues/1945
