### PR TITLE
FIX - a bug in get_feature_names_out and ApplyToSubFrame

### DIFF
--- a/skrub/_apply_to_sub_frame.py
+++ b/skrub/_apply_to_sub_frame.py
@@ -265,7 +265,7 @@ class ApplyToSubFrame(TransformerMixin, SkrubBaseEstimator):
 
     # set_output api compatibility
 
-    def get_feature_names_out(self):
+    def get_feature_names_out(self, input_features=None):
         """Get output feature names for transformation.
 
         Returns


### PR DESCRIPTION
# Bug Fix Pull Request


## Description

This code fails at preview time because ApplyToCols tries to call get_feature_names_out in ApplyToSubFrame (which is used because OHE isn't a single column transformer). 

```python
import skrub
import pandas as pd
from sklearn.preprocessing import OneHotEncoder


df = pd.DataFrame(
    {
        "cat": ["a", "b", "c"],
    }
)

do = skrub.var("df", df).skb.apply(
    skrub.ApplyToCols(OneHotEncoder(sparse_output=False), cols="cat")
)
# do
```
Result: 
```
RuntimeError: Evaluation of 'apply()' failed.
You can see the full traceback above. The error message was:
TypeError: ApplyToSubFrame.get_feature_names_out() takes 1 positional argument but 2 were given
```

This PR fixes the problem.