### PR TITLE
fix column_associations when column names are not strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ Bugfixes
   double dollar (``$$``) signs has been fixed.
   :pr:`2154` by :user:`Katerina Michenina <Michenina-Lab>`,
   :user:`CecilyTS <CecilyTS>`, :user:`Eve Rabin <eve2705>`.
+- An error that happened when running ``TableReport`` or ``column_associations``
+  on some dataframes with non-string column names has been fixed in :pr:`2179`
+  by :user:`Jérôme Dockès <jeromedockes>`.
 
 Deprecations
 ------------

--- a/skrub/_check_input.py
+++ b/skrub/_check_input.py
@@ -20,14 +20,6 @@ def cast_column_names_to_strings(df):
 
 
 def _column_names_to_strings(column_names):
-    non_string = [c for c in column_names if not isinstance(c, str)]
-    if not non_string:
-        return column_names
-    warnings.warn(
-        f"Some dataframe column names are not strings: {non_string}.\n"
-        "All dataframe column names must be strings in skrub pipelines; "
-        "converting to strings."
-    )
     return list(map(str, column_names))
 
 

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -134,7 +134,7 @@ def _stack_symmetric_associations(associations, df):
         right_indices[order],
         associations[order],
     )
-    col_names = np.asarray(list(map(str, sbd.column_names(df))))
+    col_names = np.asarray(sbd.column_names(df))
     left_column_names, right_column_names = (
         col_names[left_indices],
         col_names[right_indices],

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -134,7 +134,7 @@ def _stack_symmetric_associations(associations, df):
         right_indices[order],
         associations[order],
     )
-    col_names = np.asarray(sbd.column_names(df))
+    col_names = np.asarray(list(map(str, sbd.column_names(df))))
     left_column_names, right_column_names = (
         col_names[left_indices],
         col_names[right_indices],
@@ -302,9 +302,11 @@ def _melt(df, left_col, right_col, val):
 def _melt_pandas(df, left_col, right_col, val):
     # Deal with multi-level index and columns
     if df.index.nlevels > 1:
-        df.index = df.index.to_flat_index().astype("string")
+        df.index = df.index.to_flat_index()
+    df.index = df.index.astype("string")
     if df.columns.nlevels > 1:
-        df.columns = df.columns.to_flat_index().astype("string")
+        df.columns = df.columns.to_flat_index()
+    df.columns = df.columns.astype("string")
     return df.melt(ignore_index=False, var_name=right_col, value_name=val).reset_index(
         names=left_col
     )

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -879,34 +879,42 @@ def test_concat_vertical_duplicate_cols():
 def test_concat_non_str_colname():
     int_columns = pd.DataFrame({0: [1, 2], 1: [3, 4]})
     string_columns = pd.DataFrame({"0": [1, 2], "1": [3, 4]})
+    result = (
+        skrub.as_data_op(int_columns)
+        .skb.concat([skrub.as_data_op(string_columns)], axis=1)
+        .skb.eval()
+    )
+    assert result.shape == (2, 4)
 
-    # check that a warning is raised because of non-string column name
-    with pytest.warns(
-        UserWarning, match="Some dataframe column names are not strings:"
-    ):
-        skrub.as_data_op(int_columns).skb.concat(
-            [skrub.as_data_op(string_columns)], axis=1
-        )
-    with pytest.warns(
-        UserWarning, match="Some dataframe column names are not strings:"
-    ):
-        skrub.as_data_op(int_columns).skb.concat(
-            [skrub.as_data_op(int_columns)], axis=1
-        )
+    result = (
+        skrub.as_data_op(int_columns)
+        .skb.concat([skrub.as_data_op(int_columns)], axis=1)
+        .skb.eval()
+    )
+    assert result.shape == (2, 4)
 
-    # no warnings raised when all column names are strings
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        skrub.as_data_op(string_columns).skb.concat(
-            [skrub.as_data_op(string_columns)], axis=1
-        )
+    result = (
+        skrub.as_data_op(string_columns)
+        .skb.concat([skrub.as_data_op(string_columns)], axis=1)
+        .skb.eval()
+    )
+    assert result.shape == (2, 4)
 
-    # check that no warning is raised when concatenating vertically
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        skrub.as_data_op(int_columns).skb.concat(
-            [skrub.as_data_op(int_columns)], axis=0
-        )
+    result = (
+        skrub.as_data_op(int_columns)
+        .skb.concat([skrub.as_data_op(int_columns)], axis=0)
+        .skb.eval()
+    )
+    assert result.shape == (4, 2)
+    assert list(result.columns) == [0, 1]
+
+    result = (
+        skrub.as_data_op(string_columns)
+        .skb.concat([skrub.as_data_op(string_columns)], axis=0)
+        .skb.eval()
+    )
+    assert result.shape == (4, 2)
+    assert list(result.columns) == ["0", "1"]
 
 
 def test_concat_numpy_arrays():
@@ -926,6 +934,12 @@ def test_concat_numpy_arrays():
     out = result.skb.eval()
     expected = np.concatenate([a, b], axis=1)
     np.testing.assert_array_equal(out, expected)
+
+
+def test_int_column_names():
+    assert list(
+        skrub.X(pd.DataFrame({0: [1, 2]})).skb.apply("passthrough").skb.eval().columns
+    ) == ["0"]
 
 
 def test_get_vars():

--- a/skrub/_data_ops/tests/test_errors.py
+++ b/skrub/_data_ops/tests/test_errors.py
@@ -3,7 +3,6 @@ import re
 import traceback
 
 import numpy as np
-import pandas as pd
 import pytest
 from sklearn.datasets import make_classification
 from sklearn.dummy import DummyClassifier
@@ -636,11 +635,6 @@ def test_unhashable():
         {skrub.choose_bool(name="b")}
     with pytest.raises(TypeError, match="unhashable type"):
         {skrub.choose_bool(name="b").if_else(0, 1)}
-
-
-def test_int_column_names():
-    with pytest.warns(match="Some dataframe column names are not strings"):
-        skrub.X(pd.DataFrame({0: [1, 2]})).skb.apply("passthrough")
 
 
 def test_mark_as_X_missing_cv():

--- a/skrub/tests/test_check_input.py
+++ b/skrub/tests/test_check_input.py
@@ -53,9 +53,8 @@ def test_column_names_to_unique_strings():
     df = pd.DataFrame(np.ones((2, 4)), columns=["a", 0, "0", "a"])
     assert df.columns.tolist() == ["a", 0, "0", "a"]
     check = CheckInputDataFrame()
-    with pytest.warns(UserWarning, match="Some dataframe column names are not strings"):
-        with pytest.warns(UserWarning, match="Found duplicated column names"):
-            out = check.fit_transform(df)
+    with pytest.warns(UserWarning, match="Found duplicated column names"):
+        out = check.fit_transform(df)
     assert out.shape == (2, 4)
     out_cols = out.columns.tolist()
     assert out_cols[:2] == ["a", "0"]


### PR DESCRIPTION
```
import numpy as np
import skrub
import pandas as pd

df = pd.DataFrame(np.eye(3))
print(skrub.column_associations(df))
skrub.TableReport(df).open()
```

before it would crash


also cleaned up a useless warning in the conversion of column names to strings code