### PR TITLE
fix: disable math parsing in TableReport so $$ strings do not crash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,9 @@ Changes
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
 Bugfixes
 --------
+- Fixed :class:`TableReport` generation for string values containing dollar
+  signs that matplotlib could otherwise parse as invalid math. :issue:`2097`
+  by :user:`Matt Van Horn <mvanhorn>`.
 - A bug in how the :class:`TableVectorizer` and :class:`Cleaner` treated columns
   duration columns in pandas and polars has been fixed. Now, both classes convert
   durations to the total number of seconds (with fractional part). This is done

--- a/skrub/_reporting/_plotting.py
+++ b/skrub/_reporting/_plotting.py
@@ -71,6 +71,8 @@ _MATPLOTLIB_RC_PARAMS = {
     "boxplot.whiskerprops.color": _TEXT_COLOR_PLACEHOLDER,
 }
 
+_MATPLOTLIB_PARSE_MATH_RC_PARAM = "text.parse_math"
+
 
 def _plot(plotting_fun):
     """Set the maptlotib config & silence some warnings for all report plots.
@@ -97,6 +99,8 @@ def _plot(plotting_fun):
         # fonttype: none causes matplotlib to insert labels etc as text in the
         # svg rather than drawing the glyphs.
         params = {"svg.fonttype": "none", **_MATPLOTLIB_RC_PARAMS}
+        if _MATPLOTLIB_PARSE_MATH_RC_PARAM in plt.rcParams:
+            params[_MATPLOTLIB_PARSE_MATH_RC_PARAM] = False
         original_params = {k: plt.rcParams[k] for k in params}
         try:
             for k, v in params.items():

--- a/skrub/_reporting/tests/test_plotting.py
+++ b/skrub/_reporting/tests/test_plotting.py
@@ -1,7 +1,12 @@
+import xml.etree.ElementTree as ET
+
 import numpy as np
 import pandas as pd
+import pytest
+from matplotlib import pyplot as plt
 
 from skrub._reporting import _plotting
+from skrub._reporting._summarize import summarize_dataframe
 
 
 def test_histogram():
@@ -28,3 +33,48 @@ def test_histogram():
     data = pd.Series([0.0])
     _, n_low, n_high = _plotting.histogram(data)
     assert (n_low, n_high) == (0, 0)
+
+
+@pytest.mark.skipif(
+    "text.parse_math" not in plt.rcParams,
+    reason="text.parse_math requires Matplotlib >= 3.6",
+)
+def test_value_counts_renders_dollar_wrapped_text_literally():
+    svg = _plotting.value_counts([("$x + y$", 2), ("other", 1)], 2, 3)
+    root = ET.fromstring(svg)
+    text_labels = [
+        "".join(element.itertext()).strip()
+        for element in root.iter()
+        if element.tag.endswith("text")
+    ]
+
+    assert "$x + y$" in text_labels
+
+
+def test_summarize_dataframe_with_double_dollar_string_restores_rc_params():
+    df = pd.DataFrame(
+        {
+            "text": [
+                "this is not latex $$ just a double dollar sign",
+                "another value",
+            ]
+        }
+    )
+
+    if "text.parse_math" not in plt.rcParams:
+        summary = summarize_dataframe(
+            df, with_plots=True, with_associations=False, verbose=0
+        )
+        assert summary["columns"][0]["value_counts_plot"].startswith("<?xml")
+        return
+
+    original_parse_math = plt.rcParams["text.parse_math"]
+    plt.rcParams["text.parse_math"] = True
+    try:
+        summary = summarize_dataframe(
+            df, with_plots=True, with_associations=False, verbose=0
+        )
+        assert summary["columns"][0]["value_counts_plot"].startswith("<?xml")
+        assert plt.rcParams["text.parse_math"] is True
+    finally:
+        plt.rcParams["text.parse_math"] = original_parse_math


### PR DESCRIPTION
# Bug Fix Pull Request

## Description

`TableReport` / `summarize_dataframe` crashed on string values containing `$$` because Matplotlib parsed them as math. This disables math parsing for the report's text so `$$`-containing strings render literally instead of raising.

Fixes #2097

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

Added a test in `skrub/_reporting/tests/test_plotting.py` covering a `$$`-containing value; the targeted plotting tests pass (3 passed). The `text.parse_math` rcParam is only set when it exists in `rcParams`, so Matplotlib 3.4/3.5 (still within the declared `matplotlib>=3.4.3` floor) is unaffected.

## AI Disclosure

- [x] This PR contains AI-generated code
    - [x] I have tested the code generated in my PR
    - [x] I have read and understood every line that has been generated by the AI agent
    - [x] I can explain what the AI-generated code does
