### PR TITLE
Add dict method for converting report data to dictionary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Ongoing development
 
 New Features
 ------------
+- :meth:`TableReport.dict` now allows exporting the report data as a Python 
+  -dictionary. :pr:`2188` by :user:`m4nn2609-dot <m4nn2609-dot>`.
 - New methods :meth:`SkrubLearner.get_named_params` and
   :meth:`SkrubLearner.set_named_params` allow getting and setting the outcomes for
   choices contained in the DataOp, keyed by choice name. It provides a more

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,7 @@ Ongoing development
 
 New Features
 ------------
-- :meth:`TableReport.dict` now allows exporting the report data as a Python 
-  -dictionary. :pr:`2188` by :user:`m4nn2609-dot <m4nn2609-dot>`.
+- :meth:`TableReport.dict` now allows exporting the report data as a Python dictionary. :pr:`2188` by :user:`m4nn2609-dot <m4nn2609-dot>`.
 - New methods :meth:`SkrubLearner.get_named_params` and
   :meth:`SkrubLearner.set_named_params` allow getting and setting the outcomes for
   choices contained in the DataOp, keyed by choice name. It provides a more

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -439,7 +439,7 @@ class TableReport:
         to_remove = ["dataframe", "sample_table"]
         data = {k: v for k, v in self._summary.items() if k not in to_remove}
         return json.dumps(data, cls=JSONEncoder)
-        
+
     def dict(self):
         """Get the report data in Python Dictionary format.
 

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -439,6 +439,15 @@ class TableReport:
         to_remove = ["dataframe", "sample_table"]
         data = {k: v for k, v in self._summary.items() if k not in to_remove}
         return json.dumps(data, cls=JSONEncoder)
+    def dict(self):
+        """Get the report data in Python Dictionary format.
+
+        Returns
+        -------
+        dict :
+            The report data
+        """
+        return json.loads(self.json())
 
     def markdown(self):
         """Get the report as a Markdown string.

--- a/skrub/_reporting/_table_report.py
+++ b/skrub/_reporting/_table_report.py
@@ -439,6 +439,7 @@ class TableReport:
         to_remove = ["dataframe", "sample_table"]
         data = {k: v for k, v in self._summary.items() if k not in to_remove}
         return json.dumps(data, cls=JSONEncoder)
+        
     def dict(self):
         """Get the report data in Python Dictionary format.
 

--- a/skrub/_reporting/tests/test_table_report.py
+++ b/skrub/_reporting/tests/test_table_report.py
@@ -674,3 +674,8 @@ def test_column_filters_fail(df_module, filter, expected, match):
     )
     with pytest.raises(expected, match=match):
         TableReport(df, column_filters=filter)
+
+
+def test_table_report_dict(air_quality):
+    report = TableReport(air_quality)
+    assert report.dict() == json.loads(report.json())


### PR DESCRIPTION
closes #2147 
Add a `dict()` method to `TableReport` that returns the report data as a 
Python dictionary, equivalent to `json.loads(report.json())`.

This allows users to access the report contents programmatically without 
having to manually parse the JSON string.