### PR TITLE
make "literal" the reST default role

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -162,6 +162,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# The reST default role (used for this markup: `text`) to use for all
+# documents.
+default_role = "literal"
+
 # -- Options for autodoc / autosummary ----------------------------------------
 # generate autosummary even if no references
 autosummary_generate = True


### PR DESCRIPTION
I don't know about you but it seems I am just unable to remember to type `` `some_thing` `` instead of ``` ``some_thing`` ``` for inline code. with this change to the sphinx config the "default role" (how single backticks are interpreted) becomes literal ie formatted like code.

it is copied from the scikit-learn configuration