### PR TITLE
handle exclude_cols in wrap_transformer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Changes
 - The parameter ``how`` of :meth:`DataOp.skb.apply` is replaced by a simpler
   Boolean parameter ``no_wrap``. :pr:`2049` by :user:`Jérôme Dockès
   <jeromedockes>`.
+- The ``exclude_cols`` of :meth:`DataOp.skb.apply` can now be a DataOp.
+  :pr:`2050` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Bugfixes
 --------

--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -366,13 +366,10 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
                 "Expected a boolean."
             )
 
-        cols = self.cols
-        if self.exclude_cols is not None:
-            cols = selectors.make_selector(cols) - self.exclude_cols
-
         self._wrapped_transformer = wrap_transformer(
             self.transformer,
-            cols,
+            cols=self.cols,
+            exclude_cols=self.exclude_cols,
             allow_reject=self.allow_reject,
             keep_original=self.keep_original,
             rename_columns=self.rename_columns,

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -821,10 +821,12 @@ for op_name in _UNARY_OPS:
     setattr(DataOp, op_name, _make_unary_op(op_name))
 
 
-def _check_wrap_params(cols, how, allow_reject, reason):
+def _check_wrap_params(cols, exclude_cols, how, allow_reject, reason):
     msg = None
     if not isinstance(cols, type(s.all())):
         msg = f"`cols` must be `all()` (the default) when {reason}"
+    if exclude_cols is not None:
+        msg = f"`exclude_cols` must be None (the default) when {reason}"
     elif how not in ["auto", "no_wrap"]:
         msg = f"`how` must be 'auto' (the default) or 'no_wrap' when {reason}"
     elif allow_reject:
@@ -857,7 +859,7 @@ def _check_estimator_type(estimator):
     )
 
 
-def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
+def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X):
     """
     Wrap the estimator passed to .skb.apply in ApplyToCols if needed.
     """
@@ -883,7 +885,7 @@ def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
     _check_estimator_type(estimator)
 
     def _check(reason):
-        _check_wrap_params(cols, how, allow_reject, reason)
+        _check_wrap_params(cols, exclude_cols, how, allow_reject, reason)
 
     if no_wrap:
         _check("`no_wrap` is True")
@@ -898,10 +900,10 @@ def _wrap_estimator(estimator, cols, no_wrap, how, allow_reject, X):
         _check("the input is not a DataFrame")
         return estimator
     if how == "auto":
-        return ApplyToCols(estimator, cols=cols, allow_reject=allow_reject)
+        return ApplyToCols(estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject)
     columnwise = {"cols": True, "frame": False}[how]
     return wrap_transformer(
-        estimator, cols, allow_reject=allow_reject, columnwise=columnwise
+        estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject, columnwise=columnwise
     )
 
 
@@ -1358,6 +1360,7 @@ class Apply(DataOpImpl):
         "estimator",
         "y",
         "cols",
+        "exclude_cols",
         "no_wrap",
         "how",
         "allow_reject",
@@ -1396,12 +1399,14 @@ class Apply(DataOpImpl):
 
         if "fit" in method_name:
             cols = yield self.cols
+            exclude_cols = yield self.exclude_cols
             no_wrap = yield self.no_wrap
             how = yield self.how
             allow_reject = yield self.allow_reject
             self.estimator_ = _wrap_estimator(
                 estimator=estimator,
                 cols=cols,
+                exclude_cols=exclude_cols,
                 no_wrap=no_wrap,
                 how=how,
                 allow_reject=allow_reject,

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -900,10 +900,16 @@ def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X
         _check("the input is not a DataFrame")
         return estimator
     if how == "auto":
-        return ApplyToCols(estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject)
+        return ApplyToCols(
+            estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject
+        )
     columnwise = {"cols": True, "frame": False}[how]
     return wrap_transformer(
-        estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject, columnwise=columnwise
+        estimator,
+        cols=cols,
+        exclude_cols=exclude_cols,
+        allow_reject=allow_reject,
+        columnwise=columnwise,
     )
 
 

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -147,6 +147,7 @@ class SkrubNamespace:
         estimator,
         y=None,
         cols=_SELECT_ALL_COLUMNS,
+        exclude_cols=None,
         no_wrap=False,
         how="auto",
         allow_reject=False,
@@ -159,6 +160,7 @@ class SkrubNamespace:
             Apply(
                 estimator=estimator,
                 cols=cols,
+                exclude_cols=exclude_cols,
                 X=self._data_op,
                 y=y,
                 no_wrap=no_wrap,
@@ -449,14 +451,14 @@ class SkrubNamespace:
         """  # noqa: E501
         # TODO later we could also expose `wrap_transformer`'s `keep_original`
         # and `rename_cols` params
-        if exclude_cols is not None:
-            cols = s.make_selector(cols) - exclude_cols
+
         # unsupervised should be an actual bool
         unsupervised = bool(unsupervised)
         return self._apply(
             estimator=estimator,
             y=y,
             cols=cols,
+            exclude_cols=exclude_cols,
             no_wrap=no_wrap,
             how=how,
             allow_reject=allow_reject,

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -498,7 +498,7 @@ def test_data_op_impl():
 
 
 @pytest.mark.parametrize("why_no_wrap", ["numpy", "predictor", "no_wrap", "how"])
-@pytest.mark.parametrize("bad_param", ["cols", "how", "allow_reject"])
+@pytest.mark.parametrize("bad_param", ["cols", "exclude_cols", "how", "allow_reject"])
 def test_apply_bad_params(why_no_wrap, bad_param):
     # When the estimator is a predictor or the input is a numpy array (not a
     # dataframe) (or no_wrap=True, or how='no_wrap') the estimator can only be
@@ -529,6 +529,13 @@ def test_apply_bad_params(why_no_wrap, bad_param):
             cols = ["col_0", "col_1"]
     else:
         cols = s.all()
+    if bad_param == "exclude_cols":
+        if why_no_wrap == "numpy":
+            exclude_cols = [0]
+        else:
+            exclude_cols = ["col_0"]
+    else:
+        exclude_cols = None
     how = "cols" if bad_param == "how" else how
     allow_reject = True if bad_param == "allow_reject" else False
     no_wrap = True if why_no_wrap == "no_wrap" else False
@@ -536,8 +543,8 @@ def test_apply_bad_params(why_no_wrap, bad_param):
     with pytest.raises(
         (ValueError, RuntimeError),
         match=(
-            r"(`cols` must be `all\(\)`|`how` must be 'auto'|`allow_reject` must be"
-            r" False)"
+            r"(`cols` must be `all\(\)`|`exclude_cols` must be None|"
+            r"`how` must be 'auto'|`allow_reject` must be False)"
         ),
     ):
         with warnings.catch_warnings():
@@ -549,6 +556,7 @@ def test_apply_bad_params(why_no_wrap, bad_param):
                 how=how,
                 allow_reject=allow_reject,
                 cols=cols,
+                exclude_cols=exclude_cols,
             )
 
 

--- a/skrub/_wrap_transformer.py
+++ b/skrub/_wrap_transformer.py
@@ -8,7 +8,9 @@ __all__ = ["wrap_transformer"]
 
 def wrap_transformer(
     transformer,
-    selector,
+    cols,
+    *,
+    exclude_cols=None,
     allow_reject=False,
     keep_original=False,
     rename_columns="{}",
@@ -34,8 +36,11 @@ def wrap_transformer(
     transformer : transformer (single-column or not)
         The transformer to wrap.
 
-    selector : skrub selector
+    cols : skrub selector
         The columns to which the transformer will be applied.
+
+    exclude_cols : skrub selector or None
+        Columns to subtract from cols.
 
     allow_reject : bool, default=False
         Whether to allow column rejections. Only used when the result is an
@@ -85,7 +90,9 @@ def wrap_transformer(
     >>> wrap_transformer(OrdinalEncoder(), s.string(), columnwise=True, n_jobs=4)
     ApplyToEachCol(cols=string(), n_jobs=4, transformer=OrdinalEncoder())
     """
-    selector = make_selector(selector)
+    cols = make_selector(cols)
+    if exclude_cols is not None:
+        cols = cols - exclude_cols
 
     if isinstance(columnwise, str) and columnwise == "auto":
         columnwise = is_single_column_transformer(transformer)

--- a/skrub/_wrap_transformer.py
+++ b/skrub/_wrap_transformer.py
@@ -100,7 +100,7 @@ def wrap_transformer(
     if columnwise:
         return ApplyToEachCol(
             transformer,
-            cols=selector,
+            cols=cols,
             allow_reject=allow_reject,
             keep_original=keep_original,
             rename_columns=rename_columns,
@@ -108,7 +108,7 @@ def wrap_transformer(
         )
     return ApplyToSubFrame(
         transformer,
-        cols=selector,
+        cols=cols,
         keep_original=keep_original,
         rename_columns=rename_columns,
     )


### PR DESCRIPTION
it is mostly refactoring but also allows using exclude_cols in .skb.apply() when either cols or exclude_cols is a choice or DataOp by deferring the check for exclude_cols and consolidation into cols to evaluation time