### PR TITLE
Chore - remove "use_table_report" config parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ Changes
   :pr:`1952` and :pr:`1954` by :user:`Lisa McBride <lisaleemcb>`.
 - The configuration parameter "use_table_report" has been removed from the skrub
   configuration. Use :meth:`patch_display` instead.
-  :pr:`1965` by :user:`Riccardo Cappuzzo<rcap107>`.
+  :pr:`1973` by :user:`Riccardo Cappuzzo<rcap107>`.
 
 Bug Fixes
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,13 +58,16 @@ Changes
   the ``SKB_DATA_DIRECTORY`` environment variable. The environment variable ``SKRUB_DATA_DIRECTORY``
   is deprecated and will be removed in a future version of skrub.
   :pr:`1852` by :user:`Riccardo Cappuzzo<rcap107>`.
-  :class:`SingleColumnTransformer` and associated exception :class:`RejectColumn` (used
+- :class:`core.SingleColumnTransformer` and associated exception :class:`core.RejectColumn` (used
   internally by many skrub estimators) have been added to the public API, in the newly-created
   :package:`skrub.core` module. :pr:`1851` by :user:`Eloi Massoulié <emassoulie>`.
-  - Added the strings ``"None"`` and ``"none"`` to the list of null string values in
+- Added the strings ``"None"`` and ``"none"`` to the list of null string values in
   :class:`Cleaner`. Also, exposed the list of null string values that will be set
   to null by the :class:`Cleaner` as the parameter ``null_strings``.
   :pr:`1952` and :pr:`1954` by :user:`Lisa McBride <lisaleemcb>`.
+- The configuration parameter "use_table_report" has been removed from the skrub
+  configuration. Use :meth:`patch_display` instead.
+  :pr:`1965` by :user:`Riccardo Cappuzzo<rcap107>`.
 
 Bug Fixes
 --------

--- a/doc/modules/configuration_and_utils/customizing_configuration.rst
+++ b/doc/modules/configuration_and_utils/customizing_configuration.rst
@@ -40,7 +40,7 @@ are available by using
 >>> import skrub
 >>> config = skrub.get_config()
 >>> config.keys()
-dict_keys(['use_table_report', 'use_table_report_data_ops', 'table_report_verbosity', 'max_plot_columns', 'max_association_columns', 'subsampling_seed', 'enable_subsampling', 'float_precision', 'cardinality_threshold', 'data_dir', 'eager_data_ops'])
+dict_keys(['use_table_report_data_ops', 'table_report_verbosity', 'max_plot_columns', 'max_association_columns', 'subsampling_seed', 'enable_subsampling', 'float_precision', 'cardinality_threshold', 'data_dir', 'eager_data_ops'])
 
 These are the parameters currently available in the global configuration:
 
@@ -52,10 +52,6 @@ These are the parameters currently available in the global configuration:
      - Default Value
      - Env Variable
      - Description
-   * - ``use_table_report``
-     - ``False``
-     - ``SKB_USE_TABLE_REPORT``
-     - If set to ``True``, the HTML representation of Pandas and Polars dataframes is replaced with the :class:`~skrub.TableReport`.
    * - ``use_table_report_data_ops``
      - ``True``
      - ``SKB_USE_TABLE_REPORT_DATA_OPS``

--- a/doc/modules/configuration_and_utils/customizing_configuration.rst
+++ b/doc/modules/configuration_and_utils/customizing_configuration.rst
@@ -15,7 +15,7 @@ Skrub includes a configuration manager that allows setting various parameters
 It is possible to change configuration options using the |set_config| function:
 
 >>> from skrub import set_config
->>> set_config(use_table_report=True)
+>>> set_config(table_report_verbosity=0)
 
 This alters the behavior of skrub in the current script. Each configuration parameter
 has an environment variable that can be used to set it permanently.

--- a/skrub/_config.py
+++ b/skrub/_config.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 import numpy as np
 
-from ._reporting import _patching
-
 
 def _get_default_data_dir():
     """Get the default data directory path.
@@ -57,7 +55,6 @@ def _parse_env_bool(env_variable_name, default):
 
 
 _global_config = {
-    "use_table_report": _parse_env_bool("SKB_USE_TABLE_REPORT", False),
     "use_table_report_data_ops": _parse_env_bool("SKB_USE_TABLE_REPORT_DATA_OPS", True),
     "table_report_verbosity": int(os.environ.get("SKB_TABLE_REPORT_VERBOSITY", 1)),
     "max_plot_columns": int(os.environ.get("SKB_MAX_PLOT_COLUMNS", 30)),
@@ -106,20 +103,7 @@ def get_config():
     return _get_threadlocal_config().copy()
 
 
-def _apply_external_patches(config):
-    if config["use_table_report"]:
-        _patching._patch_display(
-            max_plot_columns=config["max_plot_columns"],
-            max_association_columns=config["max_plot_columns"],
-            verbose=config["table_report_verbosity"],
-        )
-    else:
-        # No-op if dispatch haven't been previously enabled
-        _patching._unpatch_display()
-
-
 def set_config(
-    use_table_report=None,
     use_table_report_data_ops=None,
     table_report_verbosity=None,
     max_plot_columns=None,
@@ -135,18 +119,6 @@ def set_config(
 
     Parameters
     ----------
-    use_table_report : bool, default=None
-        The type of display used for dataframes. If ``None``, falls back to the current
-        configuration, which is ``False`` by default.
-
-        - If ``True``, replace the default DataFrame HTML displays with
-          :class:`~skrub.TableReport`.
-        - If ``False``, the original Pandas or Polars dataframe HTML representation
-          will be used.
-
-        This configuration can also be set with the ``SKB_USE_TABLE_REPORT``
-        environment variable.
-
     use_table_report_data_ops : bool, default=None
         The type of HTML representation used for the dataframes preview in skrub
         DataOps. If ``None``, falls back to the current configuration, which is ``True``
@@ -252,16 +224,9 @@ def set_config(
     Examples
     --------
     >>> from skrub import set_config
-    >>> set_config(use_table_report=True)  # doctest: +SKIP
+    >>> set_config(use_table_report_data_ops=True)  # doctest: +SKIP
     """
     local_config = _get_threadlocal_config()
-    if use_table_report is not None:
-        if not isinstance(use_table_report, bool):
-            raise ValueError(
-                f"'use_table_report' must be a boolean, got {use_table_report!r}."
-            )
-        local_config["use_table_report"] = use_table_report
-
     if use_table_report_data_ops is not None:
         if not isinstance(use_table_report_data_ops, bool):
             raise ValueError(
@@ -335,13 +300,11 @@ def set_config(
 
     if eager_data_ops is not None:
         local_config["eager_data_ops"] = eager_data_ops
-    _apply_external_patches(local_config)
 
 
 @contextmanager
 def config_context(
     *,
-    use_table_report=None,
     use_table_report_data_ops=None,
     table_report_verbosity=None,
     max_plot_columns=None,
@@ -357,17 +320,6 @@ def config_context(
 
     Parameters
     ----------
-    use_table_report : bool, default=None
-        The type of display used for dataframes. Default is ``False``.
-
-        - If ``True``, replace the default DataFrame HTML displays with
-          :class:`~skrub.TableReport`.
-        - If ``False``, the original Pandas or Polars dataframe HTML representation
-          will be used.
-
-        This configuration can also be set with the ``SKB_USE_TABLE_REPORT``
-        environment variable.
-
     use_table_report_data_ops : bool, default=None
         The type of HTML representation used for the dataframes preview in skrub
         DataOps. Default is ``True``.
@@ -480,7 +432,6 @@ def config_context(
     """
     original_config = get_config()
     set_config(
-        use_table_report=use_table_report,
         use_table_report_data_ops=use_table_report_data_ops,
         table_report_verbosity=table_report_verbosity,
         max_plot_columns=max_plot_columns,
@@ -497,8 +448,3 @@ def config_context(
         yield
     finally:
         set_config(**original_config)
-
-
-# Apply patching set by environment variables. Without it, setting SKB_USE_TABLE_REPORT
-# or SKB_USE_TABLE_REPORT_DATA_OPS would not have an effect.
-_apply_external_patches(get_config())

--- a/skrub/_reporting/tests/test_patch_display.py
+++ b/skrub/_reporting/tests/test_patch_display.py
@@ -2,7 +2,7 @@ import pickle
 
 import pytest
 
-from skrub import config_context, patch_display, set_config, unpatch_display
+from skrub import patch_display, unpatch_display
 from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
@@ -52,54 +52,6 @@ def test_patch_display(df_module, repeat_patch, repeat_unpatch, capsys):
             assert capsys.readouterr().err != ""
         finally:
             unpatch_display()
-
-
-@pytest.mark.parametrize("repeat_patch", [1, 2])
-@pytest.mark.parametrize("repeat_unpatch", [1, 2])
-@skip_polars_installed_without_pyarrow
-def test_patch_display_config(df_module, repeat_patch, repeat_unpatch, capsys):
-    df = df_module.make_dataframe(
-        dict(
-            a=[1, 2, 3, 4],
-            b=["one", "two", "three", "four"],
-            c=[11.1, 11.2, 11.3, 11.4],
-        )
-    )
-    assert "<table" in df._repr_html_()
-    assert "<skrub-table-report" not in df._repr_html_()
-
-    set_config(use_table_report=False)
-    assert "<table" in df._repr_html_()
-    assert "<skrub-table-report" not in df._repr_html_()
-    for _ in range(repeat_patch):
-        set_config(use_table_report=True)
-        try:
-            assert "<skrub-table-report" in df._repr_html_()
-            pickle.loads(pickle.dumps(df))
-        finally:
-            for _ in range(repeat_unpatch):
-                set_config(use_table_report=False)
-        pickle.loads(pickle.dumps(df))
-        assert "<table" in df._repr_html_()
-        assert "<skrub-table-report" not in df._repr_html_()
-
-        try:
-            capsys.readouterr()
-            with config_context(use_table_report=True, table_report_verbosity=0):
-                df._repr_html_()
-                assert capsys.readouterr().err == ""
-
-            capsys.readouterr()
-            with config_context(use_table_report=True, table_report_verbosity=None):
-                df._repr_html_()
-                assert capsys.readouterr().err != ""
-
-            capsys.readouterr()
-            with config_context(use_table_report=True, table_report_verbosity=1):
-                df._repr_html_()
-                assert capsys.readouterr().err != ""
-        finally:
-            set_config(use_table_report=False)
 
 
 def test_max_plot_max_assoc_columns_parameter(pd_module):

--- a/skrub/_reporting/tests/test_patch_display.py
+++ b/skrub/_reporting/tests/test_patch_display.py
@@ -6,6 +6,12 @@ from skrub import patch_display, unpatch_display
 from skrub.conftest import skip_polars_installed_without_pyarrow
 
 
+@pytest.fixture(autouse=True)
+def teardown_patch_display():
+    yield
+    unpatch_display()
+
+
 @pytest.mark.parametrize("repeat_patch", [1, 2])
 @pytest.mark.parametrize("repeat_unpatch", [1, 2])
 @skip_polars_installed_without_pyarrow
@@ -61,6 +67,7 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     )
     assert "data-test-plots-skipped" not in df._repr_html_()
     assert "data-test-associations-skipped" not in df._repr_html_()
+    unpatch_display()
 
     df2 = pd_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(30)}
@@ -68,6 +75,7 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     patch_display()
     assert "data-test-plots-skipped" not in df2._repr_html_()
     assert "data-test-associations-skipped" not in df2._repr_html_()
+    unpatch_display()
 
     df3 = pd_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(31)}
@@ -75,6 +83,7 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     patch_display()
     assert "data-test-plots-skipped" in df3._repr_html_()
     assert "data-test-associations-skipped" in df3._repr_html_()
+    unpatch_display()
 
     df4 = pd_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(12)}
@@ -82,6 +91,7 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     patch_display(max_plot_columns=10, max_association_columns=10)
     assert "data-test-plots-skipped" in df4._repr_html_()
     assert "data-test-associations-skipped" in df4._repr_html_()
+    unpatch_display()
 
     df5 = pd_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(12)}
@@ -89,6 +99,7 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     patch_display(max_plot_columns=15, max_association_columns=15)
     assert "data-test-plots-skipped" not in df5._repr_html_()
     assert "data-test-associations-skipped" not in df5._repr_html_()
+    unpatch_display()
 
     df6 = pd_module.make_dataframe(
         {f"col_{i}": [i + j for j in range(3)] for i in range(5)}
@@ -96,3 +107,4 @@ def test_max_plot_max_assoc_columns_parameter(pd_module):
     patch_display(max_plot_columns=None, max_association_columns=None)
     assert "data-test-plots-skipped" not in df6._repr_html_()
     assert "data-test-associations-skipped" not in df6._repr_html_()
+    unpatch_display()

--- a/skrub/tests/test_config.py
+++ b/skrub/tests/test_config.py
@@ -79,14 +79,6 @@ def test_deprecated_env_var_warning(monkeypatch, tmp_path):
             _get_default_data_dir()
 
 
-def test_config_context():
-    assert get_config()["use_table_report_data_ops"] is True
-
-    # Not using as a context manager affects nothing
-    config_context(use_table_report_data_ops=False)
-    assert get_config()["use_table_report_data_ops"] is True
-
-
 def test_use_table_report_data_ops(simple_df):
     X = skrub.X(simple_df)
     with config_context(use_table_report_data_ops=True):

--- a/skrub/tests/test_config.py
+++ b/skrub/tests/test_config.py
@@ -32,7 +32,6 @@ def test_default_config():
     cfg = get_config()
     # Rather than asserting that the dictionary is exactly equal to the hard-coded
     # default values, we check each expected default value individually.
-    assert cfg["use_table_report"] is False
     assert cfg["use_table_report_data_ops"] is True
     # On CI the absolute path is different, check that it ends with skrub_data
     assert pathlib.Path(cfg["data_dir"]).name == "skrub_data"
@@ -49,7 +48,6 @@ def test_default_config():
     # doc/modules/configurations_and_utils/customizing_configurations.rst
     # should also be updated if new configuration keys are added.
     expected_keys = {
-        "use_table_report",
         "use_table_report_data_ops",
         "data_dir",
         "table_report_verbosity",
@@ -82,11 +80,11 @@ def test_deprecated_env_var_warning(monkeypatch, tmp_path):
 
 
 def test_config_context():
-    assert get_config()["use_table_report"] is False
+    assert get_config()["use_table_report_data_ops"] is True
 
     # Not using as a context manager affects nothing
-    config_context(use_table_report=True)
-    assert get_config()["use_table_report"] is False
+    config_context(use_table_report_data_ops=False)
+    assert get_config()["use_table_report_data_ops"] is True
 
 
 def test_use_table_report_data_ops(simple_df):
@@ -95,15 +93,6 @@ def test_use_table_report_data_ops(simple_df):
         assert _use_table_report(X)
         with config_context(use_table_report_data_ops=False):
             assert not _use_table_report(X)
-
-
-@skip_polars_installed_without_pyarrow
-def test_use_table_report(simple_df):
-    assert not _use_table_report(simple_df)
-    with config_context(use_table_report=True):
-        assert _use_table_report(simple_df)
-        with config_context(use_table_report=False):
-            assert not _use_table_report(simple_df)
 
 
 @skip_polars_installed_without_pyarrow
@@ -124,12 +113,6 @@ def test_max_plot_columns(simple_df):
         )
         assert report.max_association_columns == "all"
         assert report.max_plot_columns == "all"
-
-    # Check that max_plot_columns can be set after patching the TableReport
-    # repr_html.
-    with config_context(use_table_report=True):
-        with config_context(max_plot_columns=1):
-            assert "Plotting was skipped" in simple_df._repr_html_()
 
 
 def test_enable_subsampling(simple_df):
@@ -177,7 +160,6 @@ def test_float_precision(simple_series):
 @pytest.mark.parametrize(
     "params",
     [
-        {"use_table_report": "hello"},
         {"use_table_report_data_ops": 1},
         {"max_plot_columns": "hello"},
         {"max_association_columns": "hello"},


### PR DESCRIPTION

## Description
This PR removes the "use_table_report" configuration parameter. This config parameter is patching over the default behavior of pandas and polars dataframes in a non-transparent way. 

Given it is a big change, it's better if the user changes this using patch_display and unpatch_display instead. 

For the moment I have kept the data ops version of this parameter, but maybe we should remove both. 