### PR TITLE
DOC: fix get_data_dir cross-reference in TextEncoder

### DIFF
--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -79,7 +79,7 @@ class TextEncoder(SingleColumnTransformer):
 
     cache_folder : str, default=None
         Path to store models. By default ``~/skrub_data``.
-        See :func:`skrub.datasets._utils.get_data_dir`.
+        See :func:`skrub.datasets.get_data_dir`.
         Note that when unpickling ``TextEncoder`` on another machine,
         the ``cache_folder`` path needs to be accessible to store the downloaded model.
 


### PR DESCRIPTION
Closes #2126

### What

The `cache_folder` parameter docstring of `TextEncoder` references the function at its private path:

```
See :func:`skrub.datasets._utils.get_data_dir`.
```

Sphinx does not resolve this cross-reference because `get_data_dir` is documented at its **public** location (`skrub.datasets.get_data_dir`, listed in `doc/api_reference.py` and `skrub.datasets.__all__`), so the link in the rendered docs is broken.

### Fix

Point the `:func:` reference to the public path, matching how the rest of the docs reference it (e.g. `doc/guides/utilities/fetching_datasets.rst` already uses `:func:`~skrub.datasets.get_data_dir``):

```
See :func:`skrub.datasets.get_data_dir`.
```

No changelog entry per the `no changelog needed` label on the issue.