### PR TITLE
FiX - fixing a broken example

### DIFF
--- a/examples/0090_apply_to_cols.py
+++ b/examples/0090_apply_to_cols.py
@@ -24,13 +24,13 @@ and transforming dataframe columns using arbitrary logic.
 
 # %%
 # We begin with loading a dataset with heterogeneous datatypes, and replacing Pandas's
-# display with the TableReport display via :func:`skrub.set_config`.
+# display with the TableReport display via :func:`skrub.patch_display`.
 import pandas as pd
 
 import skrub
 from skrub.datasets import fetch_employee_salaries
 
-skrub.set_config(use_table_report=True)
+skrub.patch_display()
 file_path = fetch_employee_salaries().path
 data = pd.read_csv(file_path)
 X = data.drop(columns="current_annual_salary")


### PR DESCRIPTION
#1973 broke one of the examples because it was using set_config(use_table_report), which has now been removed. This PR fixes the broken example by replacing the line with patch_display