### PR TITLE
DOC Fix GapEncoder ngram_range description

### DIFF
--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -87,8 +87,8 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
         n-grams counts.
     max_iter : int, default=5
         Maximum number of iterations on the input data.
-    ngram_range : int 2-tuple, default=(2, 4)
-       The lower and upper boundaries of the range of n-values for different
+    ngram_range : int 2-tuple (min_n, max_n), default=(2, 4)
+        The lower and upper boundaries of the range of n-values for different
         n-grams used in the string similarity. All values of `n` such
         that ``min_n <= n <= max_n`` will be used.
     analyzer : {'word', 'char', 'char_wb'}, default='char'


### PR DESCRIPTION
Fixes #2129.

This updates the `GapEncoder` `ngram_range` parameter documentation to match the formatting used by `SimilarityEncoder`:

- adds `(min_n, max_n)` to clarify the tuple contents
- fixes the indentation of the wrapped description line so the docs render correctly

This is a documentation-only change.