### PR TITLE
DOC: reference scikit-learn central

### DIFF
--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -266,6 +266,9 @@ fetchContributors();
 
 <div class="home-footer">The skrub developers - 2026
 &nbsp;&mdash;&nbsp;
-Financial support from <a href="https://inria.fr">inria</a> and <a href="https://probabl.ai">:probabl.</a></div>
+Financial support from <a href="https://inria.fr">inria</a> and <a href="https://probabl.ai">:probabl.</a>
+&nbsp;&mdash;&nbsp;
+Part of <a href="https://scikit-learn-central.probabl.ai">scikit-learn central</a>
+</div>
 
 {%- endblock footer %}

--- a/doc/_templates/scikit-learn-central-footer.html
+++ b/doc/_templates/scikit-learn-central-footer.html
@@ -1,0 +1,2 @@
+Part of <a href="https://scikit-learn-central.probabl.ai">scikit-learn
+central</a> 

--- a/doc/_templates/scikit-learn-central-footer.html
+++ b/doc/_templates/scikit-learn-central-footer.html
@@ -1,2 +1,2 @@
 Part of <a href="https://scikit-learn-central.probabl.ai">scikit-learn
-central</a> 
+central</a>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,7 +233,8 @@ html_theme_options = {
     # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "article_footer_items": ["prev-next.html", "test.html", "test.html"],
     # "content_footer_items": ["prev-next.html", "test.html", "test.html"],
-    "footer_start": ["funding_footer.html", "scikit-learn-central-footer.html"],
+    "footer_start": ["funding_footer.html"],
+    "footer_end": ["scikit-learn-central-footer.html"],
     # When specified as a dictionary, the keys should follow glob-style patterns, as in
     # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-exclude_patterns
     # In particular, "**" specifies the default for all pages

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,7 +233,8 @@ html_theme_options = {
     # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "article_footer_items": ["prev-next.html", "test.html", "test.html"],
     # "content_footer_items": ["prev-next.html", "test.html", "test.html"],
-    "footer_start": ["funding_footer.html"],
+    "footer_start": ["funding_footer.html",
+                     "scikit-learn-central-footer.html"],
     # When specified as a dictionary, the keys should follow glob-style patterns, as in
     # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-exclude_patterns
     # In particular, "**" specifies the default for all pages

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -233,8 +233,7 @@ html_theme_options = {
     # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "article_footer_items": ["prev-next.html", "test.html", "test.html"],
     # "content_footer_items": ["prev-next.html", "test.html", "test.html"],
-    "footer_start": ["funding_footer.html",
-                     "scikit-learn-central-footer.html"],
+    "footer_start": ["funding_footer.html", "scikit-learn-central-footer.html"],
     # When specified as a dictionary, the keys should follow glob-style patterns, as in
     # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-exclude_patterns
     # In particular, "**" specifies the default for all pages


### PR DESCRIPTION
Add a pointer in the footer to scikit-learn central.

skrub is prominent on scikit-learn: https://scikit-learn-central.probabl.ai/
It is in skrub's interest to point there