### PR TITLE
adding the variance threshold

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,8 +54,8 @@ Changes
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
 - The :class:`TableReport` can now be exported in markdown format with ``.markdown``.
   :pr:`2048` by :user:`Riccardo Cappuzzo <rcap107>`.
-- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance 
-  threshold and it acts similarly to the VarianceThreshold transformer. 
+- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance
+  threshold and it acts similarly to the VarianceThreshold transformer.
   :pr:`2155` by :user:`Janne de Melo Santana <jannesantana>`, :user:`Xixi Khamsane<XIXI1234-creator>`, :user:`Rim El Khader<Rim-e>`
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,8 +54,9 @@ Changes
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
 - The :class:`TableReport` can now be exported in markdown format with ``.markdown``.
   :pr:`2048` by :user:`Riccardo Cappuzzo <rcap107>`.
-- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance threshold and it acts similarly to the VarianceThreshold transformer.
-  :pr:`2109` by :user:`Janne de Melo Santana <jannesantana>`.
+- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance 
+  threshold and it acts similarly to the VarianceThreshold transformer. 
+  :pr:`2155` by :user:`Janne de Melo Santana <jannesantana>`, :user:`Xixi Khamsane<XIXI1234-creator>`, :user:`Rim El Khader<Rim-e>`
 
 Bugfixes
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ Changes
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
 - The :class:`TableReport` can now be exported in markdown format with ``.markdown``.
   :pr:`2048` by :user:`Riccardo Cappuzzo <rcap107>`.
-- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance threshold and it acts similarly to the VarianceThreshold transformer. 
+- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance threshold and it acts similarly to the VarianceThreshold transformer.
   :pr:`2109` by :user:`Janne de Melo Santana <jannesantana>`.
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,8 @@ Changes
   :pr:`2096` by :user:`Ayesha Siddiqua <siddiqua-tamk>`.
 - The :class:`TableReport` can now be exported in markdown format with ``.markdown``.
   :pr:`2048` by :user:`Riccardo Cappuzzo <rcap107>`.
+- The :class:`DropUninformative` was improved so that `drop_if_constant` becomes a variance threshold and it acts similarly to the VarianceThreshold transformer. 
+  :pr:`2109` by :user:`Janne de Melo Santana <jannesantana>`.
 
 Bugfixes
 --------

--- a/skrub/_drop_uninformative.py
+++ b/skrub/_drop_uninformative.py
@@ -85,7 +85,7 @@ class DropUninformative(SingleColumnTransformer):
         drop_if_constant=False,
         drop_if_unique=False,
         drop_null_fraction=1.0,
-        threshold=0.0
+        threshold=0.0,
     ):
         self.drop_if_constant = drop_if_constant
         self.drop_if_unique = drop_if_unique
@@ -128,16 +128,20 @@ class DropUninformative(SingleColumnTransformer):
         return self._null_count / len(column) > self.drop_null_fraction
 
     def _drop_if_constant(self, column):
-        if self.drop_if_constant:       
-            if sbd.is_numeric(column) == 1 and (self._null_count == 0): # if numeric or boolean
-                if sbd.std(column)**2 <= self.threshold: # check if passes the threshold
-                    return True 
+        if self.drop_if_constant:
+            if sbd.is_numeric(column) == 1 and (
+                self._null_count == 0
+            ):  # if numeric or boolean
+                if (
+                    sbd.std(column) ** 2 <= self.threshold
+                ):  # check if passes the threshold
+                    return True
                 else:
                     return False
-            elif ((sbd.n_unique(column) == 1) and (self._null_count == 0)):
+            elif (sbd.n_unique(column) == 1) and (self._null_count == 0):
                 # use the original logic to deal with the other cases
-                        return True
-            
+                return True
+
         return False
 
     def _drop_if_unique(self, column):

--- a/skrub/_drop_uninformative.py
+++ b/skrub/_drop_uninformative.py
@@ -85,10 +85,12 @@ class DropUninformative(SingleColumnTransformer):
         drop_if_constant=False,
         drop_if_unique=False,
         drop_null_fraction=1.0,
+        threshold=0.0
     ):
         self.drop_if_constant = drop_if_constant
         self.drop_if_unique = drop_if_unique
         self.drop_null_fraction = drop_null_fraction
+        self.threshold = threshold
 
     def _check_params(self):
         if not isinstance(self.drop_if_constant, bool):
@@ -126,9 +128,16 @@ class DropUninformative(SingleColumnTransformer):
         return self._null_count / len(column) > self.drop_null_fraction
 
     def _drop_if_constant(self, column):
-        if self.drop_if_constant:
-            if (sbd.n_unique(column) == 1) and (self._null_count == 0):
-                return True
+        if self.drop_if_constant:       
+            if sbd.is_numeric(column) == 1 and (self._null_count == 0): # if numeric or boolean
+                if sbd.std(column)**2 <= self.threshold: # check if passes the threshold
+                    return True 
+                else:
+                    return False
+            elif ((sbd.n_unique(column) == 1) and (self._null_count == 0)):
+                # use the original logic to deal with the other cases
+                        return True
+            
         return False
 
     def _drop_if_unique(self, column):

--- a/skrub/tests/test_drop_uninformative.py
+++ b/skrub/tests/test_drop_uninformative.py
@@ -130,9 +130,7 @@ def drop_if_constant_table(df_module):
                 "const",
                 None,
             ],
-            "low_variance": [
-                0.01,0.02,0.05
-            ]
+            "low_variance": [0.01, 0.02, 0.05],
         }
     )
 
@@ -144,7 +142,7 @@ def drop_if_constant_table(df_module):
         (dict(drop_if_constant=True), "constant_float", []),
         (dict(drop_if_constant=True), "constant_float_with_nulls", [2.5, 2.5, np.nan]),
         (dict(drop_if_constant=True), "constant_str", []),
-        (dict(drop_if_constant=True,threshold=0.5), "low_variance", []),
+        (dict(drop_if_constant=True, threshold=0.5), "low_variance", []),
         (
             dict(drop_if_constant=True),
             "constant_str_with_nulls",

--- a/skrub/tests/test_drop_uninformative.py
+++ b/skrub/tests/test_drop_uninformative.py
@@ -130,6 +130,9 @@ def drop_if_constant_table(df_module):
                 "const",
                 None,
             ],
+            "low_variance": [
+                0.01,0.02,0.05
+            ]
         }
     )
 
@@ -141,6 +144,7 @@ def drop_if_constant_table(df_module):
         (dict(drop_if_constant=True), "constant_float", []),
         (dict(drop_if_constant=True), "constant_float_with_nulls", [2.5, 2.5, np.nan]),
         (dict(drop_if_constant=True), "constant_str", []),
+        (dict(drop_if_constant=True,threshold=0.5), "low_variance", []),
         (
             dict(drop_if_constant=True),
             "constant_str_with_nulls",


### PR DESCRIPTION
# Bug Fix Pull Request

<!--
Before proceeding, please confirm that:
1. The changes have been discussed with the maintainers
2. A plan has been agreed upon
3. The related issue has been assigned to you
-->

## Description

Before, drop_if_constant would only drop columns that were constant. We added a variance threshold for numeric and boolean columns types.
The next step would be to change the name to drop_var_threshold, for example. 

Addresses #2109 

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix (the tests have been made separately)
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

We've created a testing dataframe that covers different cases.

## AI Disclosure

- [ ] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
