### PR TITLE
DOC Fix verbose default inconsistency in TableReport docstring

### DIFF
--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -127,7 +127,7 @@ class TableReport:
     verbose : int, default = None
         Whether to print progress information while the report is being generated.
 
-        * verbose = None uses the global configuration (see :func:`set_config`),
+        * verbose = ``None`` uses the global configuration (see :func:`set_config`),
           which then defaults to 1.
         * verbose = 1 prints how many columns have been processed so far.
         * verbose = 0 silences the output.

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -124,9 +124,11 @@ class TableReport:
         formats for the filter values are a list of column names,
         a list of column indices, or a Selector object.
         See the end of the "Examples" section below for details.
-    verbose : int, default = 1
+    verbose : int, default = None
         Whether to print progress information while the report is being generated.
 
+        * verbose = None uses the global configuration (see :func:`set_config`),
+          which then defaults to 1.
         * verbose = 1 prints how many columns have been processed so far.
         * verbose = 0 silences the output.
     plot_distributions : bool or "auto", default="auto"


### PR DESCRIPTION
# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

<!-- Please include a summary of the bug fix -->

Fix inconsistency in `TableReport` docstring where `verbose` was documented as defaulting to `1`, while the actual default in the signature is `None` (which defers to the global config).

See #1182 and #1567 for historic reasons.

## Checklist

- [x] I have read the contributing guidelines
- [ ] I have added tests that verify the bug fix
- [ ] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## AI Disclosure

- [ ] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
