### PR TITLE
CHORE - Silencing a deprecation warning in nightlies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,6 +327,8 @@ filterwarnings = [
   'ignore:.*Attribute n is deprecated.*:DeprecationWarning',
   # FIXME we need to decided what to do with pyarrow that is required by pandas >= 3.0
   'ignore:(?s).*Pyarrow will become a required dependency of pandas.*:DeprecationWarning',
+  # Ignore pandas warning about converting Series of length 1 to scalar
+  'ignore:Converting a Series or array of length 1 into a scalar is deprecated.*',
   # accessing .values on a pandas dataframe raises this warning after numpy 1.25;
   # should be addressed in pandas
   'ignore:np.find_common_type is deprecated.*:DeprecationWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -328,6 +328,7 @@ filterwarnings = [
   # FIXME we need to decided what to do with pyarrow that is required by pandas >= 3.0
   'ignore:(?s).*Pyarrow will become a required dependency of pandas.*:DeprecationWarning',
   # Ignore pandas warning about converting Series of length 1 to scalar
+  # https://github.com/skrub-data/skrub/pull/1974
   'ignore:Converting a Series or array of length 1 into a scalar is deprecated.*',
   # accessing .values on a pandas dataframe raises this warning after numpy 1.25;
   # should be addressed in pandas


### PR DESCRIPTION
Nightlies are failing because of a pandas 4.0 deprecation warning in the joiners.

Example: https://github.com/skrub-data/skrub/actions/runs/23178427828

Given this is a long term warning and we might be done with the joiners by the time pandas 4.0 gets released, we can silence this in the meanitme. 