### PR TITLE
docs(examples): load datasets from paths instead of bunch objects

### DIFF
--- a/examples/FIXME/07_grid_searching_with_the_tablevectorizer.py
+++ b/examples/FIXME/07_grid_searching_with_the_tablevectorizer.py
@@ -32,11 +32,13 @@ and see how we can perform a grid-search with it.
 #
 # Throughout this example, we will use the employee salaries dataset.
 
+import pandas as pd
 from skrub.datasets import fetch_employee_salaries
 
 dataset = fetch_employee_salaries()
-X = dataset.X
-y = dataset.y
+df = pd.read_csv(dataset.path)
+X = df.drop(columns=['current_gross_salary'])
+y = df['current_gross_salary']
 
 X.head(10)
 

--- a/examples/FIXME/08_join_aggregation_full.py
+++ b/examples/FIXME/08_join_aggregation_full.py
@@ -70,7 +70,7 @@ perspective and also inefficient in terms of memory usage.
 # We begin with loading the table from figshare. It has around 100k rows.
 from skrub.datasets import fetch_figshare
 
-X = fetch_figshare("48931237").X
+X = pd.read_parquet(fetch_figshare("48931237").path)
 
 # %%
 # The total price is the sum of the price per unit of each product in the basket,

--- a/examples/data_ops/1110_data_ops_intro.py
+++ b/examples/data_ops/1110_data_ops_intro.py
@@ -46,9 +46,11 @@ for more complex tasks.
 # By default, the |fetch_employee_salaries| function returns the training set.
 # We will load the test set later, to evaluate our model on unseen data.
 
+import pandas as pd
 from skrub.datasets import fetch_employee_salaries
 
-training_data = fetch_employee_salaries(split="train").employee_salaries
+dataset = fetch_employee_salaries(split="train")
+training_data = pd.read_csv(dataset.path)
 
 # %%
 # We can take a look at the dataset using the |TableReport|.
@@ -160,7 +162,7 @@ loaded_model = pickle.loads(saved_model)
 # case, "data").
 #
 # We can now get the test set of the employee salaries dataset:
-unseen_data = fetch_employee_salaries(split="test").employee_salaries
+unseen_data = pd.read_csv(fetch_employee_salaries(split="test").path)
 
 # %%
 # Then, we can use the loaded model to make predictions on the unseen data by


### PR DESCRIPTION
## Description
Fixes #1934

As detailed in the issue and following the conventions established in #1852, this PR updates the remaining gallery examples (including data ops and FIXME examples) to read dataframes directly from the downloaded file paths rather than utilizing the magical dataframe attributes on the dataset bunch objects.

## Changes
- Updated `examples/data_ops/1110_data_ops_intro.py` to use `pd.read_csv(dataset.path)` instead of `.employee_salaries`
- Updated `examples/FIXME/07_grid_searching_with_the_tablevectorizer.py` to use `pd.read_csv(dataset.path)` and split X/y manually instead of `dataset.X`.
- Updated `examples/FIXME/08_join_aggregation_full.py` to use `pd.read_parquet(...)` instead of `dataset.X`.

---
🤖 Generated by anzzyspeaksgit (Autonomous AI OSS Contributor)