### PR TITLE
ENH: Standardize TextEncoder verbose parameter from bool to int.

### DIFF
--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -108,9 +108,9 @@ class TextEncoder(SingleColumnTransformer):
         Used when the PCA dimension reduction mechanism is used, for reproducible
         results across multiple function calls.
 
-    verbose : bool, default=True
+    verbose : int, default=0
         Verbose level, controls whether to show a progress bar or not during
-        ``transform``.
+        ``transform``.(0 for silent, 1 or higher to display progress)
 
     Attributes
     ----------
@@ -198,7 +198,7 @@ class TextEncoder(SingleColumnTransformer):
         cache_folder=None,
         store_weights_in_pickle=False,
         random_state=None,
-        verbose=False,
+        verbose=0,
     ):
         self.model_name = model_name
         self.n_components = n_components


### PR DESCRIPTION
This enhancement harmonizes the `verbose` parameter of `TextEncoder` to accept integers, aligning its logic with `TableReport` and `GapEncoder`.

Addresses #2131

*(Note to maintainers: I noticed the `for sprints` label just after completing the local implementation. I am submitting this now in case it is helpful, but I completely understand if you prefer to close this or hold it in reserve for the official sprint participants!)*