### PR TITLE
Add drop method to selector base class and include unit tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,9 @@ New Features
 - A new dataframe generator, :func:`datasets.toy_cities`, has been added for
   use cases on dataframes with variable sizes and variable correlation between
   columns. :pr:`2042` by :user:`Eloi Massoulié <emassoulie>`.
+- A new selector function, :func:`selectors.drop`, has been added to drop columns
+  from a dataframe using a selector. It mirrors the behavior of :func:`selectors.select`.
+  :pr:`2108` by :user:`Mary Njoroge <Maryahcee>`.
 
 Changes
 -------

--- a/skrub/selectors/__init__.py
+++ b/skrub/selectors/__init__.py
@@ -85,6 +85,7 @@ from ._base import (
     Selector,
     all,
     cols,
+    drop,
     filter,
     filter_names,
     inv,
@@ -104,6 +105,7 @@ __all__ = [
     "inv",
     "make_selector",
     "select",
+    "drop",
 ]
 __all__ += _selectors.__all__
 

--- a/skrub/selectors/_base.py
+++ b/skrub/selectors/_base.py
@@ -220,6 +220,62 @@ def select(df, selector):
     return _select_col_names(df, make_selector(selector).expand(df))
 
 
+def drop(df, selector):
+    """Apply a selector to a dataframe and return a dataframe without the \
+    selected columns.
+
+    ``selector`` can be anything accepted by ``make_selector`` i.e. a selector,
+    column name or list of column names.
+
+    Parameters
+    ----------
+    df : dataframe
+        The dataframe to process.
+    selector : selector, str, or list
+        A selector object, column name, or list of column names indicating which
+        columns to drop.
+
+    Returns
+    -------
+    dataframe
+        The dataframe without the columns matched by the selector.
+
+    Examples
+    --------
+    >>> from skrub import selectors as s
+    >>> import pandas as pd
+    >>> df = pd.DataFrame(
+    ...     {
+    ...         "height_mm": [210.0, 297.0],
+    ...         "width_mm": [188.5, 210.0],
+    ...         "kind": ["A5", "A4"],
+    ...         "ID": [5, 4],
+    ...     }
+    ... )
+    >>> df
+       height_mm  width_mm kind  ID
+    0      210.0     188.5   A5   5
+    1      297.0     210.0   A4   4
+
+    >>> s.drop(df, s.glob("*_mm"))
+      kind  ID
+    0   A5   5
+    1   A4   4
+
+    We can also pass column names directly:
+
+    >>> s.drop(df, ['height_mm', 'width_mm'])
+      kind  ID
+    0   A5   5
+    1   A4   4
+
+    """
+    all_cols = sbd.column_names(df)
+    matched_cols = make_selector(selector).expand(df)
+    remaining_cols = [col for col in all_cols if col not in matched_cols]
+    return _select_col_names(df, remaining_cols)
+
+
 class Selector:
     """Generic selector type, that returns set columns when applied.
 
@@ -273,39 +329,6 @@ class Selector:
             if self._matches(col):
                 matching_col_names.append(col_name)
         return matching_col_names
-
-    def drop(self, df):
-        """Apply the selector to a dataframe and return a dataframe without the \
-        selected columns.
-        Parameters
-        ----------
-        df : dataframe
-        Returns
-        -------
-        dataframe
-            The dataframe without the columns matched by the selector.
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> from skrub import selectors as s
-        >>> selector = s.glob("*_mm")
-        >>> df = pd.DataFrame(
-        ...     {
-        ...         "height_mm": [210.0, 297.0],
-        ...         "width_mm": [188.5, 210.0],
-        ...         "kind": ["A5", "A4"],
-        ...         "ID": [5, 4],
-        ...     }
-        ... )
-        >>> selector.drop(df)
-           kind  ID
-        0    A5   5
-        1    A4   4
-        """
-        all_cols = sbd.column_names(df)
-        matched_cols = self.expand(df)
-        remaining_cols = [col for col in all_cols if col not in matched_cols]
-        return _select_col_names(df, remaining_cols)
 
     def expand_index(self, df):
         """Lists the indices of dataframe ``df``'s columns that the selector \

--- a/skrub/selectors/_base.py
+++ b/skrub/selectors/_base.py
@@ -274,6 +274,39 @@ class Selector:
                 matching_col_names.append(col_name)
         return matching_col_names
 
+    def drop(self, df):
+        """Apply the selector to a dataframe and return a dataframe without the \
+        selected columns.
+        Parameters
+        ----------
+        df : dataframe
+        Returns
+        -------
+        dataframe
+            The dataframe without the columns matched by the selector.
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from skrub import selectors as s
+        >>> selector = s.glob("*_mm")
+        >>> df = pd.DataFrame(
+        ...     {
+        ...         "height_mm": [210.0, 297.0],
+        ...         "width_mm": [188.5, 210.0],
+        ...         "kind": ["A5", "A4"],
+        ...         "ID": [5, 4],
+        ...     }
+        ... )
+        >>> selector.drop(df)
+           kind  ID
+        0    A5   5
+        1    A4   4
+        """
+        all_cols = sbd.column_names(df)
+        matched_cols = self.expand(df)
+        remaining_cols = [col for col in all_cols if col not in matched_cols]
+        return _select_col_names(df, remaining_cols)
+
     def expand_index(self, df):
         """Lists the indices of dataframe ``df``'s columns that the selector \
         would retain if applied to ``df``.

--- a/skrub/selectors/tests/test_base.py
+++ b/skrub/selectors/tests/test_base.py
@@ -13,25 +13,29 @@ def test_import_selectors():
 
 def test_repr():
     """
-    >>> from skrub import selectors as s
-    >>> s.all()
-    all()
-    >>> s.all() - ["ID", "Name"]
-    (all() - cols('ID', 'Name'))
-    >>> s.cols("ID", "Name") & "ID"
-    (cols('ID', 'Name') & cols('ID'))
-    >>> s.filter_names(lambda n: 'a' in n) ^ s.filter(lambda c: c[2] == 3)
-    (filter_names(<lambda>) ^ filter(<lambda>))
-    >>> ~s.all()
-    (~all())
-    >>> s.Filter(lambda c, x: c[2] == x, args=(3,), name='my_filter')
-    my_filter(3)
-    >>> s.Filter(lambda c, x: c[2] == x, args=(3,), selector_repr='my_filter()')
-    my_filter()
-    >>> s.NameFilter(lambda c_n, n: c_n.lower() == n,
-    ...              args=('col',),
-    ...              selector_repr='lower_check()')
-    lower_check()
+     >>> from skrub import selectors as s
+     >>> s.all()
+     all()
+     >>> s.all() - ["ID", "Name"]
+     (all() - cols('ID', 'Name'))
+     >>> s.cols("ID", "Name") & "ID"
+     (cols('ID', 'Name') & cols('ID'))
+     >>> s.filter_names(lambda n: 'a' in n) ^ s.filter(lambda c: c[2] == 3)
+     (filter_names(<lambda>) ^ filter(<lambda>))
+     >>> ~s.all()
+     (~all())
+     >>> s.Filter(lambda c, x: c[2] == x, args=(3,), name='my_filter')
+     my_filter(3)
+     >>> s.Filter(lambda c, x: c[2] == x, args=(3,), selector_repr='my_filter()')
+     my_filter()
+     >>> s.NameFilter(lambda c_n, n: c_n.lower() == n,
+     ...              args=('col',),
+     ...              selector_repr='lower_check()')
+     lower_check()
+     >>> import pandas as pd
+    >>> (s.cols("ID","Name")).drop(pd.DataFrame({"ID":[1],"Name":["A"],"Age":[1]}))
+        Age
+     0    1
     """
 
 
@@ -47,6 +51,16 @@ def test_select(df_module):
     df = df_module.example_dataframe
     df_module.assert_frame_equal(
         s.select(df, s.cols("float-col", "str-col")), df[["float-col", "str-col"]]
+    )
+
+
+def test_drop(df_module):
+    df = df_module.example_dataframe
+    df_module.assert_frame_equal(
+        s.cols("float-col", "str-col").drop(df),
+        df[
+            [col for col in sbd.column_names(df) if col not in ["float-col", "str-col"]]
+        ],
     )
 
 

--- a/skrub/selectors/tests/test_base.py
+++ b/skrub/selectors/tests/test_base.py
@@ -13,29 +13,29 @@ def test_import_selectors():
 
 def test_repr():
     """
-     >>> from skrub import selectors as s
-     >>> s.all()
-     all()
-     >>> s.all() - ["ID", "Name"]
-     (all() - cols('ID', 'Name'))
-     >>> s.cols("ID", "Name") & "ID"
-     (cols('ID', 'Name') & cols('ID'))
-     >>> s.filter_names(lambda n: 'a' in n) ^ s.filter(lambda c: c[2] == 3)
-     (filter_names(<lambda>) ^ filter(<lambda>))
-     >>> ~s.all()
-     (~all())
-     >>> s.Filter(lambda c, x: c[2] == x, args=(3,), name='my_filter')
-     my_filter(3)
-     >>> s.Filter(lambda c, x: c[2] == x, args=(3,), selector_repr='my_filter()')
-     my_filter()
-     >>> s.NameFilter(lambda c_n, n: c_n.lower() == n,
-     ...              args=('col',),
-     ...              selector_repr='lower_check()')
-     lower_check()
-     >>> import pandas as pd
-    >>> (s.cols("ID","Name")).drop(pd.DataFrame({"ID":[1],"Name":["A"],"Age":[1]}))
-        Age
-     0    1
+    >>> from skrub import selectors as s
+    >>> s.all()
+    all()
+    >>> s.all() - ["ID", "Name"]
+    (all() - cols('ID', 'Name'))
+    >>> s.cols("ID", "Name") & "ID"
+    (cols('ID', 'Name') & cols('ID'))
+    >>> s.filter_names(lambda n: 'a' in n) ^ s.filter(lambda c: c[2] == 3)
+    (filter_names(<lambda>) ^ filter(<lambda>))
+    >>> ~s.all()
+    (~all())
+    >>> s.Filter(lambda c, x: c[2] == x, args=(3,), name='my_filter')
+    my_filter(3)
+    >>> s.Filter(lambda c, x: c[2] == x, args=(3,), selector_repr='my_filter()')
+    my_filter()
+    >>> s.NameFilter(lambda c_n, n: c_n.lower() == n,
+    ... args=('col',),
+    ... selector_repr='lower_check()')
+    lower_check()
+    >>> import pandas as pd
+    >>> s.drop(pd.DataFrame({"ID":[1],"Name":["A"],"Age":[1]}), s.cols("ID","Name"))
+       Age
+    0    1
     """
 
 
@@ -57,7 +57,7 @@ def test_select(df_module):
 def test_drop(df_module):
     df = df_module.example_dataframe
     df_module.assert_frame_equal(
-        s.cols("float-col", "str-col").drop(df),
+        s.drop(df, s.cols("float-col", "str-col")),
         df[
             [col for col in sbd.column_names(df) if col not in ["float-col", "str-col"]]
         ],


### PR DESCRIPTION
# Bug Fix Pull Request

## Description

Add drop  function to the selectors module for dropping columns from a dataframe using a selector.

   Changes:

      - Implements the drop() module-level function in skrub/selectors/_base.py
     - Adds dedicated unit tests verifying drop logic across both Pandas and Polars DataFrames

Addresses Add drop method to selector base class and include unit tests #2083


## Checklist

- [ x] I have read the contributing guidelines
- [ x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x ] My code follows the code style of this project
- [ x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

I ran:
     ```
   pytest skrub/selectors/_base.py -v  
   pytest skrub/selectors/tests/test_base.py -v
   pre-commit run --all-file
```

## AI Disclosure

- [ x] This PR contains AI-generated code
    - [x ] I have tested the code generated in my PR
    - [ x] I have read and understood every line that has been generated by the AI agent
    - [ x] I can explain what the AI-generated code does
