### PR TITLE
MAINT - deprecating drop_if_unique

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,8 @@ Bugfixes
 
 Deprecations
 ------------
-
+- The parameter ``drop_if_unique`` of :class:`Cleaner` and :class:`DropUninformative`
+  has been deprecated. :pr:`2040` by :user:`Riccardo Cappuzzo <rcap107>`.
 
 Release 0.8.0
 =============

--- a/doc/modules/multi_column_operations/drop_uninformative.rst
+++ b/doc/modules/multi_column_operations/drop_uninformative.rst
@@ -25,11 +25,6 @@ using various heuristics. These heuristics include:
   is set to ``False`` by default. Note that missing values are treated as distinct
   values, so constant columns with missing values will not be dropped.
 
-- **Dropping unique string/categorical columns**: Columns where each row has a
-  unique value (e.g., alphanumeric IDs) can be dropped. This is controlled by the
-  ``drop_if_unique`` parameter, which is ``False`` by default. Be cautious when
-  enabling this option, as it may remove columns containing free-flowing text.
-
 |DropUninformative| is used by both |TableVectorizer| and |Cleaner|, and both
 accept the same parameters for dropping columns.
 
@@ -84,58 +79,29 @@ Consider the following dataset:
 ...     'treatment': ['med_A', 'med_B', 'med_C', 'med_D', 'med_E', 'med_F', 'med_G', 'med_H']
 ... })
 
-We can drop columns with more than 50% missing values:
-
->>> cleaner = ApplyToCols(DropUninformative(drop_null_fraction=0.5))
->>> cleaned_df = cleaner.fit_transform(df)
->>> cleaned_df
-   patient_id   age treatment
-0           1  25.0     med_A
-1           2  30.0     med_B
-2           3   ...     med_C
-3           4  45.0     med_D
-4           5  50.0     med_E
-5           6   ...     med_F
-6           7  60.0     med_G
-7           8  65.0     med_H
-
-
-
 Applying |DropUninformative| only to a subset of columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+We can apply the |DropUninformative| transformer to specific columns using
+|ApplyToCols| and the skrub selectors. In this case, we want to drop columns with
+more than 50% missing values, but only if they have ``string`` type:
+
+>>> import skrub.selectors as s
+>>> cleaner = ApplyToCols(DropUninformative(drop_null_fraction=0.5), cols=s.string())
+>>> cleaned_df = cleaner.fit_transform(df)
+>>> cleaned_df
+   patient_id   age  blood_pressure treatment
+0           1  25.0           120.0     med_A
+1           2  30.0             NaN     med_B
+2           3   NaN             NaN     med_C
+3           4  45.0             NaN     med_D
+4           5  50.0           140.0     med_E
+5           6   NaN             NaN     med_F
+6           7  60.0             NaN     med_G
+7           8  65.0           150.0     med_H
+
+
 You can apply the |DropUninformative| transformer to specific columns using
-|ApplyToCols|.
-
->>> from skrub import ApplyToCols
->>> df = pd.DataFrame({
-... "id_to_drop": ["A1", "A2", "A3"],
-... "text_to_keep": ["foo", "bar", "baz"]
-... })
->>> df
-  id_to_drop text_to_keep
-0         A1          foo
-1         A2          bar
-2         A3          baz
-
-Dropping unique columns in this dataframe results in an empty dataframe:
-
->>> cleaner = Cleaner(drop_if_unique=True)
->>> cleaner.fit_transform(df)
-Empty DataFrame
-Columns: []
-Index: [0, 1, 2]
-
-To apply the transformer only to the ``id_to_drop`` column, use |ApplyToCols|:
-
->>> ApplyToCols(cleaner, cols="id_to_drop")
-ApplyToCols(cols='id_to_drop', transformer=Cleaner(drop_if_unique=True))
->>> ApplyToCols(cleaner, cols="id_to_drop").fit_transform(df)
-  text_to_keep
-0          foo
-1          bar
-2          baz
-
 For more advanced filtering operations, refer to the User Guide on
 :ref:`user_guide_selectors` and the |ApplyToCols| documentation for details
 on applying transformers to specific columns.

--- a/skrub/_drop_uninformative.py
+++ b/skrub/_drop_uninformative.py
@@ -1,4 +1,5 @@
 import numbers
+import warnings
 
 from sklearn.utils.validation import check_is_fitted
 
@@ -20,11 +21,6 @@ class DropUninformative(SingleColumnTransformer):
         If True, drop the column if it contains only one unique value. Missing values
         count as one additional distinct value.
 
-    drop_if_unique : bool, default=False
-        If True, drop the column if all values are distinct. Missing values count as
-        one additional distinct value. Numeric columns are never dropped. This may
-        lead to dropping columns that contain free-flowing text.
-
     drop_null_fraction : float or None, default=1.0
         Drop columns with a fraction of missing values larger than threshold. If None,
         keep the column even if all its values are missing.
@@ -45,10 +41,6 @@ class DropUninformative(SingleColumnTransformer):
       all values must be null for the column to be dropped).
     - The column includes only one unique value (the column is constant). Missing
       values are considered a separate value.
-    - The number of unique values in the column is equal to the length of the
-      column, i.e., all values are unique. This is only considered for non-numeric
-      columns. Missing values are considered a separate value. Note that this
-      may lead to dropping columns that contain free-flowing text.
 
     Examples
     --------
@@ -71,14 +63,6 @@ class DropUninformative(SingleColumnTransformer):
     []
     >>> du.fit_transform(df["col2"])
     []
-
-    Finally, it is possible to set ``drop_if_unique`` to ``True`` in order to drop
-    string columns that contain all distinct values:
-
-    >>> df = pd.DataFrame({"col1": ["A", "B", "C"]})
-    >>> du = DropUninformative(drop_if_unique=True)
-    >>> du.fit_transform(df["col1"])
-    []
     """
 
     def __init__(
@@ -95,6 +79,13 @@ class DropUninformative(SingleColumnTransformer):
         if not isinstance(self.drop_if_constant, bool):
             raise TypeError(
                 f"drop_if_constant must be boolean, found {self.drop_if_constant}."
+            )
+        if self.drop_if_unique is not False:
+            warnings.warn(
+                "The `drop_if_unique` parameter of `DropUninformative` is deprecated"
+                " and will be removed in a future version.",
+                DeprecationWarning,
+                stacklevel=3,
             )
         if not isinstance(self.drop_if_unique, bool):
             raise TypeError(

--- a/skrub/_drop_uninformative.py
+++ b/skrub/_drop_uninformative.py
@@ -25,6 +25,13 @@ class DropUninformative(SingleColumnTransformer):
         Drop columns with a fraction of missing values larger than threshold. If None,
         keep the column even if all its values are missing.
 
+    drop_if_unique : bool, default=False
+        If True, drop the column if all values are unique (i.e. the
+        number of unique values is equal to the number of rows). Missing values
+        do not count as unique values for this criterion.
+
+        .. deprecated:: 0.9.0
+
     See Also
     --------
     Cleaner :

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -184,6 +184,8 @@ class Cleaner(TransformerMixin, BaseEstimator):
         of unique values is equal to the number of rows in the column. Numeric columns
         are never dropped.
 
+        .. deprecated:: 0.9.0
+
     datetime_format : str, default=None
         The format to use when parsing dates. If None, the format is inferred.
 
@@ -247,12 +249,10 @@ class Cleaner(TransformerMixin, BaseEstimator):
 
     - :class:`DropUninformative`: drop the column if it is considered to be
       "uninformative". A column is considered to be "uninformative" if it contains
-      only missing values (``drop_null_fraction``), only a constant value
-      (``drop_if_constant``), or if all values are distinct (``drop_if_unique``).
+      only missing values (``drop_null_fraction``) or only a constant value
+      (``drop_if_constant``).
       By default, the ``Cleaner`` keeps all columns, unless they contain only
       missing values.
-      Note that setting ``drop_if_unique`` to ``True`` may lead to dropping columns
-      that contain text.
 
     - ``ToDatetime()``: parse datetimes represented as strings and return them as
       actual datetimes with the correct dtype. If ``datetime_format`` is provided,

--- a/skrub/tests/test_drop_uninformative.py
+++ b/skrub/tests/test_drop_uninformative.py
@@ -95,7 +95,10 @@ def test_error_checking(drop_null_table):
     with pytest.raises(TypeError, match="drop_if_constant"):
         dn.fit_transform(sbd.col(drop_null_table, "value_nan"))
     dn = DropUninformative(drop_if_unique="wrong")
-    with pytest.raises(TypeError, match="drop_if_unique"):
+    with (
+        pytest.warns(DeprecationWarning),
+        pytest.raises(TypeError, match="drop_if_unique"),
+    ):
         dn.fit_transform(sbd.col(drop_null_table, "value_nan"))
     dn = DropUninformative(drop_null_fraction="wrong")
     with pytest.raises(ValueError, match="Threshold"):
@@ -192,11 +195,20 @@ def drop_id_column(df_module):
     )
 
 
+def test_drop_if_unique_deprecation(drop_id_column):
+    with pytest.warns(DeprecationWarning, match="drop_if_unique.*deprecated"):
+        DropUninformative(drop_if_unique=True).fit_transform(drop_id_column["str"])
+
+
 @pytest.mark.parametrize("drop_if_unique", [True, False])
 def test_drop_id(df_module, drop_id_column, drop_if_unique):
     enc = DropUninformative(drop_if_unique=drop_if_unique)
     for column in drop_id_column.columns:
-        res = enc.fit_transform(drop_id_column[column])
+        if drop_if_unique:
+            with pytest.warns(DeprecationWarning):
+                res = enc.fit_transform(drop_id_column[column])
+        else:
+            res = enc.fit_transform(drop_id_column[column])
         # Check that "str" is the only column that gets dropped
         if column == "str" and drop_if_unique:
             assert res == []

--- a/skrub/tests/test_table_vectorizer.py
+++ b/skrub/tests/test_table_vectorizer.py
@@ -486,6 +486,12 @@ def test_cleaner_invalid_numeric_dtype(df_module):
         Cleaner(numeric_dtype="wrong").fit_transform(X)
 
 
+def test_cleaner_drop_if_unique_deprecation(df_module):
+    X = df_module.make_dataframe({"a": ["x", "y", "z"], "b": [1, 2, 3]})
+    with pytest.warns(DeprecationWarning, match="drop_if_unique.*deprecated"):
+        Cleaner(drop_if_unique=True).fit_transform(X)
+
+
 def test_cleaner_get_feature_names_out(df_module):
     """Test that Cleaner.get_feature_names_out returns the correct column names."""
     X = _get_clean_dataframe(df_module)


### PR DESCRIPTION
Follow-up of #2037. After IRL discussions, we reached the conclusion that `drop_if_unique` is unlikely to bring value and may actually cause harm as it drops informative columns. This PR deprecates the functionality. 