### PR TITLE
Update docs to add link to quickstart example 

### DIFF
--- a/doc/documentation.rst
+++ b/doc/documentation.rst
@@ -6,9 +6,10 @@ User Guide
 Skrub is a Python library that facilitates machine learning with tabular data
 (dataframes, such as pandas and polars) using a scikit-learn-compatible API.
 
-Use the sections below to navigate the guide. For runnable code, see the
-:doc:`Example gallery <auto_examples/index>`. For class and function details, see
-the :ref:`API Reference <api_ref>`.
+Use the sections below to navigate the guide. For a quickstart example,
+try :ref:`Getting Started <sphx_glr_auto_examples_0000_getting_started.py>`.
+For runnable code, see the :doc:`Example gallery <auto_examples/index>`.
+For class and function details, see the :ref:`API Reference <api_ref>`.
 
 
 .. include:: includes/big_toc_css.rst


### PR DESCRIPTION
This PR just adds a link to the first example in the Examples section of the documentation, to the User Guide section. This just boosts the visibility of the Getting Started example for new users.
