### PR TITLE
MAINT: make TextEncoder `verbose` an int for consistency (#2131)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ Changes
   :pr:`2094` by :user:`Alicja Kosak <AlicjaKo>`.
 - Added support for numpy arrays in :meth:`DataOp.skb.concat`.
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
+- The ``verbose`` parameter of :class:`TextEncoder` is now an ``int`` (default
+  ``0``) instead of a ``bool``, for consistency with :class:`GapEncoder`,
+  :class:`TableReport` and :func:`patch_display`. Passing a boolean still works.
+  The docstring previously stated the default was ``True`` although it was
+  ``False``. :pr:`2138` by :user:`Labib Bin Salam <Labib-Bin-Salam>`.
 Bugfixes
 --------
 - A bug in how the :class:`TableVectorizer` and :class:`Cleaner` treated columns

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,7 @@ Changes
   ``0``) instead of a ``bool``, for consistency with :class:`GapEncoder`,
   :class:`TableReport` and :func:`patch_display`. Passing a boolean still works.
   The docstring previously stated the default was ``True`` although it was
-  ``False``. :pr:`2138` by :user:`Labib Bin Salam <Labib-Bin-Salam>`.
+  ``False``. :pr:`2139` by :user:`Labib Bin Salam <Labib-Bin-Salam>`.
 Bugfixes
 --------
 - A bug in how the :class:`TableVectorizer` and :class:`Cleaner` treated columns

--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -108,8 +108,8 @@ class TextEncoder(SingleColumnTransformer):
         Used when the PCA dimension reduction mechanism is used, for reproducible
         results across multiple function calls.
 
-    verbose : bool, default=True
-        Verbose level, controls whether to show a progress bar or not during
+    verbose : int, default=0
+        Verbosity level. When greater than 0, a progress bar is shown during
         ``transform``.
 
     Attributes
@@ -198,7 +198,7 @@ class TextEncoder(SingleColumnTransformer):
         cache_folder=None,
         store_weights_in_pickle=False,
         random_state=None,
-        verbose=False,
+        verbose=0,
     ):
         self.model_name = model_name
         self.n_components = n_components
@@ -329,7 +329,7 @@ class TextEncoder(SingleColumnTransformer):
             unique_x,
             normalize_embeddings=False,
             batch_size=self.batch_size,
-            show_progress_bar=self.verbose,
+            show_progress_bar=self.verbose > 0,
         )[indices_x]
 
     @functools.cached_property


### PR DESCRIPTION
Closes #2131.

The `verbose` parameter of `TextEncoder` accepted a `bool`, which is inconsistent with `GapEncoder`, `TableReport` and `patch_display`, where `verbose` is an `int` (even when only two levels are meaningful).

This PR switches `TextEncoder.verbose` to an `int` with default `0`. Because `bool` is a subclass of `int`, existing calls passing `True`/`False` keep working unchanged, so this is non-breaking:

```python
TextEncoder()              # verbose == 0
TextEncoder(verbose=1)     # progress bar
TextEncoder(verbose=True)  # still works
```

It also fixes the docstring, which stated the default was `True` while the actual default was `False` (as noted in the issue).

### Changes
- `skrub/_text_encoder.py`: default `verbose=0`; docstring now documents `verbose : int, default=0`; `show_progress_bar=self.verbose > 0`.
- `CHANGES.rst`: entry under *Changes*.

### Verification
- `ruff check` and `ruff format --check` pass.
- Module doctests pass.
- Manually verified the default is `0`, and that `verbose=1`/`verbose=2`/`verbose=True` all enable the progress bar.