### PR TITLE
DOC - adding disclaimers and slight clean up of joiner docs

### DIFF
--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -129,24 +129,6 @@ API_REFERENCE = {
             },
         ],
     },
-    "joining": {
-        "title": "Joining dataframes",
-        "short_summary": None,
-        "description": None,
-        "sections": [
-            {
-                "description": None,
-                "autosummary": [
-                    "Joiner",
-                    "AggJoiner",
-                    "MultiAggJoiner",
-                    "AggTarget",
-                    "InterpolationJoiner",
-                    "fuzzy_join",
-                ],
-            },
-        ],
-    },
     "selectors": {
         "title": "Selectors",
         "short_summary": None,
@@ -312,6 +294,24 @@ API_REFERENCE = {
                     "config_context",
                 ],
             }
+        ],
+    },
+    "joining": {
+        "title": "Joining dataframes",
+        "short_summary": None,
+        "description": None,
+        "sections": [
+            {
+                "description": None,
+                "autosummary": [
+                    "Joiner",
+                    "AggJoiner",
+                    "MultiAggJoiner",
+                    "AggTarget",
+                    "InterpolationJoiner",
+                    "fuzzy_join",
+                ],
+            },
         ],
     },
     "datasets": {

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -182,8 +182,15 @@ class AggJoiner(TransformerMixin, BaseEstimator):
     .. warning::
         The auxiliary table is stored in memory as part of the state of the transformer,
         which can lead to high memory usage if the auxiliary table is large.
-        Consider using the skrub Data Ops and a standard dataframe library (Pandas
-        or Polars) to perform the aggregation instead.
+
+        Additionally, the auxiliary table is frozen in memory after fitting, which
+        means that if the auxiliary table is modified after fitting, the changes will
+        not be reflected in the transformed output. If you need to update the
+        auxiliary table, you will need to refit the transformer.
+
+        Consider using the :ref:`skrub Data Ops <_user_guide_data_ops_index>`
+        and a standard dataframe library (Pandas or Polars) to perform the
+        aggregation instead.
 
 
     Parameters

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -177,7 +177,14 @@ class AggJoiner(TransformerMixin, BaseEstimator):
     If `cols` is not provided, `cols` are all columns from `aux_table`,
     except `aux_key`.
 
-    Accepts :obj:`pandas.DataFrame` and :class:`polars.DataFrame` inputs.
+    Accepts :obj:`pandas.DataFrame` and :obj:`polars.DataFrame` inputs.
+
+    .. warning::
+        The auxiliary table is stored in memory as part of the state of the transformer,
+        which can lead to high memory usage if the auxiliary table is large.
+        Consider using the skrub Data Ops and a standard dataframe library (Pandas
+        or Polars) to perform the aggregation instead.
+
 
     Parameters
     ----------

--- a/skrub/_deduplicate.py
+++ b/skrub/_deduplicate.py
@@ -142,6 +142,16 @@ def deduplicate(
     This works best if there are a number of underlying categories that
     sometimes appear in the data with small variations and/or misspellings.
 
+    .. warning::
+        This method can be computationally expensive for large datasets, as it
+        requires computing pairwise distances between unique values and performing
+        hierarchical clustering.
+
+        Additionally, this is an unsupervised method that
+        relies on the assumption that the most common spelling in each cluster is
+        the correct one.
+        Depending on the use case, this assumption may not always hold true.
+
     Parameters
     ----------
     X : sequence of str

--- a/skrub/_fuzzy_join.py
+++ b/skrub/_fuzzy_join.py
@@ -24,7 +24,7 @@ def fuzzy_join(
     drop_unmatched=False,
     metric="euclidean",
 ):
-    """Fuzzy (approximate) join.
+    """Perform a fuzzy (approximate) join between the left and right tables.
 
     Rows in the left table are joined to their closest match from the right
     table. The resulting table has the same rows (in the same order) as the
@@ -34,42 +34,14 @@ def fuzzy_join(
     several equally good matching rows in the right table one of them will be
     used; which one is unspecified.
 
-    To identify the best match for each row, values from the matching columns
-    (``left_key`` and ``right_key``) are vectorized, i.e. represented by vectors of
-    continuous values. Then, distances between these vectors are computed
-    (using the specified metric) to find, for each left table row, its nearest
-    neighbor within the right table.
+    .. warning::
+        This method can be computationally expensive for large datasets, as it
+        requires vectorizing the matching columns and performing a nearest neighbor
+        search.
 
-    Optionally, a maximum distance threshold, ``max_dist``, can be set. Matches
-    between vectors that are separated by a distance (strictly) greater than
-    ``max_dist`` will be rejected. We will consider that left table rows that
-    are farther than ``max_dist`` from their nearest neighbor do not have a
-    matching row in the right table, and the output will contain nulls for
-    the entries that would normally have come from the right table (as in a
-    traditional left join).
-
-    To make it easier to set a ``max_dist`` threshold, the distances are
-    rescaled by dividing them by a reference distance, which can be chosen with
-    ``ref_dist``. The default is ``'random_pairs'``. The possible choices are:
-
-    'random_pairs'
-        Pairs of rows are sampled randomly from the right table and their
-        distance is computed. The reference distance is the first quartile of
-        those distances.
-
-    'second_neighbor'
-        The reference distance is the distance to the *second* nearest neighbor
-        in the right table.
-
-    'self_join_neighbor'
-        Once the match candidate (i.e. the nearest neighbor from the right
-        table) has been found, we find its nearest neighbor in the right
-        table (excluding itself). The reference distance is the distance that
-        separates those 2 right rows.
-
-    'no_rescaling'
-        The reference distance is 1.0, i.e. no rescaling of the distances is
-        applied.
+        Additionally, the quality of the matches depends on the choice of the
+        ``string_encoder``, the distance metric and the ``ref_dist`` used for
+        rescaling the distances.
 
     Parameters
     ----------
@@ -134,6 +106,46 @@ def fuzzy_join(
     --------
     Joiner :
         Same as fuzzy_join but as a scikit-learn transformer.
+
+    Notes
+    -----
+        To identify the best match for each row, values from the matching columns
+    (``left_on`` and ``right_on``) are vectorized, i.e. represented by vectors of
+    continuous values. Then, distances between these vectors are computed
+    (using the specified metric) to find, for each left table row, its nearest
+    neighbor within the right table.
+
+    Optionally, a maximum distance threshold, ``max_dist``, can be set. Matches
+    between vectors that are separated by a distance (strictly) greater than
+    ``max_dist`` will be rejected. We will consider that left table rows that
+    are farther than ``max_dist`` from their nearest neighbor do not have a
+    matching row in the right table, and the output will contain nulls for
+    the entries that would normally have come from the right table (as in a
+    traditional left join).
+
+    To make it easier to set a ``max_dist`` threshold, the distances are
+    rescaled by dividing them by a reference distance, which can be chosen with
+    ``ref_dist``. The default is ``'random_pairs'``. The possible choices are:
+
+    'random_pairs'
+        Pairs of rows are sampled randomly from the right table and their
+        distance is computed. The reference distance is the first quartile of
+        those distances.
+
+    'second_neighbor'
+        The reference distance is the distance to the *second* nearest neighbor
+        in the right table.
+
+    'self_join_neighbor'
+        Once the match candidate (i.e. the nearest neighbor from the right
+        table) has been found, we find its nearest neighbor in the right
+        table (excluding itself). The reference distance is the distance that
+        separates those 2 right rows.
+
+    'no_rescaling'
+        The reference distance is 1.0, i.e. no rescaling of the distances is
+        applied.
+
 
     Examples
     --------

--- a/skrub/_interpolation_joiner.py
+++ b/skrub/_interpolation_joiner.py
@@ -27,20 +27,6 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
     rows in the right table that satisfy the join condition, we estimate what
     those rows would contain if they existed in the table.
 
-    Suppose we want to join a table ``buildings(latitude, longitude, n_stories)``
-    with a table ``annual_avg_temp(latitude, longitude, avg_temp)``. Our annual
-    average temperature table may not contain data for the exact latitude and
-    longitude of our buildings. However, we can interpolate what we need from
-    the data points it does contain. Using ``annual_avg_temp``, we train a
-    model to predict the temperature, given the latitude and longitude. Then,
-    we use this model to estimate the values we want to add to our
-    ``buildings`` table. In a way we are joining ``buildings`` to a virtual
-    table, in which rows for any (latitude, longitude) location are inferred,
-    rather than retrieved, when requested. This is done with::
-
-        InterpolationJoiner(
-            annual_avg_temp, on=["latitude", "longitude"]
-        ).fit_transform(buildings)
 
     Parameters
     ----------
@@ -135,6 +121,24 @@ class InterpolationJoiner(TransformerMixin, BaseEstimator):
     Joiner :
         Works in a similar way but instead of inferring values, picks the
         closest row from the auxiliary table.
+
+    Notes
+    -----
+
+    Suppose we want to join a table ``buildings(latitude, longitude, n_stories)``
+    with a table ``annual_avg_temp(latitude, longitude, avg_temp)``. Our annual
+    average temperature table may not contain data for the exact latitude and
+    longitude of our buildings. However, we can interpolate what we need from
+    the data points it does contain. Using ``annual_avg_temp``, we train a
+    model to predict the temperature, given the latitude and longitude. Then,
+    we use this model to estimate the values we want to add to our
+    ``buildings`` table. In a way we are joining ``buildings`` to a virtual
+    table, in which rows for any (latitude, longitude) location are inferred,
+    rather than retrieved, when requested. This is done with::
+
+        InterpolationJoiner(
+            annual_avg_temp, on=["latitude", "longitude"]
+        ).fit_transform(buildings)
 
     Examples
     --------

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -85,42 +85,17 @@ class Joiner(TransformerMixin, BaseEstimator):
     the main table (i.e. as the argument passed to `transform`), but each row
     is augmented with values from the best match in the auxiliary table.
 
-    To identify the best match for each row, values from the matching columns
-    (`main_key` and `aux_key`) are vectorized, i.e. represented by vectors of
-    continuous values. Then, the distances between these vectors are computed
-    (using the specified metric) to find, for each main table row, its
-    nearest neighbor within the auxiliary table.
+    Fuzzy joining is performed by finding the nearest neighbor in the auxiliary
+    table for each row in the main table according to a specified distance metric.
 
-    Optionally, a maximum distance threshold, `max_dist`, can be set. Matches
-    between vectors that are separated by a distance (strictly) greater than
-    `max_dist` will be rejected. We will consider that main table rows that
-    are farther than `max_dist` from their nearest neighbor do not have a
-    matching row in the auxiliary table, and the output will contain nulls for
-    the entries that would normally have come from the auxiliary table (as in a
-    traditional left join).
+    .. warning::
+        This method can be computationally expensive for large datasets, as it
+        requires vectorizing the matching columns and performing nearest neighbor
+        search.
 
-    To make it easier to set a `max_dist` threshold, the distances are
-    rescaled by dividing them by a reference distance, which can be chosen with
-    `ref_dist`. The default is `'random_pairs'`. The possible choices are:
+        Additionally, the auxiliary table is stored as state of the transformer,
+        which can lead to high memory usage if the auxiliary table is large.
 
-    'random_pairs'
-        Pairs of rows are sampled randomly from the auxiliary table and their
-        distance is computed. The reference distance is the first quartile of
-        those distances.
-
-    'second_neighbor'
-        The reference distance is the distance to the *second* nearest neighbor
-        in the auxiliary table.
-
-    'self_join_neighbor'
-        Once the match candidate (i.e. the nearest neighbor from the auxiliary
-        table) has been found, we find its nearest neighbor in the auxiliary
-        table (excluding itself). The reference distance is the distance that
-        separates those 2 auxiliary rows.
-
-    'no_rescaling'
-        The reference distance is 1.0, i.e. no rescaling of the distances is
-        applied.
 
     Parameters
     ----------
@@ -191,6 +166,51 @@ class Joiner(TransformerMixin, BaseEstimator):
         Join two tables (dataframes) based on approximate column matching. This
         is the same functionality as provided by the `Joiner` but exposed as
         a function rather than a transformer.
+
+    Notes
+    -----
+    This transformer is initialized with an auxiliary table `aux_table`. It
+    transforms a main table by joining it, with approximate ("fuzzy") matching,
+    to the auxiliary table. The output of `transform` has the same rows as
+    the main table (i.e. as the argument passed to `transform`), but each row
+    is augmented with values from the best match in the auxiliary table.
+
+    To identify the best match for each row, values from the matching columns
+    (`main_key` and `aux_key`) are vectorized, i.e. represented by vectors of
+    continuous values. Then, the distances between these vectors are computed
+    (using the specified metric) to find, for each main table row, its
+    nearest neighbor within the auxiliary table.
+
+    Optionally, a maximum distance threshold, `max_dist`, can be set. Matches
+    between vectors that are separated by a distance (strictly) greater than
+    `max_dist` will be rejected. We will consider that main table rows that
+    are farther than `max_dist` from their nearest neighbor do not have a
+    matching row in the auxiliary table, and the output will contain nulls for
+    the entries that would normally have come from the auxiliary table (as in a
+    traditional left join).
+
+    To make it easier to set a `max_dist` threshold, the distances are
+    rescaled by dividing them by a reference distance, which can be chosen with
+    `ref_dist`. The default is `'random_pairs'`. The possible choices are:
+
+    'random_pairs'
+        Pairs of rows are sampled randomly from the auxiliary table and their
+        distance is computed. The reference distance is the first quartile of
+        those distances.
+
+    'second_neighbor'
+        The reference distance is the distance to the *second* nearest neighbor
+        in the auxiliary table.
+
+    'self_join_neighbor'
+        Once the match candidate (i.e. the nearest neighbor from the auxiliary
+        table) has been found, we find its nearest neighbor in the auxiliary
+        table (excluding itself). The reference distance is the distance that
+        separates those 2 auxiliary rows.
+
+    'no_rescaling'
+        The reference distance is 1.0, i.e. no rescaling of the distances is
+        applied.
 
     Examples
     --------

--- a/skrub/_joiner.py
+++ b/skrub/_joiner.py
@@ -93,8 +93,13 @@ class Joiner(TransformerMixin, BaseEstimator):
         requires vectorizing the matching columns and performing nearest neighbor
         search.
 
-        Additionally, the auxiliary table is stored as state of the transformer,
-        which can lead to high memory usage if the auxiliary table is large.
+        Additionally, the auxiliary table is stored in memory as part of the state
+        of the transformer, which can lead to high memory usage if the auxiliary
+        table is large.
+        Moreover, it is frozen in memory after fitting, which means that if the
+        auxiliary table is modified after fitting, the changes will not be reflected
+        in the transformed output. If you need to update the auxiliary table, you
+        will need to refit the transformer.
 
 
     Parameters

--- a/skrub/_multi_agg_joiner.py
+++ b/skrub/_multi_agg_joiner.py
@@ -23,32 +23,14 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
     Apply numerical and categorical aggregation operations on the `cols`
     to aggregate, selected by dtypes. See the list of supported operations
     at the parameter `operations`.
-
-    If `cols` is not provided, `cols` is set to a list of lists.
-    For each table in `aux_tables`, the corresponding list will be all columns
-    of that table, except the `aux_keys` associated with that table.
-
     As opposed to the :class:`AggJoiner`, here `aux_tables` is an iterable of tables,
-    each of which will be joined on the main table. Therefore `aux_keys` is now
-    an iterable of keys, of the same length as `aux_tables`, and each entry
-    in `aux_keys` is used to join the corresponding auxiliary table. In the same way,
-    each entry in `cols` is an iterable of columns to aggregate in the corresponding
-    auxiliary table. If the keys are the same in the main table and the auxiliary
-    tables, the `keys` parameter can be used instead of `main_keys` and `aux_keys`.
+    each of which will be joined on the main table.
 
-    Therefore if we have a single table, we could either use
-
-    - the :class:`AggJoiner`: ``AggJoiner(aux_table, key="ID")``
-    - or the :class:`MultiAggJoiner`: ``MultiAggJoiner([aux_table], keys=[["ID"]])``
-
-    Note that for `keys`, `main_keys`, `aux_keys`, `cols` and `operations`,
-    an input of the form ``[["a"], ["b"], ["c", "d"]]`` is valid
-    while ``["a", "b", ["c", "d"]]`` is not.
-
-    Using a column from the first auxiliary table to join the second auxiliary table
-    is not (yet) supported.
-
-    Accepts :obj:`pandas.DataFrame` and :class:`polars.DataFrame` inputs.
+    .. warning::
+        The auxiliary table is stored in memory as part of the state of the transformer,
+        which can lead to high memory usage if the auxiliary table is large.
+        Consider using the skrub Data Ops and a standard dataframe library (Pandas
+        or Polars) to perform the aggregation instead.
 
     Parameters
     ----------
@@ -125,6 +107,35 @@ class MultiAggJoiner(TransformerMixin, BaseEstimator):
     --------
     AggJoiner :
         Aggregate an auxiliary dataframe before joining it on a base dataframe.
+
+    Notes
+    ------
+    If `cols` is not provided, `cols` is set to a list of lists.
+    For each table in `aux_tables`, the corresponding list will be all columns
+    of that table, except the `aux_keys` associated with that table.
+
+    As opposed to the :class:`AggJoiner`, here `aux_tables` is an iterable of tables,
+    each of which will be joined on the main table. Therefore `aux_keys` is now
+    an iterable of keys, of the same length as `aux_tables`, and each entry
+    in `aux_keys` is used to join the corresponding auxiliary table. In the same way,
+    each entry in `cols` is an iterable of columns to aggregate in the corresponding
+    auxiliary table. If the keys are the same in the main table and the auxiliary
+    tables, the `keys` parameter can be used instead of `main_keys` and `aux_keys`.
+
+    Therefore if we have a single table, we could either use
+
+    - the :class:`AggJoiner`: ``AggJoiner(aux_table, key="ID")``
+    - or the :class:`MultiAggJoiner`: ``MultiAggJoiner([aux_table], keys=[["ID"]])``
+
+    Note that for `keys`, `main_keys`, `aux_keys`, `cols` and `operations`,
+    an input of the form ``[["a"], ["b"], ["c", "d"]]`` is valid
+    while ``["a", "b", ["c", "d"]]`` is not.
+
+    Using a column from the first auxiliary table to join the second auxiliary table
+    is not (yet) supported.
+
+    Accepts :obj:`pandas.DataFrame` and :class:`polars.DataFrame` inputs.
+
 
     Examples
     --------


### PR DESCRIPTION
Joiners and deduplicate have certain shortcomings that may lead users into overly optimistic expectations. This PR cleans up the documentation of those objects and adds warnings about some issues that may occur. 

We might be reworking or deprecating this part of skrub, but that will take a long time, so for the time being we should try to deprioritize joiners as much as possible in favor of using the Data Ops instead. 