### PR TITLE
add methods to find a node in a dataop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ New Features
   :class:`ParamSearch` and :class:`OptunaParamSearch` have been improved and now
   display the :class:`DataOp` they contain. :pr:`2024` by :user:`Jérôme Dockès
   <jeromedockes>`.
+- The method :meth:`DataOp.skb.find` can find a node by name (or by a callable
+  predicate) in a DataOp. The method :meth:`DataOp.skb.find_X_y` finds the nodes
+  marked with :meth:`DataOp.skb.mark_as_X` and :meth:`DataOp.skb.mark_as_y`, and
+  the ``cv`` splitter and ``split_kwargs`` passed to
+  :meth:`DataOp.skb.mark_as_X`, if they exist. :pr:`2041`
+  by :user:`Jérôme Dockès <jeromedockes>`.
 
 Changes
 -------

--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -253,6 +253,8 @@ API_REFERENCE = {
                     "DataOp.skb.subsample",
                     "DataOp.skb.train_test_split",
                     "DataOp.skb.with_scoring",
+                    "DataOp.skb.find",
+                    "DataOp.skb.find_X_y",
                 ],
                 "template": "autosummary/accessor_method.rst",
             },

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -17,16 +17,15 @@ from .. import _join_utils
 from .._sklearn_compat import _safe_indexing, _VisualBlock
 from .._utils import set_module
 from ._choosing import BaseNumericChoice, get_default
-from ._data_ops import Apply, DataOp, Scoring, SplitX, check_subsampled_X_y_shape
+from ._data_ops import Apply, DataOp, as_data_op, check_subsampled_X_y_shape
 from ._evaluation import (
     choice_graph,
     eval_choices,
     evaluate,
     find_first_apply,
-    find_node,
     find_node_by_name,
-    find_X,
-    find_y,
+    find_scoring_node,
+    find_X_y_and_cv,
     get_params,
     param_grid,
     set_params,
@@ -176,13 +175,6 @@ class _DataOpWrapperMixin(_CloudPickle):
         return _SklearnParamsReprHtml(html)
 
 
-def _find_scoring_node(data_op):
-    return find_node(
-        data_op,
-        lambda o: isinstance(o, DataOp) and isinstance(o._skrub_impl, Scoring),
-    )
-
-
 @set_module("skrub")
 class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
     """Learner that evaluates a skrub DataOp.
@@ -288,7 +280,7 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         return result
 
     def _score(self, environment):
-        score_node = _find_scoring_node(self.data_op)
+        score_node = find_scoring_node(self.data_op)
         if score_node is None:
             return self._eval_in_mode("score", environment)
         estimator = self.__skrub_to_Xy_pipeline__(environment)
@@ -476,7 +468,7 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
             )
         return node._skrub_impl.estimator_
 
-    def truncated_after(self, name):
+    def truncated_after(self, what):
         """Extract the part of the learner that leads up to the given step.
 
         This is similar to slicing a scikit-learn pipeline. It can be useful
@@ -484,18 +476,29 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         task but then extract only the part of the learner that performs
         feature extraction.
 
-        The target step must have been given a name with ``.skb.set_name()``.
-
         Parameters
         ----------
-        name : str
-            The name of the intermediate step we want to extract.
+        what : str or callable
+            - If a string, it is the name (set with
+              :meth:`DataOp.skb.set_name`) of the step we want to extract.
+            - If a callable, it is the search predicate: it accepts a DataOp
+              and returns a Boolean. The first node for which it returns True
+              is returned.
 
         Returns
         -------
         SkrubLearner
             A skrub learner that performs all the transformations leading up to
             (and including) the required step.
+
+        See Also
+        --------
+        DataOp.skb.find
+            Search for a node directly from a DataOp rather than a SkrubLearner.
+
+        DataOp.skb.find_X_y
+            Find the nodes that have been marked with
+            :meth:`DataOp.skb.mark_as_X` and :meth:`DataOp.skb.mark_as_y`.
 
         Examples
         --------
@@ -544,9 +547,12 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         >>> learner.find_fitted_estimator("vectorizer")
         ApplyToSubFrame(transformer=TableVectorizer(datetime=DatetimeEncoder(add_total_seconds=False)))
         """  # noqa: E501
-        node = find_node_by_name(self.data_op, name)
+        node = self.data_op.skb.find(what)
         if node is None:
-            raise KeyError(name)
+            raise ValueError(f"No node matching {what!r} could be found.")
+        if not isinstance(node, DataOp):
+            # If the found node is a choice, wrap it in a DataOp
+            node = as_data_op(node)
         new = self.__class__(node)
         _copy_attr(self, new, ["_is_fitted"])
         return new
@@ -672,7 +678,7 @@ class _XyPipeline(_XyPipelineMixin, SkrubLearner):
         return [(name, scorer_output)]
 
     def _score(self, X, y=None, cast_to_float=True):
-        score_node = _find_scoring_node(self.data_op)
+        score_node = find_scoring_node(self.data_op)
         if score_node is None:
             return self._eval_in_mode("score", X, y)
         env = self._get_env(X, y)
@@ -693,31 +699,17 @@ class _XyPipeline(_XyPipelineMixin, SkrubLearner):
         return result
 
 
-def _find_X_y_and_cv(data_op):
-    """Find the nodes marked with `.skb.mark_as_X()` and `.skb.mark_as_y()`"""
-    x_node = find_X(data_op)
-    if x_node is None:
+def _compute_X_y_and_cv(data_op, environment):
+    """Evaluate the nodes marked with `.skb.mark_as_X()` and `.skb.mark_as_y()`."""
+    nodes = find_X_y_and_cv(data_op.skb.clone())
+    if "X" not in nodes:
         raise ValueError('DataOp should have a node marked with "mark_as_X()"')
-    result = {"X": x_node}
-    if isinstance(x_node._skrub_impl, SplitX):
-        result["cv"] = x_node._skrub_impl.cv
-        result["split_kwargs"] = x_node._skrub_impl.split_kwargs
-    if (y_node := find_y(data_op)) is not None:
-        result["y"] = y_node
-    else:
+    if "y" not in nodes:
         first = find_first_apply(data_op)
-        if first is None:
-            return result
-        if getattr(first._skrub_impl, "y", None) is not None:
+        if first is not None and getattr(first._skrub_impl, "y", None) is not None:
             # the estimator requests a y so some node must have been
             # marked as y
             raise ValueError('DataOp should have a node marked with "mark_as_y()"')
-    return result
-
-
-def _compute_X_y_and_cv(data_op, environment):
-    """Evaluate the nodes marked with `.skb.mark_as_X()` and `.skb.mark_as_y()`."""
-    nodes = _find_X_y_and_cv(data_op.skb.clone())
     values = evaluate(nodes, mode="fit_transform", environment=environment, clear=True)
     if "y" in nodes:
         msg = (

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -25,6 +25,7 @@ from ._data_ops import (
     Apply,
     DataOp,
     Scoring,
+    SplitX,
     Value,
     Var,
 )
@@ -1107,6 +1108,26 @@ def find_node_by_name(data_op, name):
         return getattr(obj, "name", None) == name
 
     return find_node(data_op, pred)
+
+
+def find_X_y_and_cv(data_op):
+    """Find the nodes marked with `.skb.mark_as_X()` and `.skb.mark_as_y()`"""
+    result = {}
+    if (x_node := find_X(data_op)) is not None:
+        result["X"] = x_node
+        if isinstance(x_node._skrub_impl, SplitX):
+            result["cv"] = x_node._skrub_impl.cv
+            result["split_kwargs"] = x_node._skrub_impl.split_kwargs
+    if (y_node := find_y(data_op)) is not None:
+        result["y"] = y_node
+    return result
+
+
+def find_scoring_node(data_op):
+    return find_node(
+        data_op,
+        lambda o: isinstance(o, DataOp) and isinstance(o._skrub_impl, Scoring),
+    )
 
 
 def needs_eval(obj, return_node=False):

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -3375,7 +3375,7 @@ class SkrubNamespace:
         To compute the values, evaluate the whole dictionary as a single DataOp:
 
         >>> X_y_values = skrub.as_data_op(X_y).skb.eval({'df': df})
-        >>> X_y_values
+        >>> X_y_values  # doctest: +SKIP
         {'X':    description  price
         0       screen    100
         1       hammer     15

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -38,6 +38,9 @@ from ._evaluation import (
     clone,
     describe_steps,
     evaluate,
+    find_node,
+    find_node_by_name,
+    find_X_y_and_cv,
     nodes,
 )
 from ._inspection import (
@@ -3168,3 +3171,235 @@ class SkrubNamespace:
                 ),
             )
         return DataOp(AppliedEstimator(self._data_op))
+
+    def find(self, what):
+        """
+        Find a node (DataOp or choice) in the computational graph.
+
+        Parameters
+        ----------
+        what : str or callable
+            - If a string, it is the name (set with
+              :meth:`DataOp.skb.set_name`) of the node to search for.
+            - If a callable, it is the search predicate: it accepts a DataOp
+              and returns a Boolean. The first node for which it returns True
+              is returned.
+
+        Returns
+        -------
+        DataOp or None
+            The node named ``what``, when ``what`` is a string, or the first
+            node for which ``what`` returned True, if ``what`` is a callable.
+            If nothing was found, ``None`` is returned.
+
+        See Also
+        --------
+        DataOp.skb.find_X_y
+            Find the nodes that have been marked with
+            :meth:`DataOp.skb.mark_as_X` and :meth:`DataOp.skb.mark_as_y`.
+
+        SkrubLearner.truncated_after
+            Truncate the (possibly fitted) SkrubLearner after the specified node.
+
+        Examples
+        --------
+        >>> import skrub
+        >>> from sklearn.dummy import DummyClassifier
+
+        >>> data = skrub.datasets.toy_orders()
+        >>> x = skrub.X(data.X)
+        >>> x
+        <Var 'X'>
+        Result:
+        ―――――――
+           ID product  quantity        date
+        0   1     pen         2  2020-04-03
+        1   2     cup         3  2020-04-04
+        2   3     cup         5  2020-04-04
+        3   4   spoon         1  2020-04-05
+        >>> vectorized = x.skb.apply(skrub.TableVectorizer()).skb.set_name("vectorized")
+        >>> vectorized  # doctest: +SKIP
+        <vectorized | Apply TableVectorizer>
+        Result:
+        ―――――――
+            ID  product_cup  product_pen  ...  date_month  date_day  date_total_seconds
+        0  1.0          0.0          1.0  ...         4.0       3.0        1.585872e+09
+        1  2.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        2  3.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        3  4.0          0.0          0.0  ...         4.0       5.0        1.586045e+09
+        [4 rows x 9 columns]
+        >>> y = skrub.y(data.y)
+        >>> y
+        <Var 'y'>
+        Result:
+        ―――――――
+        0    False
+        1    False
+        2     True
+        3    False
+        Name: delayed, dtype: bool
+        >>> strategy = skrub.choose_from(["most_frequent", "prior"], name="strategy")
+        >>> pred = vectorized.skb.apply(DummyClassifier(strategy=strategy), y=y)
+
+        Find a node by its name:
+
+        >>> found = pred.skb.find("vectorized")
+        >>> found  # doctest: +SKIP
+        <vectorized | Apply TableVectorizer>
+        Result:
+        ―――――――
+            ID  product_cup  product_pen  ...  date_month  date_day  date_total_seconds
+        0  1.0          0.0          1.0  ...         4.0       3.0        1.585872e+09
+        1  2.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        2  3.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        3  4.0          0.0          0.0  ...         4.0       5.0        1.586045e+09
+        [4 rows x 9 columns]
+        >>> found is vectorized
+        True
+
+        Note that choices are also considered:
+
+        >>> found = pred.skb.find("strategy")
+        >>> found
+        choose_from(['most_frequent', 'prior'], name='strategy')
+        >>> found is strategy
+        True
+
+        Find by a predicate function:
+
+        >>> def has_9_columns(data_op):
+        ...     value = data_op.skb.preview()
+        ...     if (shape := getattr(value, "shape")) is None:
+        ...         return False
+        ...     if len(shape) == 1:
+        ...         return False
+        ...     return shape[1] == 9
+
+
+        >>> found = pred.skb.find(has_9_columns)
+        >>> found  # doctest: +SKIP
+        <vectorized | Apply TableVectorizer>
+        Result:
+        ―――――――
+            ID  product_cup  product_pen  ...  date_month  date_day  date_total_seconds
+        0  1.0          0.0          1.0  ...         4.0       3.0        1.585872e+09
+        1  2.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        2  3.0          1.0          0.0  ...         4.0       4.0        1.585958e+09
+        3  4.0          0.0          0.0  ...         4.0       5.0        1.586045e+09
+        [4 rows x 9 columns]
+        >>> found is vectorized
+        True
+        """
+        if not isinstance(what, DataOp) and callable(what):
+            return find_node(self._data_op, what)
+        if isinstance(what, str):
+            return find_node_by_name(self._data_op, what)
+        raise TypeError(
+            "what should either be a string or a callable accepting a "
+            f"DataOp and returning a Boolean, got object of type: {type(what)}."
+        )
+
+    def find_X_y(self):
+        """
+        Find the nodes that have been marked with ``mark_as_X()`` and ``mark_as_y()``.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the following keys (all are optional):
+
+            - "X", if a node has been marked with :meth:`DataOp.skb.mark_as_X`.
+            - "y", if a node has been marked with :meth:`DataOp.skb.mark_as_y`.
+            - Additionally, if a ``cv`` has been passed to
+              :meth:`DataOp.skb.mark_as_X`, the parameters that were passed to
+              ``mark_as_X``:
+
+              - "cv"
+              - "split_kwargs"
+
+        See Also
+        --------
+        DataOp.skb.find
+            Find a node by name or by an arbitrary predicate.
+        SkrubLearner.truncated_after
+            Truncate the (possibly fitted) SkrubLearner after the specified node.
+
+        Notes
+        -----
+        To evaluate the DataOps in the returned dictionary, it is recommended
+        to evaluate the whole dict as a single DataOp::
+
+            Xy = my_data_op.skb.find_X_y()
+            Xy_values = skrub.as_data_op(Xy).skb.eval({...})
+            X_value = Xy_values['X']
+            y_value = Xy_values['y']
+
+        rather than::
+
+            Xy = my_data_op.skb.find_X_y()
+            X_value = Xy['X'].skb.eval({...})
+            y_value = Xy['y'].skb.eval({...})
+
+        Indeed, evaluating each value in the dict separately can result in
+        running some computation twice, and worse, obtaining X and y that are
+        not aligned if the data loading and processing that produces X and y
+        produces row in an undeterministic order (e.g. due to aggregations,
+        joins, database queries etc.).
+
+        Examples
+        --------
+        >>> import skrub
+        >>> from sklearn.dummy import DummyClassifier
+
+        >>> df = skrub.datasets.toy_products()
+        >>> df
+           description  price            seller     category
+        0       screen    100   supermarket.com  electronics
+        1       hammer     15  bestproducts.com        tools
+        2     keyboard     20   supermarket.com  electronics
+        3      usb key      9  bestproducts.com  electronics
+        4      charger     13  bestproducts.com  electronics
+        5  screwdriver     12   supermarket.com        tools
+
+        >>> data = skrub.var("df")
+        >>> groups = data["seller"]
+        >>> X = data[["description", "price"]].skb.mark_as_X()
+        >>> y = data["category"].skb.mark_as_y()
+        >>> pred = X.skb.apply(DummyClassifier(), y=y)
+        >>> X_y = pred.skb.find_X_y()
+        >>> X_y
+        {'X': <GetItem ['description', 'price']>, 'y': <GetItem 'category'>}
+        >>> X_y['X'] is X
+        True
+
+        To compute the values, evaluate the whole dictionary as a single DataOp:
+
+        >>> X_y_values = skrub.as_data_op(X_y).skb.eval({'df': df})
+        >>> X_y_values
+        {'X':    description  price
+        0       screen    100
+        1       hammer     15
+        2     keyboard     20
+        3      usb key      9
+        4      charger     13
+        5  screwdriver     12, 'y': 0    electronics
+        1          tools
+        2    electronics
+        3    electronics
+        4    electronics
+        5          tools
+        Name: category, dtype: str}
+
+        When a ``cv`` object was passed to :meth:`DataOp.skb.mark_as_X()`, the result
+        will also contain the keys ``"cv"`` and ``"split_kwargs"``:
+
+        >>> from sklearn.model_selection import LeaveOneGroupOut
+
+        >>> X = data[["description", "price"]].skb.mark_as_X(
+        ...     cv=LeaveOneGroupOut(), split_kwargs={"groups": groups}
+        ... )
+        >>> pred = X.skb.apply(DummyClassifier(), y=y)
+        >>> pred.skb.find_X_y()
+        {'X': <X>, 'cv': LeaveOneGroupOut(), 'split_kwargs': {'groups': <GetItem 'seller'>}, 'y': <GetItem 'category'>}
+        """  # noqa: E501
+        return find_X_y_and_cv(self._data_op)

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -10,7 +10,7 @@ from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification, make_regression
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LogisticRegression, Ridge
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import GroupKFold, train_test_split
 from sklearn.utils import check_random_state
 
 import skrub
@@ -907,3 +907,49 @@ def test_copy_attrs():
         .skb.set_name("transform")
     )
     assert isinstance(out.skb.applied_estimator.skb.eval().transformer_, PassThrough)
+
+
+def test_find():
+    a = skrub.var("a")
+    b = skrub.var("b")
+    c = skrub.choose_from([1, 2], name="c")
+    d = (a + b).skb.set_name("d")
+    e = c + d
+    assert e.skb.find("c") is c
+    assert e.skb.find(lambda n: not hasattr(n, "skb") and n.name == "c") is c
+    assert e.skb.find("d") is d
+    assert e.skb.find(lambda n: hasattr(n, "skb") and n.skb.name == "d") is d
+    assert e.skb.find("z") is None
+    assert e.skb.find(lambda n: False) is None
+    with pytest.raises(TypeError, match="what should either be a string or a callable"):
+        e.skb.find(c)
+    with pytest.raises(TypeError, match="what should either be a string or a callable"):
+        e.skb.find(0)
+
+
+def test_find_X_y():
+    X = skrub.X()
+    y = skrub.y()
+    pred = X.skb.apply(DummyRegressor(), y=y)
+    Xy = pred.skb.find_X_y()
+    assert list(Xy) == ["X", "y"]
+    assert Xy["X"] is X
+    assert Xy["y"] is y
+    Xy = X.skb.find_X_y()
+    assert list(Xy) == ["X"]
+    assert Xy["X"] is X
+    Xy = y.skb.find_X_y()
+    assert list(Xy) == ["y"]
+    assert Xy["y"] is y
+    assert skrub.var("a").skb.find_X_y() == {}
+    groups = skrub.var("groups")
+    kfold = GroupKFold()
+    X = skrub.var("X").skb.mark_as_X(cv=kfold, split_kwargs={"groups": groups})
+    y = skrub.y()
+    pred = X.skb.apply(DummyRegressor(), y=y)
+    Xy = pred.skb.find_X_y()
+    assert list(Xy) == ["X", "cv", "split_kwargs", "y"]
+    assert Xy["X"] is X
+    assert Xy["y"] is y
+    assert Xy["cv"] is kfold
+    assert Xy["split_kwargs"]["groups"] is groups

--- a/skrub/_data_ops/tests/test_estimators.py
+++ b/skrub/_data_ops/tests/test_estimators.py
@@ -1248,18 +1248,19 @@ def test_find_fitted_estimator():
     assert isinstance(learner.find_fitted_estimator("predictor"), LogisticRegression)
 
 
-def test_truncated_after():
-    learner = (
-        skrub.X()
-        .skb.apply(MinMaxScaler())
-        .skb.set_name("scaling")
-        .skb.apply(LogisticRegression(), y=skrub.y())
-        .skb.make_learner()
-    )
+@pytest.mark.parametrize("wrap_in_choice", [False, True])
+def test_truncated_after(wrap_in_choice):
+    scaled = skrub.X().skb.apply(MinMaxScaler())
+    if wrap_in_choice:
+        scaled = skrub.as_data_op(skrub.choose_from([scaled], name="scaling"))
+    else:
+        scaled = scaled.skb.set_name("scaling")
+    learner = scaled.skb.apply(LogisticRegression(), y=skrub.y()).skb.make_learner()
     X = np.array([10.0, 5.0, 0.0])[:, None]
     y = np.array([1, 0, 1])
     learner.fit({"X": X, "y": y})
     sub_learner = learner.truncated_after("scaling")
+    assert isinstance(sub_learner.data_op, skrub.DataOp)
     assert np.allclose(
         sub_learner.transform({"X": X}), np.array([1.0, 0.5, 0.0])[:, None]
     )
@@ -1267,7 +1268,7 @@ def test_truncated_after():
     assert np.allclose(
         sub_learner.transform({"X": X}), np.array([10.0, 5.0, -1.0])[:, None]
     )
-    with pytest.raises(KeyError, match="'xyz'"):
+    with pytest.raises(ValueError, match="'xyz'"):
         learner.truncated_after("xyz")
 
 


### PR DESCRIPTION
- `find_X_y` returns the nodes marked as X and y and if they exist the cv and split_kwargs
- find looks for a node by name or by a callable predicate