### PR TITLE
DOC fix GapEncoder ngram_range parameter indentation

### DIFF
--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -88,7 +88,7 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
     max_iter : int, default=5
         Maximum number of iterations on the input data.
     ngram_range : int 2-tuple, default=(2, 4)
-       The lower and upper boundaries of the range of n-values for different
+        The lower and upper boundaries of the range of n-values for different
         n-grams used in the string similarity. All values of `n` such
         that ``min_n <= n <= max_n`` will be used.
     analyzer : {'word', 'char', 'char_wb'}, default='char'


### PR DESCRIPTION
Fixes the indentation of the `ngram_range` parameter description in the `GapEncoder` docstring so the rendered documentation aligns with the surrounding parameter descriptions.

Validation:
- Ran `python -m py_compile skrub/_gap_encoder.py`.

Closes #2129