### PR TITLE
feat(TableReport): add dict() method returning parsed JSON content

### DIFF
--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -440,6 +440,17 @@ class TableReport:
         data = {k: v for k, v in self._summary.items() if k not in to_remove}
         return json.dumps(data, cls=JSONEncoder)
 
+    def dict(self):
+        """Get the report data as a Python dictionary.
+
+        Returns
+        -------
+        dict :
+            The report data as a dictionary, equivalent to
+            ``json.loads(self.json())``.
+        """
+        return json.loads(self.json())
+
     def markdown(self):
         """Get the report as a Markdown string.
 

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -80,6 +80,15 @@ def test_report(air_quality):
 
 
 @skip_polars_installed_without_pyarrow
+def test_report_dict(air_quality):
+    report = TableReport(air_quality, title="dict title")
+    result = report.dict()
+    assert isinstance(result, dict)
+    assert result == json.loads(report.json())
+    assert result["title"] == "dict title"
+
+
+@skip_polars_installed_without_pyarrow
 def test_few_columns(df_module, check_polars_numpy2):
     report = TableReport(df_module.example_dataframe)
     assert "First 10 columns" not in report.html()


### PR DESCRIPTION
## Summary

Add `TableReport.dict()` which returns `json.loads(self.json())`, giving users programmatic access to the report data as a plain Python dict without needing to manually parse the JSON string. The implementation delegates to the existing `json()` method so the custom numpy-aware `JSONEncoder` already in place handles `numpy.float64`/`numpy.int64` type conversion correctly.

Closes #2147

## Changes

- `skrub/_reporting/_table_report.py` — add `dict()` method after `json()`, returning `json.loads(self.json())`
- `skrub/_reporting/tests/test_table_report.py` — add `test_report_dict` test verifying return type, equality with `json.loads(report.json())`, and title field access

## Test plan

- [x] `python -m pytest skrub/_reporting/tests/` passes (112 passed, 132 pre-existing env skips)
- [x] Manual smoke test confirms `report.dict()` returns a `dict`, matches `json.loads(report.json())`, and handles numpy types correctly