### PR TITLE
temporarily disable report in score mode when using with_scoring

### DIFF
--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -266,6 +266,11 @@ class SkrubLearner(_DataOpWrapperMixin, BaseEstimator):
         >>> predict_results['result']  # doctest: +SKIP
         array([0, 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 1, 0])
         """
+        if mode == "score" and find_scoring_node(self.data_op) is not None:
+            raise NotImplementedError(
+                "Creating the report for 'score' mode when .skb.with_scoring() "
+                "has been used is not implemented yet."
+            )
         from ._inspection import full_report
 
         if mode not in _FITTING_METHODS:

--- a/skrub/_data_ops/tests/test_inspection.py
+++ b/skrub/_data_ops/tests/test_inspection.py
@@ -115,6 +115,23 @@ def test_report_fit_mode():
     assert "olleh" in node_1_report
 
 
+def test_report_score_mode_with_scoring():
+    learner = (
+        skrub.X()
+        .skb.apply(DummyClassifier(), y=skrub.y())
+        .skb.with_scoring("accuracy")
+        .skb.make_learner()
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match=re.escape(
+            "Creating the report for 'score' mode when .skb.with_scoring() "
+            "has been used is not implemented yet."
+        ),
+    ):
+        learner.report(environment={}, mode="score")
+
+
 @pytest.mark.skipif(not _inspection._has_graphviz(), reason="report requires graphviz")
 def test_full_report_open(monkeypatch):
     mock = Mock()


### PR DESCRIPTION
scoring such dataops is a bit more involved than just evaluating in 'score' mode so until that is implemented we raise an error