### PR TITLE
doc: fix Cleaner docstring errors

### DIFF
--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -302,7 +302,7 @@ class Cleaner(TransformerMixin, BaseEstimator):
       library (Pandas or Polars) to force consistent typing and avoid issues downstream.
 
     - ``ToStr()``: convert columns to strings unless they are numerical,
-    categorical, or datetime. This step is controlled by the ``cast_to_str``
+      categorical, or datetime. This step is controlled by the ``cast_to_str``
     parameter. When ``cast_to_str=False`` (default), string conversion is skipped.
     When ``cast_to_str=True``, string conversion is applied.
 


### PR DESCRIPTION
## Summary

Fixes several issues in the `Cleaner` class docstring:

1. **Indentation**: The `ToStr()` bullet point continuation was not properly indented, causing incorrect rendering.
2. **Malformed reference**: Had an extra leading backtick before `:class:`, breaking the reference.

Fixes #2071