### PR TITLE
DOC Fix broken formatting in cross_validate environment parameter

### DIFF
--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2532,7 +2532,7 @@ class SkrubNamespace:
         ----------
         environment : dict or None
             Bindings for variables contained in the DataOp plan. If not
-            provided, the ``value``s passed when initializing ``var()`` are
+            provided, the values passed when initializing ``var()`` are
             used.
 
         keep_subsampling : bool, default=False


### PR DESCRIPTION
Addresses #1957

## Description

Fixes broken RST formatting in the `environment` parameter docstring 
of `DataOp.skb.cross_validate`. The phrase `the ``value``s` used mixed 
backtick syntax which broke rendering in the documentation.

## How Has This Been Tested?

Ran `pre-commit run --all-files`  all checks passed (ruff, codespell, RST checks).

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## AI Disclosure
- [] This PR contains AI-generated code
    - [] I have tested the code generated in my PR
    - [] I have read and understood every line that has been generated by the AI agent
    - [] I can explain what the AI-generated code does