### PR TITLE
DOC Fix Cleaner docstring formatting

### DIFF
--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -1,6 +1,7 @@
 """
 This module provides the implementation of the DatetimeEncoder
 """
+
 from datetime import datetime, timezone
 
 import numpy as np

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -363,7 +363,7 @@ class Cleaner(TransformerMixin, BaseEstimator):
     dtype: object
 
     Columns can be excluded from processing by combining the ``Cleaner`` with
-    `:class:`~skrub.ApplyToCols`. For example, to exclude the datetime column from
+    :class:`~skrub.ApplyToCols`. For example, to exclude the datetime column from
     processing and keep it as a string, we can do:
 
     >>> from skrub import ApplyToCols

--- a/skrub/_table_vectorizer.py
+++ b/skrub/_table_vectorizer.py
@@ -292,6 +292,7 @@ class Cleaner(TransformerMixin, BaseEstimator):
       it is forwarded to :class:`ToDatetime`. Otherwise, the format is inferred.
 
     - :class:`ToFloat`:
+
       - if ``parse_numbers=True``, apply :class:`ToFloat` on string columns,
         converting strings whose non-missing values can all be parsed as numbers
         to ``float32``;
@@ -302,12 +303,15 @@ class Cleaner(TransformerMixin, BaseEstimator):
       library (Pandas or Polars) to force consistent typing and avoid issues downstream.
 
     - ``ToStr()``: convert columns to strings unless they are numerical,
-    categorical, or datetime. This step is controlled by the ``cast_to_str``
-    parameter. When ``cast_to_str=False`` (default), string conversion is skipped.
-    When ``cast_to_str=True``, string conversion is applied.
+      categorical, or datetime. This step is controlled by the ``cast_to_str``
+      parameter. When ``cast_to_str=False`` (default), string conversion is
+      skipped. When ``cast_to_str=True``, string conversion is applied.
 
-    Example:
 
+
+    Examples
+    --------
+    >>> from skrub import Cleaner
     >>> import pandas as pd
     >>> df = pd.DataFrame({"num_str": ["1", "2"], "num": [1, 2], "f": [1.0, 2.0]})
     >>> Cleaner(parse_numbers=False).fit_transform(df).dtypes  # doctest: +SKIP
@@ -321,11 +325,6 @@ class Cleaner(TransformerMixin, BaseEstimator):
     num        ...
     f          float32
     dtype: object
-
-    Examples
-    --------
-    >>> from skrub import Cleaner
-    >>> import pandas as pd
     >>> df = pd.DataFrame({
     ...     'A': ['one', 'two', 'two', 'three'],
     ...     'B': ['02/02/2024', '23/02/2024', '12/03/2024', '13/03/2024'],


### PR DESCRIPTION
## Description

Fixes formatting issues in the `Cleaner` documentation.

Changes:
- fixes nested bullet formatting under `ToFloat`
- fixes indentation in the `ToStr()` note
- moves the numeric conversion example from `Notes` to `Examples`
- removes the duplicate `Examples` heading

This is a documentation-only change.

Addresses  fix small errors in Cleaner documentation #2071


## Checklist

- [x] I have read the contributing guidelines
- [ ] I have added tests that verify the bug fix
- [ ] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested

I ran:

```bash
pytest -v skrub/tests/test_docstrings.py -k Cleaner
pytest -vsl skrub/tests/test_table_vectorizer.py -k "cleaner or vectorizer"
pre-commit run --files skrub/_table_vectorizer.py

## AI Disclosure

- [ x] This PR contains AI-generated code
    - [ x] I have tested the code generated in my PR
    - [ x] I have read and understood every line that has been generated by the AI agent
    - [ x] I can explain what the AI-generated code does
