### PR TITLE
call transform() on inner Apply nodes regardless of the mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,9 @@ Changes
 
 Bugfixes
 --------
-
+- An error that could arise when calling ``score`` on a ``SkrubLearner`` that
+  contains an inner transformer that has a ``score`` method has been fixed.
+  :pr:`2052` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Deprecations
 ------------

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1446,9 +1446,9 @@ class Apply(DataOpImpl):
                 method_name = "fit_transform" if "fit" in method_name else "transform"
 
         if "transform" in method_name and not hasattr(self.estimator_, method_name):
-            # We are a predictor need to do 'transform' or 'fit_transform' (as in
-            # `.skb.preview()` or `.skb.eval()`). We replace `.transform()`
-            # with `.predict()`
+            # We are a predictor and need to do 'transform' or 'fit_transform'
+            # (as in `.skb.preview()` or `.skb.eval()`). We replace
+            # `.transform()` with `.predict()`
             if method_name == "fit_transform":
                 fit_kwargs = yield from self._eval_kwargs("fit")
                 self.estimator_.fit(X, y, **fit_kwargs)

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1440,6 +1440,18 @@ class Apply(DataOpImpl):
             # `fit_transform()` so that subsequent steps can be fitted as well.
             method_name = "fit_transform"
 
+        if "transform" not in method_name and hasattr(self.estimator_, "transform"):
+            # We have a transformer but we are evaluating in another mode than
+            # transform or fit_transform and the transformer has the
+            # corresponding (e.g., score mode and the transformer has a
+            # score()). Unless we are the last estimator, we want to call
+            # transform instead.
+            from ._evaluation import HasRunningApplyAncestor
+
+            has_running_apply_ancestor = yield HasRunningApplyAncestor()
+            if has_running_apply_ancestor:
+                method_name = "fit_transform" if "fit" in method_name else "transform"
+
         if "fit" in method_name:
             y_arg = () if self.unsupervised else (y,)
         elif method_name == "score":

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1422,8 +1422,31 @@ class Apply(DataOpImpl):
 
         # 2. Call the appropriate estimator method
 
+        if method_name == "fit" and hasattr(self.estimator_, "fit_transform"):
+            # We are a transformer in 'fit' mode. Rather than `fit()` we call
+            # `fit_transform()`. This is done even if the transformer is the
+            # last estimator, as it can make things easier for downstream nodes
+            # if we are building a transformer rather than a predictor.
+            method_name = "fit_transform"
+
+        if "transform" not in method_name:
+            # We are evaluating in another mode than transform or fit_transform
+            # and the current estimator has the corresponding method. We check
+            # if we are the last estimator: if we are not, we want to transform
+            # instead so that subsequent steps get the transformed data rather
+            # than, for example, a fitted estimator or a score.
+            #
+            # An example situation where this arises is are in score mode and
+            # we have an internal transformer such as PCA that has a score()
+            # method.
+            from ._evaluation import HasRunningApplyAncestor
+
+            has_running_apply_ancestor = yield HasRunningApplyAncestor()
+            if has_running_apply_ancestor:
+                method_name = "fit_transform" if "fit" in method_name else "transform"
+
         if "transform" in method_name and not hasattr(self.estimator_, method_name):
-            # We are a predictor and the mode is 'transform' or 'fit_transform' (as in
+            # We are a predictor need to do 'transform' or 'fit_transform' (as in
             # `.skb.preview()` or `.skb.eval()`). We replace `.transform()`
             # with `.predict()`
             if method_name == "fit_transform":
@@ -1434,23 +1457,6 @@ class Apply(DataOpImpl):
             # In `(fit_)transform` mode only, format the predictions as a
             # dataframe or column if y was one during `fit()`
             return self._format_predictions(X, pred)
-
-        if method_name == "fit" and hasattr(self.estimator_, "fit_transform"):
-            # We are a transformer in 'fit' mode. Rather than `fit()` we call
-            # `fit_transform()` so that subsequent steps can be fitted as well.
-            method_name = "fit_transform"
-
-        if "transform" not in method_name and hasattr(self.estimator_, "transform"):
-            # We have a transformer but we are evaluating in another mode than
-            # transform or fit_transform and the transformer has the
-            # corresponding (e.g., score mode and the transformer has a
-            # score()). Unless we are the last estimator, we want to call
-            # transform instead.
-            from ._evaluation import HasRunningApplyAncestor
-
-            has_running_apply_ancestor = yield HasRunningApplyAncestor()
-            if has_running_apply_ancestor:
-                method_name = "fit_transform" if "fit" in method_name else "transform"
 
         if "fit" in method_name:
             y_arg = () if self.unsupervised else (y,)

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -89,6 +89,23 @@ class _CurrentNodeDuration:
     """
 
 
+class HasRunningApplyAncestor:
+    """
+    Whether there is an Apply node, other than the currently running one, on the stack.
+
+    A `_DataOpTraversal.handle_*()` method can yield an instance of this class
+    to know if there is an Apply node lower on the stack, i.e. if there is an
+    estimator downstream waiting for the result of the currently running node.
+
+    This is used to know if the current estimator is the 'last step in the
+    pipeline'. The 'last step' is treated differently: regardless of the
+    evaluation mode, previous steps should do a transform(). For example when
+    we call score() on a SkrubLearner, we need to call score() on the last
+    estimator it contains, but transform() on its descendants (even if they
+    have a score() method, as some transformers do).
+    """
+
+
 class _DataOpTraversal:
     """Base class for objects that manipulate DataOps."""
 
@@ -125,6 +142,12 @@ class _DataOpTraversal:
         # Used to detect circular references.
         running = set()
 
+        # IDs of Apply nodes that are the target of a _Computation currently on
+        # the stack.
+        # Allows distinguishing the last estimator in the pipeline from
+        # previous ones (see HasRunningApplyAncestor docstring).
+        running_apply = set()
+
         # Total time spent evaluating each node (not counting time spent
         # evaluating its children)
         node_durations = defaultdict(float)
@@ -145,12 +168,15 @@ class _DataOpTraversal:
             generator = handler(top)
             stack.append(_Computation(top_id, generator))
             running.add(top_id)
+            if isinstance(top, DataOp) and isinstance(top._skrub_impl, Apply):
+                running_apply.add(top_id)
 
         def pop():
             "Pop an item off the stack."
             top = stack.pop()
             if isinstance(top, _Computation):
                 running.remove(top.target_id)
+                running_apply.discard(top.target_id)
             return top
 
         def step():
@@ -182,6 +208,9 @@ class _DataOpTraversal:
             elif isinstance(top, _CurrentNodeDuration):
                 pop()
                 last_result = node_durations[stack[-1].target_id]
+            elif isinstance(top, HasRunningApplyAncestor):
+                pop()
+                last_result = bool(running_apply - {stack[-1].target_id})
             elif isinstance(top, DataOp):
                 push_computation(self.handle_data_op)
 

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -101,8 +101,9 @@ class HasRunningApplyAncestor:
     pipeline'. The 'last step' is treated differently: regardless of the
     evaluation mode, previous steps should do a transform(). For example when
     we call score() on a SkrubLearner, we need to call score() on the last
-    estimator it contains, but transform() on its descendants (even if they
-    have a score() method, as some transformers do).
+    estimator it contains, but transform() on the transformers that are
+    evaluated before (even if they have a score() method, as some transformers
+    do).
     """
 
 

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -227,7 +227,8 @@ def test_transformer_with_score():
 
     predictor = pred.skb.make_learner().fit(env)
     # The PCA is not the last estimator: it performs transform()
-    assert isinstance(predictor.score(env), float)
+    # if it performed score() instead the next (Ridge) step would fail.
+    predictor.score(env)
 
 
 def test_predictor_outputs():

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -9,6 +9,7 @@ import pytest
 from pandas.testing import assert_frame_equal
 from sklearn.base import BaseEstimator
 from sklearn.datasets import make_classification, make_regression
+from sklearn.decomposition import PCA
 from sklearn.dummy import DummyRegressor
 from sklearn.linear_model import LogisticRegression, Ridge
 from sklearn.model_selection import GroupKFold, train_test_split
@@ -198,6 +199,35 @@ def test_predictor_as_transformer():
     expected = pd.DataFrame({"a": [2.0, 2.0, 2.0], "b": [20.0, 20.0, 20.0]})
     assert_frame_equal(learner.fit_transform({"X": X, "y": X}), expected)
     assert_frame_equal(learner.transform({"X": X, "y": X}), expected)
+
+
+def test_transformer_with_score():
+    """
+    When a transformer is the last estimator, we can call score() on it, but
+    when it is the descendant of other estimators it does a (fit_)transform
+    even in other modes such as score.
+
+    What we consider is whether it is the last _estimator_ to be evaluated in
+    the current run, other nodes such as a Choice wrapping the final estimators
+    or other nodes than Apply do not affect this.
+    """
+    X_a, y_a = make_regression()
+    env = {"X": X_a, "y": y_a}
+    feat = skrub.X().skb.apply(PCA(n_components=2)).skb.apply_func(lambda x: x)
+    y = skrub.y()
+    ridge_1 = feat.skb.apply(Ridge(), y=y)
+    ridge_2 = feat.skb.apply(Ridge(), y=y)
+    pred = skrub.choose_from([ridge_1, ridge_2]).as_data_op()
+    cv = pred.skb.cross_validate(env)
+    assert not cv["test_score"].isna().any()
+
+    transformer = feat.skb.make_learner().fit(env)
+    # The PCA is the last estimator: it performs score()
+    assert isinstance(transformer.score(env), float)
+
+    predictor = pred.skb.make_learner().fit(env)
+    # The PCA is not the last estimator: it performs transform()
+    assert isinstance(predictor.score(env), float)
 
 
 def test_predictor_outputs():


### PR DESCRIPTION
currently in 'score' mode, .score() is called on all estimators that have a score method. however some transformers have a score method so this can raise an error when calling score() on some SkrubLearners

```python
import skrub
from sklearn.datasets import make_regression
from sklearn.linear_model import Ridge
from sklearn.decomposition import PCA

X_a, y_a = make_regression(random_state=0)
feat = skrub.X(X_a).skb.apply(PCA(n_components=2))
pred = feat.skb.apply(Ridge(), y=skrub.y(y_a))
transformer = feat.skb.make_learner(fitted=True)
print(transformer.score({'X': X_a, 'y': y_a})) # -138.58773589398055

predictor = pred.skb.make_learner(fitted=True)
print(predictor.score({'X': X_a, 'y': y_a}))
# in main branch:
#   ValueError: Expected 2D array, got scalar array instead: array=-138.58773589398055
# with the pr:
#   0.19166321047834467
```