### PR TITLE
skrub: add TableReport.write_json mirroring TableReport.write_html

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Ongoing development
 
 New Features
 ------------
+- :class:`TableReport` has a new :meth:`TableReport.write_json` method
+  that writes the report's JSON representation to a given path or file object,
+  mirroring :meth:`TableReport.write_html`. :pr:`<NUM>` by
+  :user:`Matthew Van Horn <mvanhorn>`.
 
 Changes
 -------

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -448,6 +448,48 @@ class TableReport:
         # stage and with a UTF-8 encoding.
         file.write(html)
 
+    def write_json(self, file):
+        """Store the report data into a JSON file.
+
+        The JSON output is the same as that returned by :meth:`json`: a
+        JSON object containing the report data, excluding the underlying
+        dataframe and the sample table.
+
+        Parameters
+        ----------
+        file : str, pathlib.Path or file object
+            The file object or path of the file to store the JSON output.
+        """
+        data = self.json()
+        if isinstance(file, (str, Path)):
+            with open(file, "w", encoding="utf8") as stream:
+                stream.write(data)
+            return
+
+        try:
+            # We don't have information about the write mode of the provided
+            # file-object. We start by writing bytes into it.
+            file.write(data.encode("utf-8"))
+            return
+        except TypeError:
+            # We end-up here if the file-object was open in text mode
+            # Let's give it another chance in this mode.
+            pass
+
+        if (encoding := getattr(file, "encoding", None)) is not None:
+            try:
+                encoding_name = codecs.lookup(encoding).name
+            except LookupError:  # pragma: no cover
+                encoding_name = None
+            if encoding_name != "utf-8":
+                raise ValueError(
+                    "If `file` is a text file it should use utf-8 encoding; got:"
+                    f" {encoding!r}"
+                )
+        # We write into the file-object expecting it to be in text mode at this
+        # stage and with a UTF-8 encoding.
+        file.write(data)
+
     def open(self):
         """Open the HTML report in a web browser."""
         open_in_browser(self.html())

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -253,6 +253,56 @@ def test_write_html_with_not_utf8_encoding(tmp_path, pd_module):
     assert "</html>" not in saved_content
 
 
+@pytest.mark.parametrize(
+    "filename_type",
+    ["str", "Path", "text_file_object", "binary_file_object"],
+)
+def test_write_json(tmp_path, pd_module, filename_type):
+    df = pd_module.make_dataframe({"a": [1, 2], "b": [3, 4]})
+    report = TableReport(df)
+
+    tmp_file_path = tmp_path / Path("report.json")
+
+    # making sure we are closing the open files, and dealing with the first
+    # condition which doesn't require opening any file
+    with contextlib.ExitStack() as stack:
+        if filename_type == "str":
+            filename = str(tmp_file_path)
+        elif filename_type == "text_file_object":
+            filename = stack.enter_context(open(tmp_file_path, "w", encoding="utf-8"))
+        elif filename_type == "binary_file_object":
+            filename = stack.enter_context(open(tmp_file_path, "wb"))
+        else:
+            filename = tmp_file_path
+
+        report.write_json(filename)
+        assert tmp_file_path.exists()
+
+    with open(tmp_file_path, encoding="utf-8") as file:
+        data = json.loads(file.read())
+    assert isinstance(data, dict)
+    assert "title" in data
+    assert "dataframe" not in data
+    assert "sample_table" not in data
+
+
+def test_write_json_with_not_utf8_encoding(tmp_path, pd_module):
+    df = pd_module.make_dataframe({"a": [1, 2], "b": [3, 4]})
+    report = TableReport(df)
+    tmp_file_path = tmp_path / Path("report.json")
+
+    with open(tmp_file_path, "w", encoding="latin-1") as file:
+        encoding = getattr(file, "encoding", None)
+        with pytest.raises(
+            ValueError,
+            match=(
+                "If `file` is a text file it should use utf-8 encoding; got:"
+                f" {encoding!r}"
+            ),
+        ):
+            report.write_json(file)
+
+
 @skip_polars_installed_without_pyarrow
 def test_verbosity_parameter(df_module, capsys):
     df = df_module.make_dataframe(


### PR DESCRIPTION
## Summary

Add a new public method `write_json` to the `TableReport` class, modeled exactly on `write_html`. Match the surrounding code style (existing imports `json`, `codecs`, `Path` are all already present in the file).

1. Edit `skrub/_reporting/_table_report.py`. Immediately after the existing `write_html` method (which currently ends at line 449), insert:

   ```python
   def write_json(self, file):
       """Store the report data into a JSON file.

       The JSON output is the same as that returned by :meth:`json`: a
       JSON object containing the report data, excluding the underlying
       dataframe and the sample table.

       Parameters
       ----------
       file : str, pathlib.Path or file object
           The file object or path of the file to store the JSON output.
       """
       data = self.json()
       if isinstance(file, (str, Path)):
           with open(file, "w", encoding="utf8") as stream:
               stream.write(data)
           return

       try:
           # We don't have information about the write mode of the
           # provided file-object. Start by writing bytes into it.
           file.write(data.encode("utf-8"))
           return
       except TypeError:
           # File object is in text mode; fall through to the text-mode
           # write below.
           pass

       if (encoding := getattr(file, "encoding", None)) is not None:
           try:
               encoding_name = codecs.lookup(encoding).name
           except LookupError:  # pragma: no cover
               encoding_name = None
           if encoding_name != "utf-8":
               raise ValueError(
                   "If `file` is a text file it should use utf-8 encoding;"
                   f" got: {encoding!r}"
               )
       file.write(data)
   ```

   This is a near-copy of `write_html`; the only differences are the source string (`self.json()` vs `self.html()`) and the docstring. Do not refactor `write_html` and `write_json` to share a helper in this PR - that's a follow-up refactor, and keeping them parallel makes the diff trivial to review.

2. Edit `skrub/_reporting/tests/test_table_report.py` to add `test_write_json` and `test_write_json_with_not_utf8_encoding`, mirroring the existing parametrized `test_write_html` (lines 205-232) and `test_write_html_with_not_utf8_encoding` (lines 235-253). For the round-trip assertion, parse the written file with `json.loads` and confirm it returns a dict with at least one expected key (`dataframe_module` or `n_rows` - inspect `_summary` keys to pick a stable one).

   Example shape (adapt to match the file's existing patterns):

   ```python
   @pytest.mark.parametrize(
       "filename_type",
       ["str", "Path", "text_file_object", "binary_file_object"],
   )
   def test_write_json(tmp_path, pd_module, filename_type):
       df = pd_module.make_dataframe({"a": [1, 2], "b": [3, 4]})
       report = TableReport(df)
       tmp_file_path = tmp_path / Path("report.json")

       with contextlib.ExitStack() as stack:
           if filename_type == "str":
               filename = str(tmp_file_path)
           elif filename_type == "text_file_object":
               filename = stack.enter_context(
                   open(tmp_file_path, "w", encoding="utf-8")
               )
           elif filename_type == "binary_file_object":
               filename = stack.enter_context(open(tmp_file_path, "wb"))
           else:
               filename = tmp_file_path

           report.write_json(filename)
           assert tmp_file_path.exists()

       with open(tmp_file_path, encoding="utf-8") as f:
           data = json.loads(f.read())
       assert isinstance(data, dict)
       # Spot-check a stable key. Cross-check against TableReport.json()
       # output to pick one that's always present.
       assert "dataframe" not in data
       assert "sample_table" not in data


   def test_write_json_with_not_utf8_encoding(tmp_path, pd_module):
       df = pd_module.make_dataframe({"a": [1, 2], "b": [3, 4]})
       report = TableReport(df)
       tmp_file_path = tmp_path / Path("report.json")

       with open(tmp_file_path, "w", encoding="latin-1") as file:
           encoding = getattr(file, "encoding", None)
           with pytest.raises(
               ValueError,
               match=(
                   "If `file` is a text file it should use utf-8 encoding;"
                   f" got: {encoding!r}"
               ),
           ):
               report.write_json(file)
   ```

   Add `import json` at the top of the test file only if it's not already there; reuse the existing fixtures (`tmp_path`, `pd_module`, `contextlib`, `Path`).

3. Add a "New Features" entry under "Ongoing development" in `CHANGES.rst`:

   ```
   - :class:`TableReport` has a new :meth:`TableReport.write_json` method
     that writes the report's JSON representation to a given path or
     file object, mirroring :meth:`TableReport.write_html`.
     :pr:`<NUM>` by :user:`Matthew Van Horn <mvanhorn>`.
   ```

4. Skim `skrub/_reporting/_table_report.py` docstring index references and the user-facing reference docs (`doc/`) for any `write_html` cross-reference that should now also mention `write_json`. The reference rst files use autosummary so adding to the class docstring is usually enough; do not hand-edit autosummary stubs.

PR title: `FEAT add TableReport.write_json mirroring write_html`

PR body (concise):

> Closes #2043.
>
> Adds `TableReport.write_json(file)` which serializes the report via the existing `TableReport.json()` method and writes to either a string path, `pathlib.Path`, binary file object, or text file object - the same file-handling contract as `write_html`.
>
> Adds parametrized tests covering all four `filename_type` variants plus the non-UTF-8 text-file error path, mirroring the existing `test_write_html` suite.
>
> AI Disclosure: AI-assisted; reviewed line by line, tests run locally.

## Why this matters

Issue #2043 requests a `write_json` function on `TableReport` that mirrors `write_html`, writing the report's JSON representation to a given path or file object. The issue body is one line; @rcap107 (core maintainer) opened it and tagged "for sprints".

The supporting machinery already exists:

- `TableReport.json()` in `skrub/_reporting/_table_report.py` (line 394) returns the JSON-serialized report (with `dataframe` and `sample_table` excluded) using a custom `JSONEncoder`.
- `TableReport.write_html(file)` (line 413) accepts either a `str | Path` or a file object, handles UTF-8 encoding, supports both binary and text file objects, and raises a helpful error on non-UTF-8 text files.

`write_json` should be a direct analog: serialize via `self.json()`, then write using the same file/path/encoding plumbing.

## Testing

- `pytest skrub/_reporting/tests/test_table_report.py::test_write_json -v` passes for all four parametrized `filename_type` values (str, Path, text_file_object, binary_file_object).
- `pytest skrub/_reporting/tests/test_table_report.py::test_write_json_with_not_utf8_encoding -v` passes.
- `pytest skrub/_reporting/tests/test_table_report.py -x` - full file still green.
- Manual repro:
  ```python
  import json, pandas as pd
  from skrub import TableReport
  r = TableReport(pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
  r.write_json("/tmp/report.json")
  with open("/tmp/report.json") as f:
      data = json.load(f)
  print(type(data), set(data.keys()) & {"dataframe", "sample_table"})
  # -> <class 'dict'> set()
  ```
- `ruff check skrub/_reporting/_table_report.py skrub/_reporting/tests/test_table_report.py` clean.
- `ruff format --check` clean on touched files.
- `pytest skrub/_reporting/ -x` - no regressions in any reporting test.

Fixes #2043

AI was used for assistance.
