### PR TITLE
FIX - deprecation warning when detecting a date in pandas 4.0

### DIFF
--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -48,7 +48,7 @@ def _is_date(col):
 @_is_date.specialize("pandas", argument_type="Column")
 def _is_date_pandas(col):
     col = sbd.drop_nulls(col)
-    return (col.dt.date == col).all()
+    return (col.dt.normalize() == col).all()
 
 
 @_is_date.specialize("polars", argument_type="Column")


### PR DESCRIPTION
In Pandas 4.0, the code that is used to check whether a datetime column contains only dates will be deprecated, and this causes nightlies to fail.

This PR changes the check from

```python
def _is_date_pandas(col):
    col = sbd.drop_nulls(col)
    return (col.dt.date == col).all()
```

to
```python
def _is_date_pandas(col):
    col = sbd.drop_nulls(col)
    return (col.dt.normalize() == col).all()
```

and this fixes the problem.

The change works also for older versions, so it's a simple fix overall. 