### PR TITLE
DOC fix deduplicate example rendering

### DIFF
--- a/skrub/_deduplicate.py
+++ b/skrub/_deduplicate.py
@@ -231,6 +231,7 @@ def deduplicate(
 
     It is possible to use the deduplication function to replace values in a DataFrame
     column:
+
     >>> import pandas as pd
     >>> df = pd.DataFrame({'color': duplicated, 'value': range(10)})
     >>> df


### PR DESCRIPTION

## Description

This is a small documentation rendering fix.

Fixes the rendering of the DataFrame example in the `deduplicate` API documentation.

The doctest block was rendered inline because it followed `column:` without a separating blank line. This adds the blank line so Sphinx renders the example as a proper code block.
Before/after rendering:
<img width="1232" height="764" alt="Untitled (26)" src="https://github.com/user-attachments/assets/8562aa08-c4ad-451b-bae4-5c38e1969a95" />


## Checklist

- [x] I have read the contributing guidelines
- [ ] I have added tests that verify the bug fix
- [ ] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

I did not add tests or a changelog entry because this is a documentation-only formatting fix.


## How Has This Been Tested?

Built the documentation locally with:

```bash
uv run --group dev make html-noplot


## AI Disclosure

- [ ] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
