### PR TITLE
docs: streamline contributor setup instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,9 +144,35 @@ Every PR should link to the issue it addresses.
 Setting up the environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-To setup your development environment, you need to follow the steps in "From Source" tab
-present in :ref:`Installing from source<installing_from_source>` page.
-After that, you can return to this page to continue.
+To set up your development environment:
+
+1. Fork `skrub on GitHub <https://github.com/skrub-data/skrub/fork>`_.
+2. Clone your fork and add the official repository as ``upstream``:
+
+   .. code:: sh
+
+      git clone https://github.com/<YOUR_USERNAME>/skrub
+      cd skrub
+      git remote add upstream https://github.com/skrub-data/skrub.git
+
+3. Create and activate a virtual environment, then install the project in
+   editable mode with development dependencies:
+
+   .. code:: sh
+
+      python -m venv env_skrub
+      source env_skrub/bin/activate
+      pip install -e ".[dev]"
+      pre-commit install
+
+4. Run the test suite once to verify the environment:
+
+   .. code:: sh
+
+      pytest --pyargs skrub
+
+The :ref:`installation page <installing_from_source>` contains the same setup
+commands in a shorter form if you only need the install steps.
 
 Now that the development environment is ready, you may create a new branch and start working on
 the new issue.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -109,49 +109,11 @@ and `sentence-transformers <https://anaconda.org/conda-forge/sentence-transforme
 Advanced Usage for Contributors
 -------------------------------
 
-1. Fork the project
-'''''''''''''''''''
+For the full contribution workflow (forking, cloning your fork, adding the
+``upstream`` remote, and opening a PR), see the
+`contributing guide <https://skrub-data.org/stable/CONTRIBUTING.html>`_.
 
-To contribute to the project, you first need to
-`fork skrub on GitHub <https://github.com/skrub-data/skrub/fork>`_.
-
-That will enable you to push your commits to a branch *on your fork*.
-
-2. Clone your fork
-''''''''''''''''''
-
-Clone your forked repo to your local machine:
-
-.. code:: console
-
-    git clone https://github.com/<YOUR_USERNAME>/skrub
-    cd skrub
-
-Next, add the *upstream* remote (i.e. the official skrub repository). This allows you
-to pull the latest changes from the main repository:
-
-.. code:: console
-
-    git remote add upstream https://github.com/skrub-data/skrub.git
-
-Verify that both the origin (your fork) and upstream (official repo)
-are correctly set up:
-
-.. code:: console
-
-    git remote -v
-
-You should see something like this:
-
-.. code:: console
-
-    origin  git@github.com:<YOUR_USERNAME>/skrub.git (fetch)
-    origin  git@github.com:<YOUR_USERNAME>/skrub.git (push)
-    upstream        git@github.com:skrub-data/skrub.git (fetch)
-    upstream        git@github.com:skrub-data/skrub.git (push)
-
-
-3. Setup your environment
+1. Setup your environment
 '''''''''''''''''''''''''
 
 Now, setup a development environment.
@@ -191,7 +153,7 @@ IDE integrations. These revisions are listed in .git-blame-ignore-revs:
 
     git config blame.ignoreRevsFile .git-blame-ignore-revs
 
-4. Run the tests
+2. Run the tests
 ''''''''''''''''
 
 To ensure your environment is correctly set up, run the test suite:
@@ -202,15 +164,7 @@ To ensure your environment is correctly set up, run the test suite:
 
 Testing should take about 5 minutes.
 
-If you see some warnings like:
-
-.. code:: sh
-
-  UserWarning: Only pandas and polars DataFrames are supported, but input is a Numpy array. Please convert Numpy arrays to DataFrames before passing them to skrub transformers. Converting to pandas DataFrame with columns ['0', '1', …].
-    warnings.warn(
-
-This is expected, and you may proceed with the next steps without worrying about them.
-However, no tests should fail at this point: if they do fail, then let us know.
+No tests should fail at this point; if they do, please let us know.
 
 After that, your environment is ready for development!
 


### PR DESCRIPTION
## Summary
- move the fork/clone/upstream bootstrap steps into `CONTRIBUTING.rst`
- shorten the install page's contributor tab so it focuses on environment setup
- remove the outdated warning note from the test setup section

Closes #2116.
Follow-up to #2117.
