### PR TITLE
FIX - fixing behavior of DropUninformative for datetime columns

### DIFF
--- a/skrub/_drop_uninformative.py
+++ b/skrub/_drop_uninformative.py
@@ -22,8 +22,9 @@ class DropUninformative(SingleColumnTransformer):
 
     drop_if_unique : bool, default=False
         If True, drop the column if all values are distinct. Missing values count as
-        one additional distinct value. Numeric columns are never dropped. This may
-        lead to dropping columns that contain free-flowing text.
+        one additional distinct value. Numeric and datetime columns are never dropped.
+        Note that activating this parameter may lead to dropping columns that contain
+        free-flowing text, or string columns that contain datetimes.
 
     drop_null_fraction : float or None, default=1.0
         Drop columns with a fraction of missing values larger than threshold. If None,
@@ -126,7 +127,9 @@ class DropUninformative(SingleColumnTransformer):
         return False
 
     def _drop_if_unique(self, column):
-        if self.drop_if_unique and not sbd.is_numeric(column):
+        if self.drop_if_unique and not (
+            sbd.is_numeric(column) or sbd.is_any_date(column)
+        ):
             n_unique = sbd.n_unique(column)
             if self._null_count > 0:
                 return False

--- a/skrub/tests/test_drop_uninformative.py
+++ b/skrub/tests/test_drop_uninformative.py
@@ -1,3 +1,5 @@
+import datetime
+
 import numpy as np
 import pytest
 
@@ -188,6 +190,24 @@ def drop_id_column(df_module):
                 None,
             ],
             "variable": ["A", "B", "B"],
+            "datetime_str": [
+                "2020-01-01 00:01:02",
+                "2020-01-02 00:01:02",
+                "2020-01-03 00:01:02",
+            ],
+            "datetime_str_with_nulls": [
+                "2020-01-01 00:01:02",
+                "2020-01-02 00:01:02",
+                None,
+            ],
+            "datetime-col": [
+                datetime.datetime.fromisoformat(dt)
+                for dt in [
+                    "2020-02-03T12:30:05",
+                    "2021-03-15T00:37:15",
+                    "2022-02-13T17:03:25",
+                ]
+            ],
         }
     )
 
@@ -198,7 +218,7 @@ def test_drop_id(df_module, drop_id_column, drop_if_unique):
     for column in drop_id_column.columns:
         res = enc.fit_transform(drop_id_column[column])
         # Check that "str" is the only column that gets dropped
-        if column == "str" and drop_if_unique:
+        if column in ["str", "datetime_str"] and drop_if_unique:
             assert res == []
         else:
             df_module.assert_column_equal(res, df_module.make_column(column, res))


### PR DESCRIPTION
This PR is slightly altering the behavior of DropUninformative when `drop_if_unique=True` so that it ignores datetime columns the same way it ignores numeric columns.

In the stable branch, if the parameter is set to True then the transformer will drop columns that contain no null values and all other values are unique, except in the case the columns are numbers. This means that unique datetimes are also dropped, which I think is unintended behavior.

The PR is addressing this by not dropping datetime columns, however as I was working on this I started wondering whether we should alter the behavior in the other direction, so that if `drop_if_unique=True` then _all columns_ are dropped regardless of dtype (and possibly presence of nulls?). I wonder if this behavior would be simpler to explain, rather than having to specify the conditions: if the flag is on, any column where everything is unique is fair game. Then, users can always use ApplyToCols to exclude specific columns. 