### PR TITLE
skrub: support numpy arrays in .skb.concat() when all inputs are arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Ongoing development
 
 New Features
 ------------
+- :meth:`DataOp.skb.concat` now accepts numpy arrays when all inputs
+  are arrays, returning a numpy array. Mixed dataframe / numpy inputs
+  still raise as before. :pr:`<NUM>` by
+  :user:`Matthew Van Horn <mvanhorn>`.
 
 Changes
 -------

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -1915,6 +1915,10 @@ class Concat(DataOpImpl):
     _fields = ["first", "others", "axis"]
 
     def compute(self, e, mode, environment):
+        arrays = [e.first, *e.others]
+        if arrays and all(isinstance(a, np.ndarray) for a in arrays):
+            return np.concatenate(arrays, axis=e.axis)
+
         if not sbd.is_dataframe(e.first):
             raise TypeError(
                 "`concat` can only be used with dataframes. "

--- a/skrub/_data_ops/tests/test_evaluation.py
+++ b/skrub/_data_ops/tests/test_evaluation.py
@@ -1,6 +1,7 @@
 import time
 from collections import namedtuple
 
+import numpy as np
 import pytest
 
 import skrub
@@ -323,6 +324,22 @@ def test_describe_steps():
     BinOp: add
     * Cached, not recomputed
     """
+
+
+def test_concat_all_numpy_horizontal():
+    a = skrub.var("a", np.eye(3))
+    b = skrub.var("b", np.eye(3))
+    result = a.skb.concat([b], axis=1).skb.eval()
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (3, 6)
+
+
+def test_concat_all_numpy_vertical():
+    a = skrub.var("a", np.eye(3))
+    b = skrub.var("b", np.eye(3))
+    result = a.skb.concat([b], axis=0).skb.eval()
+    assert isinstance(result, np.ndarray)
+    assert result.shape == (6, 3)
 
 
 def _generator_result(g):


### PR DESCRIPTION
## Summary

Implement the maintainer's diff with the `np.concatenate` correction and add a passing test for the all-arrays path.

1. Edit `skrub/_data_ops/_data_ops.py`, class `Concat.compute` (around line 1917). Insert at the top of the method, before the existing `if not sbd.is_dataframe(e.first):` block:

   ```python
   arrays = [e.first, *e.others]
   if arrays and all(isinstance(a, np.ndarray) for a in arrays):
       return np.concatenate(arrays, axis=e.axis)
   ```

   Confirm `import numpy as np` is already present in the file (it is heavily used elsewhere in this module); add it if not.

   Leave the dataframe-path validation and the column-name handling (`_check_column_names`, `self.all_outputs_`) untouched. They run only when at least one input is a non-array, which is preserved.

2. Edit `skrub/_data_ops/tests/test_errors.py` to ADD a new positive-path test (and keep the existing mixed-type negative tests as-is). The two existing tests `test_concat_horizontal_numpy` and `test_concat_vertical_numpy` only test mixed cases (one var is `np.eye(3)`, the other is a dataframe), so they continue to be correct. Add:

   ```python
   def test_concat_all_numpy_horizontal():
       a = skrub.var("a", np.eye(3))
       b = skrub.var("b", np.eye(3))
       result = a.skb.concat([b], axis=1).skb.eval()
       assert isinstance(result, np.ndarray)
       assert result.shape == (3, 6)


   def test_concat_all_numpy_vertical():
       a = skrub.var("a", np.eye(3))
       b = skrub.var("b", np.eye(3))
       result = a.skb.concat([b], axis=0).skb.eval()
       assert isinstance(result, np.ndarray)
       assert result.shape == (6, 3)
   ```

   (Note: this file already has `import numpy as np` and `import skrub` at the top - verify and reuse rather than re-adding.)

   These tests probably belong in `test_evaluation.py` rather than `test_errors.py` since they are happy-path. Check both files' existing structure and put them in the one that conventionally hosts `skb.concat` positive tests; mirror the surrounding test style. If neither file has clear positive-path concat tests, prefer `test_evaluation.py` and import numpy if needed.

3. Add a "New Features" entry under "Ongoing development" in `CHANGES.rst` (lines 12-13 currently empty under "New Features"):

   ```
   - :meth:`DataOp.skb.concat` now accepts numpy arrays when all inputs
     are arrays, returning a numpy array. Mixed dataframe / numpy inputs
     still raise as before. :pr:`<NUM>` by
     :user:`Matthew Van Horn <mvanhorn>`.
   ```

4. PR template housekeeping: this is feat work, but the repo's pull_request_template.md is bug-fix shaped (`Bug Fix Pull Request`). Switch to a New Features framing in the description but keep the checklist items. Tick the AI Disclosure boxes honestly.

PR title: `FEAT support numpy arrays in .skb.concat() when all inputs are arrays`

PR body (concise):

> Closes #2066.
>
> Implements the diff proposed by @jeromedockes in the issue. When every input to `.skb.concat()` is a numpy array, the result is the concatenation of those arrays via `np.concatenate` (using the existing `axis` argument). Mixed dataframe / numpy inputs continue to raise the same `TypeError` as before.
>
> One small adjustment vs the issue diff: uses `np.concatenate` rather than `np.concat`, since `np.concat` is only available in NumPy 2.0+ and skrub supports `numpy>=1.23.5`.
>
> Adds positive-path tests for horizontal and vertical concatenation of two numpy arrays. The existing mixed-input failure tests in `test_errors.py` are unchanged and still pass.
>
> AI Disclosure: AI-assisted; reviewed line by line, tests run locally.

## Why this matters

Issue #2066 proposes that `.skb.concat()` accept numpy arrays when every input is an array, in addition to the current dataframes-only behavior. The maintainer @jeromedockes opened the issue and pasted the exact starter diff:

```python
def compute(self, e, mode, environment):
    arrays = [e.first, *e.others]
    if all(isinstance(a, np.ndarray) for a in arrays):
        return np.concat(arrays, axis=e.axis)
    if not sbd.is_dataframe(e.first):
        raise TypeError(...)
```

Two correctness details to be careful about:

1. `np.concat` was added in NumPy 2.0 as an alias for `np.concatenate`. skrub's pyproject.toml pins `numpy>=1.23.5`, so we must use `np.concatenate` (or guard for version) to stay compatible with the supported NumPy range.

2. Existing tests in `skrub/_data_ops/tests/test_errors.py` (`test_concat_horizontal_numpy`, `test_concat_vertical_numpy`) explicitly assert that mixing a numpy array and a dataframe raises. Those should keep raising; only the all-arrays case becomes valid. The test patterns where `b = skrub.var("b", np.eye(3))` is concatenated against a dataframe must continue to raise, but a new `test_concat_all_numpy` should pass.

## Testing

- `pytest skrub/_data_ops/tests/test_errors.py -x` - existing `test_concat_horizontal_numpy`, `test_concat_vertical_numpy`, `test_concat_needs_wrapping_in_list`, `test_concat_axis_undefined` still pass (mixed inputs still raise).
- `pytest skrub/_data_ops/tests/test_evaluation.py::test_concat_all_numpy_horizontal -v` passes.
- `pytest skrub/_data_ops/tests/test_evaluation.py::test_concat_all_numpy_vertical -v` passes.
- Manual repro:
  ```python
  import numpy as np, skrub
  a = skrub.var("a", np.eye(3))
  b = skrub.var("b", np.eye(3))
  print(a.skb.concat([b], axis=0).skb.eval().shape)  # -> (6, 3)
  print(a.skb.concat([b], axis=1).skb.eval().shape)  # -> (3, 6)
  ```
- Negative-path manual check: passing one numpy array and one dataframe to `skb.concat` still raises `TypeError` with the existing message.
- `pytest skrub/_data_ops/ -x` - no other data ops test regresses.
- `ruff check` and `ruff format --check` clean on touched files.

Fixes #2066

AI was used for assistance.
