### PR TITLE
fix textencoder tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,6 +346,9 @@ filterwarnings = [
   'ignore:.*`clean_up_tokenization_spaces` was not set.*',
   'ignore:The current process just got forked.*',
   'ignore:.*`clean_up_tokenization_spaces` was not set.*',
+  # Sentence-transformers using a deprecated huggingface_hub function, nothing
+  # to do with skrub.
+  'ignore:.*hf_xet\.download_files\(\) is deprecated',
 ]
 log_cli_level = "INFO"
 xfail_strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,8 +346,9 @@ filterwarnings = [
   'ignore:.*`clean_up_tokenization_spaces` was not set.*',
   'ignore:The current process just got forked.*',
   'ignore:.*`clean_up_tokenization_spaces` was not set.*',
-  # Sentence-transformers using a deprecated huggingface_hub function, nothing
-  # to do with skrub.
+  # Sentence-transformers using a deprecated huggingface_hub function.
+  # We avoid turning huggingface_hub warnings into errors, because they get
+  # masked as OSErrors by sentence_transformers. See note in test_text_encoder.
   'default::DeprecationWarning:huggingface_hub',
 ]
 log_cli_level = "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,9 +319,8 @@ ignore = [
 [tool.pytest.ini_options]
 filterwarnings = [
   # Turn deprecation warnings into errors
-  # TMP test
-  "always::FutureWarning",
-  "always::DeprecationWarning",
+  "error::FutureWarning",
+  "error::DeprecationWarning",
 
   # Ignore warning from np.in1d since the future behavior is already the desired
   # behavior. TODO remove when numpy min version >= 1.25.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,8 +320,8 @@ ignore = [
 filterwarnings = [
   # Turn deprecation warnings into errors
   # TMP test
-  # "error::FutureWarning",
-  # "error::DeprecationWarning",
+  "always::FutureWarning",
+  "always::DeprecationWarning",
 
   # Ignore warning from np.in1d since the future behavior is already the desired
   # behavior. TODO remove when numpy min version >= 1.25.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,8 +319,9 @@ ignore = [
 [tool.pytest.ini_options]
 filterwarnings = [
   # Turn deprecation warnings into errors
-  "error::FutureWarning",
-  "error::DeprecationWarning",
+  # TMP test
+  # "error::FutureWarning",
+  # "error::DeprecationWarning",
 
   # Ignore warning from np.in1d since the future behavior is already the desired
   # behavior. TODO remove when numpy min version >= 1.25.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,7 +348,7 @@ filterwarnings = [
   'ignore:.*`clean_up_tokenization_spaces` was not set.*',
   # Sentence-transformers using a deprecated huggingface_hub function, nothing
   # to do with skrub.
-  'ignore:.*hf_xet\.download_files\(\) is deprecated',
+  'default::DeprecationWarning:huggingface_hub',
 ]
 log_cli_level = "INFO"
 xfail_strict = true

--- a/skrub/tests/test_text_encoder.py
+++ b/skrub/tests/test_text_encoder.py
@@ -1,3 +1,17 @@
+"""
+IMPORTANT NOTE:
+
+huggingface_hub when downloading a model has a blanket try/except that catches
+everything and turns it into an OSError saying the model failed to download.
+This masks the real issue.
+
+Our pytest config turns DeprecationWarning and FutureWarning into exceptions,
+which then get shown as OSError and are hard to debug.
+If you see tests in this module failing with ModelNotFound errors, try
+disabling the filterwarnings in pyproject.toml to see if any deprecation
+warnings are being raised.
+"""
+
 import pickle
 import sys
 


### PR DESCRIPTION
internal huggingface deprecation warning getting turned into an exception by our pytest config and masked as a OSError by huggingface