### PR TITLE
MAINT make docstring tests opt-in via SKB_CHECK_DOCSTRINGS env var

### DIFF
--- a/skrub/tests/test_docstrings.py
+++ b/skrub/tests/test_docstrings.py
@@ -6,14 +6,30 @@ to skip while running the validation tests, so that CI will
 not fail.
 Therefore, developers having formatted methods to numpydoc
 should also remove their corresponding references from the list.
+
+All tests are skipped by default. To run them and see which docstrings
+need to be fixed, set the environment variable::
+
+    SKRUB_CHECK_DOCSTRINGS=1 pytest skrub/tests/test_docstrings.py -v
+
+Items listed in `DOCSTRING_TEMP_IGNORE_SET` are individually skipped even
+when the env variable is set, so you can focus on newly introduced issues.
 """
 
 import inspect
+import os
 import re
 from importlib import import_module
 
 import pytest
 from numpydoc.validate import validate
+
+# Set SKRUB_CHECK_DOCSTRINGS=1 to run the validation tests instead of skipping them.
+_CHECK_DOCSTRINGS = os.environ.get("SKRUB_CHECK_DOCSTRINGS", "0") == "1"
+skip_docstring_tests = pytest.mark.skipif(
+    not _CHECK_DOCSTRINGS,
+    reason="Set SKRUB_CHECK_DOCSTRINGS=1 to run docstring validation tests",
+)
 
 DOCSTRING_TEMP_IGNORE_SET = {
     # TODO remove
@@ -164,7 +180,7 @@ def filter_errors(errors, method, estimator_cls=None):
         yield code, message
 
 
-@pytest.mark.xfail(strict=False)
+@skip_docstring_tests
 @pytest.mark.parametrize(
     ["estimator_cls", "method"],
     get_methods_to_validate(),
@@ -197,7 +213,7 @@ def test_estimator_docstrings(estimator_cls, method, request):
         raise ValueError(repr_errors(res, estimator_cls, method))
 
 
-@pytest.mark.xfail(strict=False)
+@skip_docstring_tests
 @pytest.mark.parametrize(
     ["func", "name"],
     get_functions_to_validate(),

--- a/skrub/tests/test_docstrings.py
+++ b/skrub/tests/test_docstrings.py
@@ -10,7 +10,7 @@ should also remove their corresponding references from the list.
 All tests are skipped by default. To run them and see which docstrings
 need to be fixed, set the environment variable::
 
-    SKRUB_CHECK_DOCSTRINGS=1 pytest skrub/tests/test_docstrings.py -v
+    SKB_CHECK_DOCSTRINGS=1 pytest skrub/tests/test_docstrings.py -v
 
 Items listed in `DOCSTRING_TEMP_IGNORE_SET` are individually skipped even
 when the env variable is set, so you can focus on newly introduced issues.
@@ -24,11 +24,11 @@ from importlib import import_module
 import pytest
 from numpydoc.validate import validate
 
-# Set SKRUB_CHECK_DOCSTRINGS=1 to run the validation tests instead of skipping them.
-_CHECK_DOCSTRINGS = os.environ.get("SKRUB_CHECK_DOCSTRINGS", "0") == "1"
+# Set SKB_CHECK_DOCSTRINGS=1 to run the validation tests instead of skipping them.
+_CHECK_DOCSTRINGS = os.environ.get("SKB_CHECK_DOCSTRINGS", "0") == "1"
 skip_docstring_tests = pytest.mark.skipif(
     not _CHECK_DOCSTRINGS,
-    reason="Set SKRUB_CHECK_DOCSTRINGS=1 to run docstring validation tests",
+    reason="Set SKB_CHECK_DOCSTRINGS=1 to run docstring validation tests",
 )
 
 DOCSTRING_TEMP_IGNORE_SET = {


### PR DESCRIPTION
This PR modifies the way that docstrings are checked so that by default they are skipped, unless the env variable is set in which case they are executed.

This allows to check exactly which tests are failing and address them, without blocking all PRs. 

Once we're done with cleaning up the docs that are currently failing, we can set this flag to be always on. 

This will make it easier to address #1882 