### PR TITLE
DOC: use public import for ToFloat in docstring examples

### DIFF
--- a/skrub/_clean_null_strings.py
+++ b/skrub/_clean_null_strings.py
@@ -167,7 +167,7 @@ class CleanNullStrings(SingleColumnTransformer):
     In both examples above, the column can be converted to numbers by
     ``ToFloat`` (only) after being cleaned by ``CleanNullStrings``:
 
-    >>> from skrub._to_float import ToFloat
+    >>> from skrub import ToFloat
     >>> ToFloat().fit_transform(s)
     Traceback (most recent call last):
         ...

--- a/skrub/_to_float.py
+++ b/skrub/_to_float.py
@@ -25,7 +25,7 @@ class ToFloat(SingleColumnTransformer):
     Examples
     --------
     >>> import pandas as pd
-    >>> from skrub._to_float import ToFloat
+    >>> from skrub import ToFloat
 
     A column that does not contain floats is converted if possible:
 


### PR DESCRIPTION
### What does this PR do?

Fixes #2130.

The docstring examples for `ToFloat` (`skrub/_to_float.py`) and `CleanNullStrings` (`skrub/_clean_null_strings.py`) imported `ToFloat` from the private module:

```python
>>> from skrub._to_float import ToFloat
```

`ToFloat` is part of the public API (it is exported in `skrub/__init__.py` and listed in `__all__`), so the examples now use the public import, which is the recommended practice:

```python
>>> from skrub import ToFloat
```

### Notes

- Documentation-only change; no behavior change and no changelog needed (per the issue labels).
- Verified the `_to_float.py` doctests still pass with skrub's doctest flags (`NORMALIZE_WHITESPACE ELLIPSIS`).