### PR TITLE
allow filtering coords of the parallel coord plot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,8 @@ Ongoing development
 
 New Features
 ------------
-- :meth:`TableReport.dict` now allows exporting the report data as a Python dictionary. :pr:`2188` by :user:`m4nn2609-dot <m4nn2609-dot>`.
+- :meth:`TableReport.dict` now allows exporting the report data as a Python
+  dictionary. :pr:`2188` by :user:`m4nn2609-dot <m4nn2609-dot>`.
 - New methods :meth:`SkrubLearner.get_named_params` and
   :meth:`SkrubLearner.set_named_params` allow getting and setting the outcomes for
   choices contained in the DataOp, keyed by choice name. It provides a more
@@ -57,6 +58,11 @@ New Features
 - Added :func:`skrub.selectors.object` to select columns with the ``object``
   (pandas) or ``pl.Object`` (polars) dtype. :pr:`2171` by :user:`Omkar Kabde
   <omkar-334>`.
+- :meth:`ParamSearch.plot_results` and :meth:`OptunaParamSearch.plot_results`
+  accept new parameters ``show_scores``, ``show_choices``, and ``show_times`` to
+  control respectively which scores, choices (params), and times (fit or score
+  durations) should be included in the figure. :pr:`2202` by :user:`Jérôme
+  Dockès <jeromedockes>`.
 
 Changes
 -------

--- a/examples/02_data_ops/1130_choices.py
+++ b/examples/02_data_ops/1130_choices.py
@@ -279,10 +279,10 @@ search.plot_results()
 # durations or not.
 #
 # For example if we wanted to include only the encoder and classifier and hide
-# the times:
+# the fitting time:
 
 # %%
-search.plot_results(show_choices=["encoder", "classifier"], show_times=False)
+search.plot_results(show_choices=["encoder", "classifier"], show_times=["score"])
 
 # %%
 # In this example, we've seen how to use skrub's ``choose_from`` objects to tune

--- a/examples/02_data_ops/1130_choices.py
+++ b/examples/02_data_ops/1130_choices.py
@@ -269,6 +269,20 @@ search.plot_results()
 # performs better than the ``RidgeClassifier`` in most cases, that the ``StringEncoder``
 # outperforms the ``MinHashEncoder``, and that the choice of the additional ``length``
 # feature does not have a significant impact on the score.
+#
+# When we have many choices in our DataOp, or when we add many scorers with
+# :meth:`.skb.with_scoring() <DataOp.skb.with_scoring>` (not shown in this
+# example), the parallel coordinate plot can get very crowded or even
+# unreadable. To avoid this, :meth:`ParamSearch.plot_results` (and
+# :meth:`OptunaParamSearch.plot_results`) allow us to filter the scores and
+# parameters to include in the plot, and whether to include fitting and scoring
+# durations or not.
+#
+# For example if we wanted to include only the encoder and classifier and hide
+# the times:
+
+# %%
+search.plot_results(show_choices=["encoder", "classifier"], show_times=False)
 
 # %%
 # In this example, we've seen how to use skrub's ``choose_from`` objects to tune

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1379,7 +1379,7 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         min_score=None,
         show_scores=None,
         show_choices=None,
-        show_times=True,
+        show_times=None,
     ):
         """Create a parallel coordinate plot of the cross-validation results.
 
@@ -1407,38 +1407,34 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             (e.g. "alpha" in ``choose_float(0.0, 1.0, name="alpha")``).
             By default all are shown.
 
-        show_times : bool, optional, default=True
-            Whether to show fit and score time or not.
+        show_times : list of str, optional
+            List of durations to show. Available times are ["fit", "score"].
+            By default both are shown.
 
         Returns
         -------
         Plotly Figure
         """
 
-        # Check that requested show_scores and show_choices (if any) are available
+        # Check that requested show_scores, show_choices, and show_times
+        # (if any) are available
 
-        if isinstance(show_scores, str):
-            show_scores = [show_scores]
-        if show_scores is not None:
-            available_scores = self._get_score_names()
-            missing_scores = set(show_scores).difference(available_scores)
-            if missing_scores:
-                raise ValueError(
-                    "The following scores were requested in show_scores "
-                    f"but do not exist in the results:\n{missing_scores}.\n"
-                    f"The available scores are:\n{available_scores}."
-                )
-        if isinstance(show_choices, str):
-            show_choices = [show_choices]
-        if show_choices is not None:
-            available_choices = self._get_choice_names()
-            missing_choices = set(show_choices).difference(available_choices)
-            if missing_choices:
-                raise ValueError(
-                    "The following choices (params) were requested in show_choices "
-                    f"but do not exist in the results:\n{missing_choices}.\n"
-                    f"The available choices are: {available_choices}."
-                )
+        def _check(requested, available, name):
+            if isinstance(requested, str):
+                requested = [requested]
+            if requested is not None:
+                missing = set(requested).difference(available)
+                if missing:
+                    raise ValueError(
+                        f"The following {name} were requested in show_{name} "
+                        f"but do not exist in the results:\n{missing}.\n"
+                        f"The available {name} are:\n{available}."
+                    )
+            return requested
+
+        show_scores = _check(show_scores, self._get_score_names(), "scores")
+        show_choices = _check(show_choices, self._get_choice_names(), "choices")
+        show_times = _check(show_times, ["fit", "score"], "times")
 
         # Prepare the figure data
 
@@ -1461,8 +1457,11 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             if col_meta["type"] == "choice":
                 if show_choices is not None and col_meta["name"] not in show_choices:
                     to_drop.add(col_name)
-        time_cols = {"mean_fit_time", "mean_score_time"}
-        to_drop = (to_drop - time_cols) if show_times else (to_drop | time_cols)
+        for meth in ["fit", "score"]:
+            if show_times is None or meth in show_times:
+                to_drop.discard(f"mean_{meth}_time")
+            else:
+                to_drop.add(f"mean_{meth}_time")
         to_show = set(cv_results.columns) - to_drop
 
         # Find rows to show based on min_score

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1393,7 +1393,16 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             perform well, to make the plot less cluttered and to make better
             use of the colorscale's range.
 
-        metrics :
+        show_scores : list of str, optional
+            List of score names to show. By default all are shown.
+
+        show_choices : list of str, optional
+            List of choice names (e.g. "alpha" in
+            ``choose_float(0.0, 1.0, name="alpha")``) to show.
+            By default all are shown.
+
+        show_time : bool, optional, default=True
+            Whether to show fit and score time or not.
 
         Returns
         -------

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1303,6 +1303,20 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         except NotFittedError:
             attribute_error(self, "results_")
 
+    def _get_score_names(self):
+        return [
+            k.removeprefix("mean_test_")
+            for k in self.cv_results_.keys()
+            if k.startswith("mean_test_")
+        ]
+
+    def _get_choice_names(self):
+        return [
+            n
+            for c in choice_graph(self.data_op)["choices"].values()
+            if (n := c.name) is not None
+        ]
+
     def _get_cv_results_table(self, detailed=False):
         check_is_fitted(self, "cv_results_")
         data_op_choices = choice_graph(self.data_op)
@@ -1318,30 +1332,20 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         columns_metadata = []
         for c_id, display_name in data_op_choices["choice_display_names"].items():
             c = data_op_choices["choices"][c_id]
-            columns_metadata.append(
-                {
-                    "type": "choice",
-                    "id": c_id,
-                    "name": c.name,
-                    "display_name": display_name,
-                }
-            )
-        metric_names = [
-            k.removeprefix("mean_test_")
-            for k in self.cv_results_.keys()
-            if k.startswith("mean_test_")
-        ]
+            columns_metadata.append({"type": "choice", "name": c.name})
+        score_names = self._get_score_names()
+
         if isinstance(self.refit_, str):
-            metric_names.insert(0, metric_names.pop(metric_names.index(self.refit_)))
+            score_names.insert(0, score_names.pop(score_names.index(self.refit_)))
         result_keys = [
-            *(f"mean_test_{n}" for n in metric_names),
-            *(f"std_test_{n}" for n in metric_names),
+            *(f"mean_test_{n}" for n in score_names),
+            *(f"std_test_{n}" for n in score_names),
             "mean_fit_time",
             "std_fit_time",
             "mean_score_time",
             "std_score_time",
-            *(f"mean_train_{n}" for n in metric_names),
-            *(f"std_train_{n}" for n in metric_names),
+            *(f"mean_train_{n}" for n in score_names),
+            *(f"std_train_{n}" for n in score_names),
         ]
         new_names = _join_utils.pick_column_names(table.columns, result_keys)
         renaming = dict(zip(table.columns, new_names))
@@ -1351,14 +1355,14 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             renaming[c] for c in metadata["log_scale_columns"]
         ]
         if detailed:
-            for k in result_keys[len(metric_names) :][::-1]:
+            for k in result_keys[len(score_names) :][::-1]:
                 if k in self.cv_results_:
                     table.insert(table.shape[1], k, self.cv_results_[k])
                     columns_metadata.append({"type": "score", "name": k})
-        for k in result_keys[: len(metric_names)][::-1]:
+        for k in result_keys[: len(score_names)][::-1]:
             table.insert(table.shape[1], k, self.cv_results_[k])
             columns_metadata.append({"type": "score", "name": k})
-        metadata["col_score"] = f"mean_test_{metric_names[0]}"
+        metadata["col_score"] = f"mean_test_{score_names[0]}"
         metadata["columns_metadata"] = dict(zip(table.columns, columns_metadata))
         table = table.sort_values(
             metadata["col_score"],
@@ -1394,11 +1398,13 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             use of the colorscale's range.
 
         show_scores : list of str, optional
-            List of score names to show. By default all are shown.
+            List of score names to show
+            (e.g. "accuracy" in ``.skb.with_scoring(["roc_auc", "accuracy"])``).
+            By default all are shown.
 
         show_choices : list of str, optional
-            List of choice names (e.g. "alpha" in
-            ``choose_float(0.0, 1.0, name="alpha")``) to show.
+            List of choice names to show
+            (e.g. "alpha" in ``choose_float(0.0, 1.0, name="alpha")``).
             By default all are shown.
 
         show_time : bool, optional, default=True
@@ -1408,11 +1414,38 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         -------
         Plotly Figure
         """
-        cv_results, metadata = self._get_cv_results_table(detailed=True)
+
+        # Check that requested show_scores and show_choices (if any) are available
+
         if isinstance(show_scores, str):
             show_scores = [show_scores]
+        if show_scores is not None:
+            available_scores = self._get_score_names()
+            missing_scores = set(show_scores).difference(available_scores)
+            if missing_scores:
+                raise ValueError(
+                    "The following scores were requested in show_scores "
+                    f"but do not exist in the results:\n{missing_scores}.\n"
+                    f"The available scores are:\n{available_scores}."
+                )
         if isinstance(show_choices, str):
             show_choices = [show_choices]
+        if show_choices is not None:
+            available_choices = self._get_choice_names()
+            missing_choices = set(show_choices).difference(available_choices)
+            if missing_choices:
+                raise ValueError(
+                    "The following choices (params) were requested in show_choices "
+                    f"but do not exist in the results:\n{missing_choices}.\n"
+                    f"The available choices are: {available_choices}."
+                )
+
+        # Prepare the figure data
+
+        cv_results, metadata = self._get_cv_results_table(detailed=True)
+
+        # Find columns to show based on show_scores, show_choices and show_time
+
         to_drop = set()
         for col_name, col_meta in metadata["columns_metadata"].items():
             if col_meta["type"] == "score":
@@ -1425,21 +1458,23 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
                     and col_meta["name"].removeprefix("mean_test_") not in show_scores
                 ):
                     to_drop.add(col_name)
-            if (
-                show_choices is not None
-                and col_meta["type"] == "choice"
-                and col_meta["name"] not in show_choices
-            ):
-                to_drop.add(col_name)
+            if col_meta["type"] == "choice":
+                if show_choices is not None and col_meta["name"] not in show_choices:
+                    to_drop.add(col_name)
         time_cols = {"mean_fit_time", "mean_score_time"}
         to_drop = (to_drop - time_cols) if show_time else (to_drop | time_cols)
         to_show = set(cv_results.columns) - to_drop
+
+        # Find rows to show based on min_score
 
         if min_score is not None:
             col_score = metadata["col_score"]
             cv_results = cv_results[cv_results[col_score] >= min_score]
         if not cv_results.shape[0]:
             raise ValueError("No results to plot")
+
+        # Make the figure
+
         return plot_parallel_coord(
             cv_results=cv_results,
             show_columns=to_show,

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1379,7 +1379,7 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         min_score=None,
         show_scores=None,
         show_choices=None,
-        show_time=True,
+        show_times=True,
     ):
         """Create a parallel coordinate plot of the cross-validation results.
 
@@ -1407,7 +1407,7 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             (e.g. "alpha" in ``choose_float(0.0, 1.0, name="alpha")``).
             By default all are shown.
 
-        show_time : bool, optional, default=True
+        show_times : bool, optional, default=True
             Whether to show fit and score time or not.
 
         Returns
@@ -1444,7 +1444,7 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
 
         cv_results, metadata = self._get_cv_results_table(detailed=True)
 
-        # Find columns to show based on show_scores, show_choices and show_time
+        # Find columns to show based on show_scores, show_choices and show_times
 
         to_drop = set()
         for col_name, col_meta in metadata["columns_metadata"].items():
@@ -1462,7 +1462,7 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
                 if show_choices is not None and col_meta["name"] not in show_choices:
                     to_drop.add(col_name)
         time_cols = {"mean_fit_time", "mean_score_time"}
-        to_drop = (to_drop - time_cols) if show_time else (to_drop | time_cols)
+        to_drop = (to_drop - time_cols) if show_times else (to_drop | time_cols)
         to_show = set(cv_results.columns) - to_drop
 
         # Find rows to show based on min_score

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1416,6 +1416,8 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         Plotly Figure
         """
 
+        check_is_fitted(self, "cv_results_")
+
         # Check that requested show_scores, show_choices, and show_times
         # (if any) are available
 

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1315,6 +1315,17 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         table = pd.DataFrame(
             all_rows, columns=list(data_op_choices["choice_display_names"].values())
         )
+        columns_metadata = []
+        for c_id, display_name in data_op_choices["choice_display_names"].items():
+            c = data_op_choices["choices"][c_id]
+            columns_metadata.append(
+                {
+                    "type": "choice",
+                    "id": c_id,
+                    "name": c.name,
+                    "display_name": display_name,
+                }
+            )
         metric_names = [
             k.removeprefix("mean_test_")
             for k in self.cv_results_.keys()
@@ -1343,9 +1354,12 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             for k in result_keys[len(metric_names) :][::-1]:
                 if k in self.cv_results_:
                     table.insert(table.shape[1], k, self.cv_results_[k])
+                    columns_metadata.append({"type": "score", "name": k})
         for k in result_keys[: len(metric_names)][::-1]:
             table.insert(table.shape[1], k, self.cv_results_[k])
+            columns_metadata.append({"type": "score", "name": k})
         metadata["col_score"] = f"mean_test_{metric_names[0]}"
+        metadata["columns_metadata"] = dict(zip(table.columns, columns_metadata))
         table = table.sort_values(
             metadata["col_score"],
             ascending=False,
@@ -1354,7 +1368,15 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         )
         return table, metadata
 
-    def plot_results(self, *, colorscale=DEFAULT_COLORSCALE, min_score=None):
+    def plot_results(
+        self,
+        *,
+        colorscale=DEFAULT_COLORSCALE,
+        min_score=None,
+        show_scores=None,
+        show_choices=None,
+        show_time=True,
+    ):
         """Create a parallel coordinate plot of the cross-validation results.
 
         Plotly must be installed to use this method.
@@ -1371,29 +1393,50 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
             perform well, to make the plot less cluttered and to make better
             use of the colorscale's range.
 
+        metrics :
+
         Returns
         -------
         Plotly Figure
         """
         cv_results, metadata = self._get_cv_results_table(detailed=True)
-        cv_results = cv_results.drop(
-            [
-                "std_test_score",
-                "std_fit_time",
-                "std_score_time",
-                "mean_train_score",
-                "std_train_score",
-            ],
-            axis="columns",
-            errors="ignore",
-        )
+        if isinstance(show_scores, str):
+            show_scores = [show_scores]
+        if isinstance(show_choices, str):
+            show_choices = [show_choices]
+        to_drop = set()
+        for col_name, col_meta in metadata["columns_metadata"].items():
+            if col_meta["type"] == "score":
+                if col_meta["name"].startswith("std_") or col_meta["name"].startswith(
+                    "mean_train_"
+                ):
+                    to_drop.add(col_name)
+                if (
+                    show_scores is not None
+                    and col_meta["name"].removeprefix("mean_test_") not in show_scores
+                ):
+                    to_drop.add(col_name)
+            if (
+                show_choices is not None
+                and col_meta["type"] == "choice"
+                and col_meta["name"] not in show_choices
+            ):
+                to_drop.add(col_name)
+        time_cols = {"mean_fit_time", "mean_score_time"}
+        to_drop = (to_drop - time_cols) if show_time else (to_drop | time_cols)
+        to_show = set(cv_results.columns) - to_drop
 
         if min_score is not None:
             col_score = metadata["col_score"]
             cv_results = cv_results[cv_results[col_score] >= min_score]
         if not cv_results.shape[0]:
             raise ValueError("No results to plot")
-        return plot_parallel_coord(cv_results, metadata, colorscale=colorscale)
+        return plot_parallel_coord(
+            cv_results=cv_results,
+            show_columns=to_show,
+            metadata=metadata,
+            colorscale=colorscale,
+        )
 
 
 def _get_results_metadata(data_op_choices):

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1405,7 +1405,10 @@ class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):
         show_choices : list of str, optional
             List of choice names to show
             (e.g. "alpha" in ``choose_float(0.0, 1.0, name="alpha")``).
-            By default all are shown.
+            Only choices that were given an explicit name (with the ``name``
+            parameter, as above) can be selected by the filter.
+            By default there is no filtering and all choices (even those
+            without names) are shown.
 
         show_times : list of str, optional
             List of durations to show. Available times are ["fit", "score"].

--- a/skrub/_data_ops/_parallel_coord.py
+++ b/skrub/_data_ops/_parallel_coord.py
@@ -8,7 +8,9 @@ __all__ = ["get_parallel_coord_data", "plot_parallel_coord", "DEFAULT_COLORSCALE
 DEFAULT_COLORSCALE = "bluered"
 
 
-def plot_parallel_coord(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
+def plot_parallel_coord(
+    *, cv_results, show_columns, metadata, colorscale=DEFAULT_COLORSCALE
+):
     try:
         import plotly.graph_objects as go
     except ImportError:
@@ -17,8 +19,9 @@ def plot_parallel_coord(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
     return go.Figure(
         data=go.Parcoords(
             **get_parallel_coord_data(
-                cv_results,
-                metadata,
+                cv_results=cv_results,
+                show_columns=show_columns,
+                metadata=metadata,
                 colorscale=colorscale,
             )
         ),
@@ -26,7 +29,9 @@ def plot_parallel_coord(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
     )
 
 
-def get_parallel_coord_data(cv_results, metadata, colorscale=DEFAULT_COLORSCALE):
+def get_parallel_coord_data(
+    cv_results, show_columns, metadata, colorscale=DEFAULT_COLORSCALE
+):
     prepared_columns = [
         _prepare_column(
             cv_results[col_name],
@@ -34,6 +39,7 @@ def get_parallel_coord_data(cv_results, metadata, colorscale=DEFAULT_COLORSCALE)
             is_int=col_name in metadata["int_columns"],
         )
         for col_name in cv_results.columns
+        if col_name in show_columns
     ]
     prepared_columns = [
         _add_jitter(column) if column["label"] != "score" else column

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -175,8 +175,6 @@ def test_multi_scoring():
         "cols",
         "score time",
         "fit time",
-        "std_test_neg_brier_score",
-        "std_test_accuracy",
         "mean_test_neg_brier_score",
         "mean_test_accuracy",
     ]

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -176,7 +176,7 @@ def classif_grid_search():
 
 
 @pytest.mark.parametrize(
-    "show_scores, show_choices, show_time, expected",
+    "show_scores, show_choices, show_times, expected",
     [
         (
             None,
@@ -215,10 +215,10 @@ def classif_grid_search():
     ],
 )
 def test_multi_scoring_and_filtering(
-    classif_grid_search, show_scores, show_choices, show_time, expected
+    classif_grid_search, show_scores, show_choices, show_times, expected
 ):
     fig = classif_grid_search.plot_results(
-        show_scores=show_scores, show_choices=show_choices, show_time=show_time
+        show_scores=show_scores, show_choices=show_choices, show_times=show_times
     )
     dimensions = fig.data[0]["dimensions"]
     assert [d["label"] for d in dimensions] == expected

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -181,7 +181,7 @@ def classif_grid_search():
         (
             None,
             None,
-            True,
+            None,
             [
                 "cols",
                 "add",
@@ -195,21 +195,20 @@ def classif_grid_search():
         (
             "accuracy",
             ["cols", "add"],
-            False,
+            "fit",
             [
                 "cols",
                 "add",
+                "fit time",
                 "mean_test_accuracy",
             ],
         ),
         (
             [],
             "add",
-            True,
+            [],
             [
                 "add",
-                "score time",
-                "fit time",
             ],
         ),
     ],

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -35,7 +35,8 @@ def test_no_plotly():
         search.plot_results()
 
 
-def test_parallel_coord():
+@pytest.mark.parametrize("specify_show_scores", [False, True])
+def test_parallel_coord(specify_show_scores):
     X_a, y_a = make_classification(n_samples=20, n_features=4, n_informative=2)
     c0 = skrub.choose_from({"a": 0, "b": 1}, name="c0")
     c1 = skrub.choose_from([0, 1], name="c1")
@@ -56,7 +57,7 @@ def test_parallel_coord():
 
     pytest.importorskip("plotly")
 
-    fig = search.plot_results()
+    fig = search.plot_results(show_scores=["score"] if specify_show_scores else None)
     data = iter(fig.data[0]["dimensions"])
     dim = next(data)
     assert dim["label"] == "c0"
@@ -153,7 +154,8 @@ def test_column_preparation(is_log_scale, is_int):
         assert np.all(jittered["values"] == 1.0)
 
 
-def test_multi_scoring():
+@pytest.fixture(scope="module")
+def classif_grid_search():
     pytest.importorskip("plotly")
 
     X, y = make_classification()
@@ -162,19 +164,73 @@ def test_multi_scoring():
     X, y = skrub.X(X), skrub.y(y)
 
     cols = skrub.choose_from([["0"], ["1"]], name="cols")
-    pred = X[cols].skb.apply(DummyClassifier(), y=y)
+    add = skrub.choose_float(0.0, 1.0, name="add", n_steps=3)
+    mul = skrub.choose_float(1.0, 2.0, n_steps=3)  # no name
+    pred = ((X[cols] + add) * mul).skb.apply(DummyClassifier(), y=y)
     search = pred.skb.make_grid_search(
         fitted=True,
         scoring=["accuracy", "neg_brier_score"],
         refit="accuracy",
     )
-    fig = search.plot_results()
+    return search
 
+
+@pytest.mark.parametrize(
+    "show_scores, show_choices, show_time, expected",
+    [
+        (
+            None,
+            None,
+            True,
+            [
+                "cols",
+                "add",
+                "choose_float(1.0,<br>\n2.0, n_steps=3)",
+                "score time",
+                "fit time",
+                "mean_test_neg_brier_<br>\nscore",
+                "mean_test_accuracy",
+            ],
+        ),
+        (
+            "accuracy",
+            ["cols", "add"],
+            False,
+            [
+                "cols",
+                "add",
+                "mean_test_accuracy",
+            ],
+        ),
+        (
+            [],
+            "add",
+            True,
+            [
+                "add",
+                "score time",
+                "fit time",
+            ],
+        ),
+    ],
+)
+def test_multi_scoring_and_filtering(
+    classif_grid_search, show_scores, show_choices, show_time, expected
+):
+    fig = classif_grid_search.plot_results(
+        show_scores=show_scores, show_choices=show_choices, show_time=show_time
+    )
     dimensions = fig.data[0]["dimensions"]
-    assert [d["label"].replace("<br>\n", "") for d in dimensions] == [
-        "cols",
-        "score time",
-        "fit time",
-        "mean_test_neg_brier_score",
-        "mean_test_accuracy",
-    ]
+    assert [d["label"] for d in dimensions] == expected
+
+
+def test_bad_filtering_params(classif_grid_search):
+    # Ask for a score that is not available, available scores are shown
+    with pytest.raises(ValueError, match="['accuracy', 'neg_brier_score']"):
+        classif_grid_search.plot_results(show_scores=["roc_auc"])
+    # Only choices with an actual name can be selected. Here we ask for a
+    # choice name that does not exist, available ones are shown.
+    with pytest.raises(ValueError, match="['cols', 'add']"):
+        classif_grid_search.plot_results(
+            show_choices=["choose_float(1.0, 2.0, n_steps=3)"]
+        )

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -35,8 +35,7 @@ def test_no_plotly():
         search.plot_results()
 
 
-@pytest.mark.parametrize("specify_show_scores", [False, True])
-def test_parallel_coord(specify_show_scores):
+def test_parallel_coord():
     X_a, y_a = make_classification(n_samples=20, n_features=4, n_informative=2)
     c0 = skrub.choose_from({"a": 0, "b": 1}, name="c0")
     c1 = skrub.choose_from([0, 1], name="c1")
@@ -57,7 +56,7 @@ def test_parallel_coord(specify_show_scores):
 
     pytest.importorskip("plotly")
 
-    fig = search.plot_results(show_scores=["score"] if specify_show_scores else None)
+    fig = search.plot_results()
     data = iter(fig.data[0]["dimensions"])
     dim = next(data)
     assert dim["label"] == "c0"
@@ -154,8 +153,9 @@ def test_column_preparation(is_log_scale, is_int):
         assert np.all(jittered["values"] == 1.0)
 
 
-@pytest.fixture(scope="module")
-def classif_grid_search():
+@pytest.fixture(scope="module", params=[False, True])
+def classif_grid_search(request):
+    use_with_scoring = request.param
     pytest.importorskip("plotly")
 
     X, y = make_classification()
@@ -167,12 +167,19 @@ def classif_grid_search():
     add = skrub.choose_float(0.0, 1.0, name="add", n_steps=3)
     mul = skrub.choose_float(1.0, 2.0, n_steps=3)  # no name
     pred = ((X[cols] + add) * mul).skb.apply(DummyClassifier(), y=y)
-    search = pred.skb.make_grid_search(
-        fitted=True,
-        scoring=["accuracy", "neg_brier_score"],
-        refit="accuracy",
-    )
-    return search
+    if use_with_scoring:
+        return pred.skb.with_scoring(
+            ["accuracy", "neg_brier_score"]
+        ).skb.make_grid_search(
+            fitted=True,
+            refit="accuracy",
+        )
+    else:
+        return pred.skb.make_grid_search(
+            fitted=True,
+            scoring=["accuracy", "neg_brier_score"],
+            refit="accuracy",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
we can select which metrics and params to show in dataop parallel coordinate plots

if we have a huge number of scores it becomes unreadable

<img width="1680" height="937" alt="screenshot_2026-07-02T16:19:53+02:00" src="https://github.com/user-attachments/assets/76565968-999b-4790-934f-b4f566afbf40" />


now we can do

```python
s.plot_results(show_times=[], show_scores=['neg_mape__12h__q_0.5', 'd2_pinball_score__12h__q_0.5'])
```

to select which to include

<img width="1692" height="914" alt="screenshot_2026-07-02T18:03:03+02:00" src="https://github.com/user-attachments/assets/22d0c228-24b5-4549-8e31-5133eaf49f6c" />


also fixes the fact that "std_" columns were only filtered out for "score" before