### PR TITLE
docs: fix bold formatting in ApplyToCols docstring

### DIFF
--- a/skrub/_apply_to_cols.py
+++ b/skrub/_apply_to_cols.py
@@ -214,7 +214,7 @@ class ApplyToCols(TransformerMixin, BaseEstimator):
     skrub.core.RejectColumn: Column 'A' does not have Date or Datetime dtype.
     Transformer DatetimeEncoder.fit_transform failed on column 'A'. See above for the full traceback.
 
-    ** Accessing fitted transformers **
+    **Accessing fitted transformers**
 
     Depending on the transformer, the fitted transformers
     are stored in different attributes. For single-column transformers, the fitted


### PR DESCRIPTION
Fixes #2125

The "Accessing fitted transformers" heading in the `ApplyToCols` docstring had spaces between the text and the `**` markers, so the bold formatting did not render. This removes the extra spaces to match the other headings in the same docstring.

Before: `** Accessing fitted transformers **`
After:  `**Accessing fitted transformers**`

Documentation-only formatting fix, so no changelog entry is needed per CONTRIBUTING.rst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
