### PR TITLE
ENH: add exclude_cols to ApplyToCols (#1873)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Changes
 - :class:`ApplyToCols` now accepts an ``exclude_cols`` parameter, making it
   possible to transform the columns selected by ``cols`` except for an
   explicit subset, mirroring :meth:`DataOp.skb.apply`.
+  :pr:`2039` by :user:`Saba Siddique <sabasiddique1>`.
 
 Bugfixes
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Changes
   the nearest-neighbor distance used for matching. The metric can be any value
   supported by :class:`~sklearn.neighbors.NearestNeighbors` (see its docstring).
   :pr:`1861` by :user:`Saba Siddique <sabasiddique1>`.
+- :class:`ApplyToCols` now accepts an ``exclude_cols`` parameter, making it
+  possible to transform the columns selected by ``cols`` except for an
+  explicit subset, mirroring :meth:`DataOp.skb.apply`.
 
 Bugfixes
 --------

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -184,10 +184,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
     transform all numeric columns except ``"C"``:
 
     >>> scaler = ApplyToCols(StandardScaler(), cols=s.numeric(), exclude_cols="C")
-    >>> scaler.fit_transform(df)                                     # doctest: +SKIP
-        C   city                   D    A    B
-    0  19  Paris 2024-05-13 12:05:36 -1.0 -1.0
-    1  20   Rome 2024-05-15 13:46:02  1.0  1.0
+    >>> scaler.fit_transform(df)  # doctest: +SKIP
 
 
     It is possible to set ``allow_reject=True`` to allow the transformer to reject

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -33,11 +33,15 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         The transformer to apply to the selected columns.
 
     cols : str, sequence of str, or skrub selector, optional
-        The columns to attempt to transform. Only the selected columns will have
-        the transformer applied. Columns outside this selection are passed
-        through unchanged (``fit_transform`` is not called on them) and remain
-        unmodified in the output. The default is to attempt transforming all
-        columns.
+        The columns to attempt to transform. The transformer is applied to the
+        columns matched by ``cols`` and not matched by ``exclude_cols``.
+        Columns outside this selection are passed through unchanged
+        (``fit_transform`` is not called on them) and remain unmodified in the
+        output. The default is to attempt transforming all columns.
+
+    exclude_cols : str, sequence of str, or skrub selector, optional
+        Columns to exclude from transformation. The transformed columns are the
+        ones matched by ``cols`` and not matched by ``exclude_cols``.
 
     allow_reject : bool, default=False
         Whether to allow refusing to transform columns for which the provided
@@ -104,8 +108,9 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
 
     Notes
     -----
-    All columns not listed in ``cols`` remain unmodified in the output.
-    Moreover, if ``allow_reject`` is ``True`` and the transformers'
+    All columns not selected by ``cols`` or matched by ``exclude_cols`` remain
+    unmodified in the output. Moreover, if ``allow_reject`` is ``True`` and
+    the transformers'
     ``fit_transform`` raises a :class:`~core.RejectColumn` exception for a particular
     column, that column is passed through unchanged. If ``allow_reject`` is
     ``False``, :class:`~core.RejectColumn` exceptions are propagated, like other errors
@@ -174,6 +179,15 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         city                   D    A    B    C
     0  Paris 2024-05-13 12:05:36 -1.0 -1.0 -1.0
     1   Rome 2024-05-15 13:46:02  1.0  1.0  1.0
+
+    We can also exclude columns from a broader selection. For example, to
+    transform all numeric columns except ``"C"``:
+
+    >>> scaler = ApplyToCols(StandardScaler(), cols=s.numeric(), exclude_cols="C")
+    >>> scaler.fit_transform(df)                                     # doctest: +SKIP
+        C   city                   D    A    B
+    0  19  Paris 2024-05-13 12:05:36 -1.0 -1.0
+    1  20   Rome 2024-05-15 13:46:02  1.0  1.0
 
 
     It is possible to set ``allow_reject=True`` to allow the transformer to reject
@@ -281,6 +295,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
         transformer,
         cols=_SELECT_ALL_COLUMNS,
         *,
+        exclude_cols=None,
         allow_reject=False,
         keep_original=False,
         rename_columns="{}",
@@ -288,6 +303,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
     ):
         self.transformer = transformer
         self.cols = cols
+        self.exclude_cols = exclude_cols
         self.n_jobs = n_jobs
         self.allow_reject = allow_reject
         self.keep_original = keep_original
@@ -348,9 +364,13 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
                 "Expected a boolean."
             )
 
+        cols = self.cols
+        if self.exclude_cols is not None:
+            cols = selectors.make_selector(cols) - self.exclude_cols
+
         self._wrapped_transformer = wrap_transformer(
             self.transformer,
-            self.cols,
+            cols,
             allow_reject=self.allow_reject,
             keep_original=self.keep_original,
             rename_columns=self.rename_columns,

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -183,8 +183,12 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
     We can also exclude columns from a broader selection. For example, to
     transform all numeric columns except ``"C"``:
 
-    >>> scaler = ApplyToCols(StandardScaler(), cols=s.numeric(), exclude_cols="C")
-    >>> scaler.fit_transform(df)  # doctest: +SKIP
+    >>> exc_scaler = ApplyToCols(StandardScaler(), cols=s.numeric(), exclude_cols="C")
+    >>> df_enc = exc_scaler.fit_transform(df)  # doctest: +SKIP
+    >>> df_enc  # doctest: +SKIP
+        C   city                   D    A    B
+    0  19  Paris 2024-05-13 12:05:36 -1.0 -1.0
+    1  20   Rome 2024-05-15 13:46:02  1.0  1.0
 
 
     It is possible to set ``allow_reject=True`` to allow the transformer to reject

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -3,7 +3,7 @@ import datetime
 import numpy as np
 import pytest
 from sklearn.exceptions import NotFittedError
-from sklearn.preprocessing import OrdinalEncoder
+from sklearn.preprocessing import OrdinalEncoder, StandardScaler
 
 from skrub import ApplyToCols
 from skrub import _dataframe as sbd
@@ -83,6 +83,62 @@ def test_column_selection_with_selector(df_module):
     # Check that numeric columns were unchanged
     assert np.array_equal(sbd.col(X_transformed, "numeric1"), [1.0, 2.0, 3.0])
     assert np.array_equal(sbd.col(X_transformed, "numeric2"), [10.0, 20.0, 30.0])
+
+
+def test_exclude_single_column(df_module):
+    at = ApplyToCols(OrdinalEncoder(), exclude_cols="col2")
+    X = df_module.make_dataframe(
+        {"col1": ["a", "b", "c"], "col2": ["x", "y", "z"]}
+    )
+
+    X_transformed = at.fit_transform(X)
+
+    assert np.array_equal(
+        sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2]
+    )
+    assert sbd.to_list(sbd.col(X_transformed, "col2")) == ["x", "y", "z"]
+
+
+def test_exclude_multiple_columns(df_module):
+    at = ApplyToCols(OrdinalEncoder(), exclude_cols=["col2", "col3"])
+    X = df_module.make_dataframe(
+        {
+            "col1": ["a", "b", "c"],
+            "col2": ["x", "y", "z"],
+            "col3": ["m", "n", "o"],
+        }
+    )
+
+    X_transformed = at.fit_transform(X)
+
+    assert np.array_equal(
+        sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2]
+    )
+    assert sbd.to_list(sbd.col(X_transformed, "col2")) == ["x", "y", "z"]
+    assert sbd.to_list(sbd.col(X_transformed, "col3")) == ["m", "n", "o"]
+
+
+def test_cols_selector_with_excluded_column(df_module):
+    at = ApplyToCols(StandardScaler(), cols=s.numeric(), exclude_cols="id")
+    X = df_module.make_dataframe(
+        {
+            "id": [1, 2],
+            "value1": [10.0, 20.0],
+            "value2": [100.0, 300.0],
+            "name": ["a", "b"],
+        }
+    )
+
+    X_transformed = at.fit_transform(X)
+
+    assert np.array_equal(sbd.to_numpy(sbd.col(X_transformed, "id")), [1, 2])
+    assert np.allclose(
+        sbd.to_numpy(sbd.col(X_transformed, "value1")), [-1.0, 1.0]
+    )
+    assert np.allclose(
+        sbd.to_numpy(sbd.col(X_transformed, "value2")), [-1.0, 1.0]
+    )
+    assert sbd.to_list(sbd.col(X_transformed, "name")) == ["a", "b"]
 
 
 def test_fit_and_transform_separate(df_module):

--- a/skrub/tests/test_apply_to_cols.py
+++ b/skrub/tests/test_apply_to_cols.py
@@ -89,15 +89,11 @@ def test_column_selection_with_selector(df_module):
 
 def test_exclude_single_column(df_module):
     at = ApplyToCols(OrdinalEncoder(), exclude_cols="col2")
-    X = df_module.make_dataframe(
-        {"col1": ["a", "b", "c"], "col2": ["x", "y", "z"]}
-    )
+    X = df_module.make_dataframe({"col1": ["a", "b", "c"], "col2": ["x", "y", "z"]})
 
     X_transformed = at.fit_transform(X)
 
-    assert np.array_equal(
-        sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2]
-    )
+    assert np.array_equal(sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2])
     assert sbd.to_list(sbd.col(X_transformed, "col2")) == ["x", "y", "z"]
 
 
@@ -113,9 +109,7 @@ def test_exclude_multiple_columns(df_module):
 
     X_transformed = at.fit_transform(X)
 
-    assert np.array_equal(
-        sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2]
-    )
+    assert np.array_equal(sbd.to_numpy(sbd.col(X_transformed, "col1")), [0, 1, 2])
     assert sbd.to_list(sbd.col(X_transformed, "col2")) == ["x", "y", "z"]
     assert sbd.to_list(sbd.col(X_transformed, "col3")) == ["m", "n", "o"]
 
@@ -134,12 +128,8 @@ def test_cols_selector_with_excluded_column(df_module):
     X_transformed = at.fit_transform(X)
 
     assert np.array_equal(sbd.to_numpy(sbd.col(X_transformed, "id")), [1, 2])
-    assert np.allclose(
-        sbd.to_numpy(sbd.col(X_transformed, "value1")), [-1.0, 1.0]
-    )
-    assert np.allclose(
-        sbd.to_numpy(sbd.col(X_transformed, "value2")), [-1.0, 1.0]
-    )
+    assert np.allclose(sbd.to_numpy(sbd.col(X_transformed, "value1")), [-1.0, 1.0])
+    assert np.allclose(sbd.to_numpy(sbd.col(X_transformed, "value2")), [-1.0, 1.0])
     assert sbd.to_list(sbd.col(X_transformed, "name")) == ["a", "b"]
 
 


### PR DESCRIPTION
# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

Add support for an `exclude_cols` parameter in `ApplyToCols` to simplify applying a transformer to all columns except a given subset.

This avoids requiring users to explicitly use selector expressions like `s.all() - "col"` and aligns the behavior with the existing `.skb.apply` API.

Internally, this is implemented by computing:

```
cols = make_selector(cols) - exclude_cols
```

before passing the result to `wrap_transformer`.

Addresses #1873

---

## Checklist

* [x] I have read the contributing guidelines
* [x] I have added tests that verify the change
* [x] I have added an entry to CHANGES.rst describing the change
* [x] My code follows the code style of this project
* [x] I have checked my code and corrected any misspellings

---

## How Has This Been Tested?

Added tests in `skrub/tests/test_apply_to_cols.py` to verify:

* excluding a single column
* excluding multiple columns
* correct behavior when combining `cols` selector with `exclude_cols`

Tests were executed using:

```
python -m pytest skrub/tests/test_apply_to_cols.py
```

All tests passed successfully.

---

## AI Disclosure

* [x] This PR contains AI-generated code

  * [x] I have tested the code generated in my PR
  * [x] I have read and understood every line that has been generated by the AI agent
  * [x] I can explain what the AI-generated code does