### PR TITLE
#1464 Deprecate the parameter order_by of the TableReport

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,8 +33,8 @@ Deprecations
 ------------
 
 - The parameter ``order_by`` of :class:`TableReport` is deprecated. Passing
-  ``order_by`` now emits a :class:`DeprecationWarning`.
-  This parameter will be removed in a future release.
+  ``order_by`` now emits a :class:`DeprecationWarning`
+  :pr:`2101` by :user:`Heidi Koivisto <uniheko>`.
 
 
 Release 0.9.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ Bugfixes
 Deprecations
 ------------
 
+- The parameter ``order_by`` of :class:`TableReport` is deprecated. Passing
+  ``order_by`` now emits a :class:`DeprecationWarning`.
+  This parameter will be removed in a future release.
+
 
 Release 0.9.0
 =============

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -114,8 +114,10 @@ class TableReport:
     order_by : str, deprecated
         Deprecated. Column name to use for sorting. Other numerical columns
         will be plotted as function of the sorting column. Must be of
-        numerical or datetime type. Prefer sorting the dataframe prior to
-        creating the report (e.g. ``df.sort_values('col')``).
+        numerical or datetime type.
+
+        .. deprecated:: 0.10.0
+
     title : str
         Title for the report.
     column_filters : dict
@@ -280,8 +282,7 @@ class TableReport:
         if order_by is not None:
             warnings.warn(
                 "'order_by' parameter of TableReport is deprecated and will be"
-                " removed in a future version. Sort your dataframe before passing"
-                " it to TableReport (e.g. df.sort_values('col')).",
+                " removed in a future version.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -111,10 +111,11 @@ class TableReport:
         from the beginning (head) of the dataframe and half from the end
         (tail). Note this is only for display. Summary statistics, histograms
         etc. are computed using the whole dataframe.
-    order_by : str
-        Column name to use for sorting. Other numerical columns will be plotted
-        as function of the sorting column. Must be of numerical or datetime
-        type.
+    order_by : str, deprecated
+        Deprecated. Column name to use for sorting. Other numerical columns
+        will be plotted as function of the sorting column. Must be of
+        numerical or datetime type. Prefer sorting the dataframe prior to
+        creating the report (e.g. ``df.sort_values('col')``).
     title : str
         Title for the report.
     column_filters : dict
@@ -274,6 +275,16 @@ class TableReport:
                 f"'open_tab' must be one of {valid_tabs}, got {open_tab!r}."
             )
         self.open_tab = open_tab
+
+        # Deprecate order_by parameter on TableReport; prefer pre-sorted dataframes
+        if order_by is not None:
+            warnings.warn(
+                "'order_by' parameter of TableReport is deprecated and will be"
+                " removed in a future version. Sort your dataframe before passing"
+                " it to TableReport (e.g. df.sort_values('col')).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         self._summary_kwargs = {
             "order_by": order_by,

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -122,6 +122,14 @@ def test_deprecated_max_association_columns(df_module):
 
 
 @skip_polars_installed_without_pyarrow
+def test_deprecated_order_by(df_module):
+    """`order_by` parameter should emit a DeprecationWarning."""
+    df = df_module.make_dataframe({"a": [1, 2, 3]})
+    with pytest.warns(DeprecationWarning, match="order_by"):
+        TableReport(df, order_by="a")
+
+
+@skip_polars_installed_without_pyarrow
 def test_few_rows(df_module, check_polars_numpy2):
     df = sbd.slice(df_module.example_dataframe, 2)
     TableReport(df).html()


### PR DESCRIPTION
# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

This PR deprecates the parameter order_by from TableReport.

Addresses #1464

## Checklist

- [X] I have read the contributing guidelines
- [X] I have added tests that verify the bug fix
- [X] I have added an entry to CHANGES.rst describing the fix
- [X] My code follows the code style of this project
- [X] I have checked my code and corrected any misspellings

## How Has This Been Tested?

I run this: pytest --pyargs skrub, which exited cleanly. Warning report:

============================================= 1923 passed, 398 skipped, 41 xfailed, 298 xpassed, 184 warnings in 522.70s (0:08:42) =============================================

Which are coming from dependencies like scikit-learn, pandas, and numpydoc, plus a few warnings emitted by skrub code paths that the test suite exercises intentionally

## AI Disclosure

- [ ] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
