### PR TITLE
Added message and and test for associations tab with one column in _data/templates column-assosiations.html and tests/test_table_report.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Changes
 - An unnecessary warning that was raised when passing a numpy array to the
   TableVectorizer has been removed. :pr:`1908` by
   :user:`Sandrine Henry <sandrineh>`.
+- Improving the association tab error message when only one column is present
+  :pr:`#2094` by :user:`Alicja Kosak <AlicjaKo>`.
 
 Bugfixes
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Changes
   TableVectorizer has been removed. :pr:`1908` by
   :user:`Sandrine Henry <sandrineh>`.
 - Improving the association tab error message when only one column is present
-  :pr:`#2094` by :user:`Alicja Kosak <AlicjaKo>`.
+  :pr:`2094` by :user:`Alicja Kosak <AlicjaKo>`.
 
 Bugfixes
 --------

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -1,6 +1,7 @@
 """
 This module provides the implementation of the DatetimeEncoder
 """
+
 from datetime import datetime, timezone
 
 import numpy as np

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -83,5 +83,5 @@
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-    
+
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -79,8 +79,7 @@
         In this case, one of them may be redundant and for some models (such as linear models) it might be beneficial to remove it.
     </div>
 
-    {% else %}
-    {% if summary["n_columns"] == 1 %}
+    {% elif summary['n_columns'] == 1%}
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -83,5 +83,5 @@
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-
+    {% endif %}
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -83,5 +83,6 @@
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
+    {% endif %}
 
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -83,5 +83,5 @@
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-    {% endif %}
+    
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -80,6 +80,10 @@
     </div>
 
     {% else %}
+    {% if summary["n_columns"] == 1 %}
+    No associations were computed because the dataframe has only one column.
+    {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
+    {% endif %}
     {% endif %}
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -83,5 +83,5 @@
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-    {% endif %}
+
 </article>

--- a/skrub/_reporting/_data/templates/column-associations.html
+++ b/skrub/_reporting/_data/templates/column-associations.html
@@ -79,10 +79,9 @@
         In this case, one of them may be redundant and for some models (such as linear models) it might be beneficial to remove it.
     </div>
 
-    {% elif summary['n_columns'] == 1%}
+    {% elif summary['n_columns'] == 1 %}
     No associations were computed because the dataframe has only one column.
     {% else %}
     No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.
-    {% endif %}
     {% endif %}
 </article>

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -443,6 +443,10 @@ def test_single_column_report(df_module):
     col_name = sbd.name(single_col)
     html = report.html()
     assert col_name in html
+    assert (
+        "No associations were computed because the dataframe has only one "
+        "column." in html
+    )
 
 
 def test_error_make_table():


### PR DESCRIPTION
# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

So far for one column in associations tab message was "No strong associations between any pair of columns were identified by a quick screening of a subsample of the dataframe.", it was not a major issue bu misleading. I added "No associations were computed because the dataframe has only one column" message and test for that.

Addresses #1747

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

I did a code test and it passed.

## AI Disclosure

- [ ] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
