### PR TITLE
use applytocols in skb apply instead of wrap_transformer directly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,9 @@ Changes
 - :class:`ApplyToCols` now produces better error tracebacks when the wrapped
   transformer fails, in python versions >= 3.11. :pr:`1979` by :user:`Jérôme
   Dockès <jeromedockes>`.
+- The parameter ``how`` of :meth:`DataOp.skb.apply` is replaced by a simpler
+  Boolean parameter ``no_wrap``. :pr:`2049` by :user:`Jérôme Dockès
+  <jeromedockes>`.
 
 Bugfixes
 --------

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -821,7 +821,7 @@ for op_name in _UNARY_OPS:
     setattr(DataOp, op_name, _make_unary_op(op_name))
 
 
-def _check_wrap_params(cols, no_wrap, how, allow_reject, reason):
+def _check_wrap_params(cols, how, allow_reject, reason):
     msg = None
     if not isinstance(cols, type(s.all())):
         msg = f"`cols` must be `all()` (the default) when {reason}"
@@ -859,8 +859,7 @@ def _check_estimator_type(estimator):
 
 def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
     """
-    Wrap the estimator passed to .skb.apply in ApplyToEachCol or ApplyToSubFrame if
-    needed.
+    Wrap the estimator passed to .skb.apply in ApplyToCols if needed.
     """
     if not isinstance(no_wrap, bool):
         raise TypeError(
@@ -1518,7 +1517,11 @@ class Apply(DataOpImpl):
 
     def __repr__(self):
         estimator = get_chosen_or_default(self.estimator)
-        if estimator.__class__.__name__ in ["ApplyToEachCol", "ApplyToSubFrame"]:
+        if estimator.__class__.__name__ in [
+            "ApplyToEachCol",
+            "ApplyToSubFrame",
+            "ApplyToCols",
+        ]:
             estimator = estimator.transformer
         # estimator can be None or 'passthrough'
         if isinstance(estimator, str):

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -883,7 +883,7 @@ def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
     _check_estimator_type(estimator)
 
     def _check(reason):
-        _check_wrap_params(cols, no_wrap, how, allow_reject, reason)
+        _check_wrap_params(cols, how, allow_reject, reason)
 
     if no_wrap:
         _check("`no_wrap` is True")

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -45,6 +45,7 @@ from sklearn.base import BaseEstimator
 from .. import _config
 from .. import _dataframe as sbd
 from .. import selectors as s
+from .._apply_to_cols import ApplyToCols
 from .._check_input import cast_column_names_to_strings
 from .._reporting._utils import strip_xml_declaration
 from .._utils import PassThrough, set_module, short_repr
@@ -820,7 +821,7 @@ for op_name in _UNARY_OPS:
     setattr(DataOp, op_name, _make_unary_op(op_name))
 
 
-def _check_wrap_params(cols, how, allow_reject, reason):
+def _check_wrap_params(cols, no_wrap, how, allow_reject, reason):
     msg = None
     if not isinstance(cols, type(s.all())):
         msg = f"`cols` must be `all()` (the default) when {reason}"
@@ -856,33 +857,26 @@ def _check_estimator_type(estimator):
     )
 
 
-def _check_apply_how(how):
-    valid = ["auto", "cols", "frame", "no_wrap"]
-    if how in valid:
-        return how
-
-    # TODO remove when the old names are completely dropped in 0.7.0
-    translate = {"columnwise": "cols", "sub_frame": "frame", "full_frame": "no_wrap"}
-    if how in translate:
-        new = translate[how]
-        warnings.warn(
-            (
-                f"{how!r} has been renamed to {new!r}: use .skb.apply(how={new!r})"
-                " instead."
-            ),
-            FutureWarning,
-        )
-        return new
-
-    raise ValueError(f"`how` must be one of {valid}. Got: {how!r}")
-
-
-def _wrap_estimator(estimator, cols, how, allow_reject, X):
+def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
     """
     Wrap the estimator passed to .skb.apply in ApplyToEachCol or ApplyToSubFrame if
     needed.
     """
-    how = _check_apply_how(how)
+    if not isinstance(no_wrap, bool):
+        raise TypeError(
+            "The parameter 'no_wrap' of .skb.apply() must be a Boolean, "
+            f"got: {no_wrap!r}."
+        )
+    valid = ["auto", "cols", "frame", "no_wrap"]
+    if how not in valid:
+        raise ValueError(f"`how` must be one of {valid}. Got: {how!r}")
+    if how != "auto":
+        warnings.warn(
+            "The 'how' parameter of .skb.apply() has been deprecated "
+            "and will  be removed in a future release. "
+            f"Use the 'no_wrap' parameter instead. Got how={how!r}",
+            FutureWarning,
+        )
 
     if estimator in [None, "passthrough"]:
         estimator = PassThrough()
@@ -890,8 +884,11 @@ def _wrap_estimator(estimator, cols, how, allow_reject, X):
     _check_estimator_type(estimator)
 
     def _check(reason):
-        _check_wrap_params(cols, how, allow_reject, reason)
+        _check_wrap_params(cols, no_wrap, how, allow_reject, reason)
 
+    if no_wrap:
+        _check("`no_wrap` is True")
+        return estimator
     if how == "no_wrap":
         _check("`how` is 'no_wrap'")
         return estimator
@@ -901,7 +898,9 @@ def _wrap_estimator(estimator, cols, how, allow_reject, X):
     if not sbd.is_dataframe(X):
         _check("the input is not a DataFrame")
         return estimator
-    columnwise = {"auto": "auto", "cols": True, "frame": False}[how]
+    if how == "auto":
+        return ApplyToCols(estimator, cols=cols, allow_reject=allow_reject)
+    columnwise = {"cols": True, "frame": False}[how]
     return wrap_transformer(
         estimator, cols, allow_reject=allow_reject, columnwise=columnwise
     )
@@ -1360,6 +1359,7 @@ class Apply(DataOpImpl):
         "estimator",
         "y",
         "cols",
+        "no_wrap",
         "how",
         "allow_reject",
         "unsupervised",
@@ -1397,11 +1397,13 @@ class Apply(DataOpImpl):
 
         if "fit" in method_name:
             cols = yield self.cols
+            no_wrap = yield self.no_wrap
             how = yield self.how
             allow_reject = yield self.allow_reject
             self.estimator_ = _wrap_estimator(
                 estimator=estimator,
                 cols=cols,
+                no_wrap=no_wrap,
                 how=how,
                 allow_reject=allow_reject,
                 X=X,

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -357,7 +357,7 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         -------
         scikit-learn estimator
             The fitted estimator. Depending on the nature of the estimator it
-            may be wrapped in a ``skrub._apply_to_each_col.ApplyToEachCol``
+            may be wrapped in a :class:`ApplyToCols`
             or ``skrub._apply_to_sub_frame.ApplyToSubFrame``,
             see examples below.
 
@@ -399,14 +399,12 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         DummyClassifier()
 
         Depending on the parameters passed to :meth:`DataOp.skb.apply`, the
-        estimator we provide can be wrapped in a skrub transformer that applies
-        it to several columns in the input, or to a subset of the columns in a
-        dataframe. In other cases it may be applied without any wrapping. We
-        provide examples for those 3 different cases below.
+        estimator we provide may or may not be wrapped in a
+        :class:`ApplyToCols` transformer.
 
         Case 1: the ``StringEncoder`` is a skrub single-column transformer: it
         transforms a single column. In the learner it gets wrapped in a
-        :class:`ApplyToEachCol` which independently fits a separate instance of the
+        :class:`ApplyToCols` which independently fits a separate instance of the
         ``StringEncoder`` to each of the columns it transforms (in this case there is
         only one column, ``'product'``). The individual transformers can be found in the
         fitted attribute ``transformers_`` which maps column names to the corresponding
@@ -418,13 +416,13 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         >>> encoder.transformers_['product'].vectorizer_.vocabulary_
         {' pe': 2, 'pen': 12, 'en ': 8, ' pen': 3, 'pen ': 13, ' cu': 0, 'cup': 6, 'up ': 18, ' cup': 1, 'cup ': 7, ' sp': 4, 'spo': 16, 'poo': 14, 'oon': 10, 'on ': 9, ' spo': 5, 'spoo': 17, 'poon': 15, 'oon ': 11}
 
-        This case (wrapping in :class:`ApplyToEachCol`) happens when the estimator is a skrub
+        This case happens when the estimator is a skrub
         single-column transformer (it has a ``__single_column_transformer__``
-        attribute), we pass ``.skb.apply(how='cols')`` or we pass
-        ``.skb.apply(allow_reject=True)``.
+        attribute), the input is a DataFrame and we pass ``no_wrap=False`` (the
+        default).
 
         Case 2: the ``PCA`` is a regular scikit-learn transformer. In the learner it
-        gets wrapped in a :class:`ApplyToSubFrame` which applies it to the subset of columns
+        gets wrapped in a :class:`ApplyToCols` which applies it to the subset of columns
         in the dataframe selected by the ``cols`` argument passed to ``.skb.apply()``.
         The fitted ``PCA`` can be found in the fitted attribute ``transformer_``.
 
@@ -436,9 +434,9 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         >>> pca.transformer_.mean_
         array([2020.,    4.,    4.], dtype=float32)
 
-        This case (wrapping in :class:`ApplyToSubFrame`) happens when the estimator is a
-        scikit-learn transformer but not a single-column transformer, or we
-        pass ``.skb.apply(how='frame')``.
+        This case happens when the estimator is a scikit-learn transformer but
+        not a single-column transformer, the input is a DataFrame and we pass
+        ``no_wrap=False`` (the default).
 
         The ``DummyRegressor`` is a scikit-learn predictor. In the learner it gets
         applied directly to the input dataframe without any wrapping.
@@ -451,7 +449,7 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
 
         This case (no wrapping) happens when the estimator is a scikit-learn predictor
         (not a transformer), the input is not a dataframe (e.g. it is a numpy array), or
-        we pass ``.skb.apply(how='no_wrap')``.
+        we pass ``.skb.apply(no_wrap=True)``.
         """  # noqa: E501
         node = find_node_by_name(self.data_op, name)
         if node is None:

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -147,6 +147,7 @@ class SkrubNamespace:
         estimator,
         y=None,
         cols=_SELECT_ALL_COLUMNS,
+        no_wrap=False,
         how="auto",
         allow_reject=False,
         unsupervised=False,
@@ -160,6 +161,7 @@ class SkrubNamespace:
                 cols=cols,
                 X=self._data_op,
                 y=y,
+                no_wrap=no_wrap,
                 how=how,
                 allow_reject=allow_reject,
                 unsupervised=unsupervised,
@@ -176,6 +178,7 @@ class SkrubNamespace:
         y=None,
         cols=_SELECT_ALL_COLUMNS,
         exclude_cols=None,
+        no_wrap=False,
         how="auto",
         allow_reject=False,
         unsupervised=False,
@@ -206,7 +209,19 @@ class SkrubNamespace:
             _not_ be applied. The columns that are matched by ``cols`` AND not
             matched by ``exclude_cols`` are transformed.
 
+        no_wrap : bool, default = False
+            Disable wrapping of transformers in :class:`ApplyToCols`.
+
+            By default, when ``estimator`` is a transformer and the input is a
+            DataFrame, the transformer is wrapped in an instance of
+            :class:`ApplyToCols`, which allows applying it to part of the
+            dataframe only through the ``cols`` and ``allow_reject``
+            parameters. Passing ``no_wrap=True`` disables this wrapping in all
+            cases. When ``no_wrap`` is True, ``cols`` cannot be used.
+
         how : "auto", "cols", "frame" or "no_wrap", optional
+            Deprecated. Use ``no_wrap`` instead.
+
             How the estimator is applied. In most cases the default "auto"
             is appropriate.
 
@@ -225,6 +240,8 @@ class SkrubNamespace:
               transformer, the "no_wrap" strategy is chosen. Otherwise if the
               estimator has a ``__single_column_transformer__`` attribute,
               "cols" is chosen. Otherwise "frame" is chosen.
+
+            .. deprecated:: 0.9.0
 
         allow_reject : bool, optional
             Whether the transformer can refuse to transform columns for which
@@ -439,6 +456,7 @@ class SkrubNamespace:
             estimator=estimator,
             y=y,
             cols=cols,
+            no_wrap=no_wrap,
             how=how,
             allow_reject=allow_reject,
             unsupervised=unsupervised,
@@ -694,7 +712,7 @@ class SkrubNamespace:
         2     cup  2020-04-04
         3   spoon  2020-04-05
         """
-        return self._apply(SelectCols(cols), how="no_wrap")
+        return self._apply(SelectCols(cols), no_wrap=True)
 
     @checked_data_op_constructor
     def drop(self, cols):
@@ -747,7 +765,7 @@ class SkrubNamespace:
         2   3         5
         3   4         1
         """
-        return self._apply(DropCols(cols), how="no_wrap")
+        return self._apply(DropCols(cols), no_wrap=True)
 
     @checked_data_op_constructor
     def concat(self, others, axis=0):
@@ -3203,15 +3221,13 @@ class SkrubNamespace:
         <AppliedEstimator>
         Result:
         ―――――――
-        ApplyToSubFrame(transformer=TableVectorizer())
+        ApplyToCols(transformer=TableVectorizer())
 
         Note that in order to restrict transformers to a subset of columns,
-        they will be wrapped in a meta-estimator ``ApplyToSubFrame`` or
-        ``ApplyToEachCol`` depending if the transformer is applied to each column
-        separately or not. The actual transformer can be retrieved through the
-        ``transformer_`` attribute of ``ApplyToSubFrame`` or ``transformers_``
-        attribute of ``ApplyToEachCol`` (a dictionary mapping column names to the
-        corresponding transformer).
+        they will be wrapped in a meta-estimator :class:`ApplyToCols`. The
+        actual transformer can be retrieved through the ``transformer_`` (or
+        ``transformers_``, in the case of single-column transformers); see the
+        documentation of :class:`ApplyToCols` for details.
 
         >>> fitted_vectorizer.transformer_
         <GetAttr 'transformer_'>
@@ -3237,8 +3253,8 @@ class SkrubNamespace:
         <AppliedEstimator>
         Result:
         ―――――――
-        ApplyToEachCol(cols=(string() - cols('date')),
-                     transformer=StringEncoder(n_components=2))
+        ApplyToCols(cols=(string() - cols('date')),
+                    transformer=StringEncoder(n_components=2))
         >>> fitted_vectorizer.transformers_
         <GetAttr 'transformers_'>
         Result:

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -217,7 +217,8 @@ class SkrubNamespace:
             :class:`ApplyToCols`, which allows applying it to part of the
             dataframe only through the ``cols`` and ``allow_reject``
             parameters. Passing ``no_wrap=True`` disables this wrapping in all
-            cases. When ``no_wrap`` is True, ``cols`` cannot be used.
+            cases. When ``no_wrap`` is True, ``cols`` and ``allow_reject``
+            cannot be used.
 
         how : "auto", "cols", "frame" or "no_wrap", optional
             Deprecated. Use ``no_wrap`` instead.

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import sys
 import warnings
 
@@ -496,17 +497,17 @@ def test_data_op_impl():
         a.skb.eval()
 
 
-@pytest.mark.parametrize("why_no_wrap", ["numpy", "predictor", "how"])
+@pytest.mark.parametrize("why_no_wrap", ["numpy", "predictor", "no_wrap", "how"])
 @pytest.mark.parametrize("bad_param", ["cols", "how", "allow_reject"])
 def test_apply_bad_params(why_no_wrap, bad_param):
     # When the estimator is a predictor or the input is a numpy array (not a
-    # dataframe) (or how='no_wrap') the estimator can only be applied to the
-    # full input without wrapping in ApplyToEachCol or ApplyToSubFrame. In this case
-    # if the user passed a parameter that would require wrapping, such as
-    # passing a value for `cols` that is not `all()`, or passing
-    # how='cols' or allow_reject=True, we get an error.
+    # dataframe) (or no_wrap=True, or how='no_wrap') the estimator can only be
+    # applied to the full input without wrapping in ApplyToCols, ApplyToEachCol
+    # or ApplyToSubFrame. In this case if the user passed a parameter that
+    # would require wrapping, such as passing a value for `cols` that is not
+    # `all()`, or passing how='cols' or allow_reject=True, we get an error.
 
-    if why_no_wrap == bad_param == "how":
+    if bad_param == "how" and why_no_wrap in ["no_wrap", "how"]:
         return
     X_a, y_a = make_classification(random_state=0)
     X_df = pd.DataFrame(X_a, columns=[f"col_{i}" for i in range(X_a.shape[1])])
@@ -530,6 +531,7 @@ def test_apply_bad_params(why_no_wrap, bad_param):
         cols = s.all()
     how = "cols" if bad_param == "how" else how
     allow_reject = True if bad_param == "allow_reject" else False
+    no_wrap = True if why_no_wrap == "no_wrap" else False
 
     with pytest.raises(
         (ValueError, RuntimeError),
@@ -538,21 +540,53 @@ def test_apply_bad_params(why_no_wrap, bad_param):
             r" False)"
         ),
     ):
-        X.skb.apply(estimator, y=y, how=how, allow_reject=allow_reject, cols=cols)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message=".*how.*deprecated.*")
+            X.skb.apply(
+                estimator,
+                y=y,
+                no_wrap=no_wrap,
+                how=how,
+                allow_reject=allow_reject,
+                cols=cols,
+            )
 
 
-def test_apply_invalid_how():
+def test_apply_how():
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     X = skrub.var("X", df)
     t = PassThrough()
-    for how in ["auto", "cols", "frame", "no_wrap"]:
-        assert list(X.skb.apply(t, how=how).skb.eval().columns) == ["a", "b"]
+    for how in ["cols", "frame", "no_wrap"]:
+        with pytest.warns(
+            FutureWarning,
+            match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
+        ):
+            assert list(X.skb.apply(t, how=how).skb.eval().columns) == ["a", "b"]
+    assert list(X.skb.apply(t, how="auto").skb.eval().columns) == ["a", "b"]
     with pytest.raises(RuntimeError, match="`how` must be one of"):
         X.skb.apply(t, how="bad value")
-    # TODO: remove when old names are dropped in 0.7.0
-    with pytest.warns(FutureWarning, match="'columnwise' has been renamed to 'cols'"):
-        wrapper = X.skb.apply(t, how="columnwise").skb.applied_estimator.skb.eval()
+    with pytest.warns(
+        FutureWarning,
+        match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
+    ):
+        wrapper = X.skb.apply(t, how="cols").skb.applied_estimator.skb.eval()
         assert isinstance(wrapper, ApplyToEachCol)
+
+
+def test_apply_no_wrap():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    X = skrub.var("X", df)
+    t = PassThrough()
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape("The parameter 'no_wrap' of .skb.apply() must be a Boolean"),
+    ):
+        X.skb.apply(t, no_wrap="bad")
+    applied = X.skb.apply(t).skb.applied_estimator.skb.eval()
+    assert isinstance(applied, skrub.ApplyToCols)
+    assert isinstance(applied.transformer_, PassThrough)
+    applied = X.skb.apply(t, no_wrap=True).skb.applied_estimator.skb.eval()
+    assert isinstance(applied, PassThrough)
 
 
 class Mul(BaseEstimator):
@@ -635,9 +669,13 @@ def test_apply_transformer_kwargs():
         .skb.make_learner()
     )
     df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    learner.fit({"df": df})
-    learner.fit_transform({"df": df})
-    learner.transform({"df": df})
+    with pytest.warns(
+        FutureWarning,
+        match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
+    ):
+        learner.fit({"df": df})
+        learner.fit_transform({"df": df})
+        learner.transform({"df": df})
 
 
 def test_apply_kwargs_evaluation():

--- a/skrub/_data_ops/tests/test_interactive_features.py
+++ b/skrub/_data_ops/tests/test_interactive_features.py
@@ -233,7 +233,7 @@ def test_repr():
     >>> X.skb.concat(skrub.as_data_op([X, X]),axis=0)
     <Concat>
 
-    if we end up applying an ApplyToEachCol, seeing the inner transformer is more
+    if we end up applying an ApplyToCols, seeing the inner transformer is more
     informative.
 
     >>> from skrub._wrap_transformer import wrap_transformer


### PR DESCRIPTION
now that ApplyToEachCol and ApplyToSubFrame are private, it is probably better if DataOp.skb.apply() relies on the public class ApplyToCols instead.

this pr deprecates the old parameter how=auto/cols/frame/no_wrap.
it introduces the parameter no_wrap=False/True

now if no_wrap is True, no wrapping is done. if it is False, the behavior is the same as the old how='auto' : wrapping is done only if the estimator is a transformer and the input is a dataframe. the behavior of how'cols' and how='frame' will not be available once the deprecated parameter is removed