### PR TITLE
Alphabetical order of autosummary lists

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -220,6 +220,7 @@ API_REFERENCE = {
                 "description": (
                     "The ``skb`` accessor exposes all DataOps methods and attributes."
                 ),
+                "sort": True,
                 "autosummary": [
                     "DataOp.skb.apply",
                     "DataOp.skb.apply_func",
@@ -260,6 +261,7 @@ API_REFERENCE = {
             },
             {
                 "description": "Accessor attributes.",
+                "sort": True,
                 "autosummary": [
                     "DataOp.skb.description",
                     "DataOp.skb.is_X",
@@ -339,3 +341,9 @@ API_REFERENCE = {
         ],
     },
 }
+# Some autosummary lists are long; for those alphabetical order is the most
+# useful for browsing. Sections flagged with "sort": True are reordered here.
+for module in API_REFERENCE.values():
+    for section in module["sections"]:
+        if section.pop("sort", False):
+            section["autosummary"].sort()


### PR DESCRIPTION
…most

# useful for browsing. Sections flagged with "sort": True are reordered here.

# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

<!-- Please include a summary of the bug fix -->

Addresses #<!-- issue number -->

## Checklist

- [+] I have read the contributing guidelines
- [-] I have added tests that verify the bug fix
- [-] I have added an entry to CHANGES.rst describing the fix
- [+] My code follows the code style of this project
- [+] I have checked my code and corrected any misspellings

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
The code was checked manually in the terminal by:
python -c "import api_reference as ar; l = ar.API_REFERENCE['data_ops']['sections'][4]['autosummary']; assert l == sorted(l), 'not sort'; print('OK, sort')"

## AI Disclosure

- [-] This PR contains AI-generated code
    - [+] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
