### PR TITLE
better error message when variables are missing from env

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New Features
 
 Changes
 -------
+- The error message when a key is missing from the environment passed to a
+  :class:`DataOp` or :class:`SkrubLearner` has been improved.
+  :pr:`2211` by :user:`Jérôme Dockès <jeromedockes>`.
 
 Bugfixes
 --------

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -150,6 +150,14 @@ class UninitializedVariable(KeyError):
     Evaluating a DataOp and a value has not been provided for one of the variables.
     """
 
+    def __init__(self, name):
+        self.name = name
+        self.message = f"No value has been provided for {name!r}"
+        super().__init__(name)
+
+    def __str__(self):
+        return self.message
+
 
 def _remove_shell_frames(stack):
     """
@@ -961,9 +969,7 @@ class Var(DataOpImpl):
         if mode == "preview":
             assert not environment
             if e.value is NULL:
-                raise UninitializedVariable(
-                    f"No value has been provided for {e.name!r}"
-                )
+                raise UninitializedVariable(e.name)
             return e.value
         if e.name in environment:
             return environment[e.name]
@@ -971,7 +977,7 @@ class Var(DataOpImpl):
             e.becomes_default or environment.get("_skrub_use_var_values", False)
         ) and e.value is not NULL:
             return e.value
-        raise UninitializedVariable(f"No value has been provided for {e.name!r}")
+        raise UninitializedVariable(e.name)
 
     def preview_if_available(self):
         return self.value

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -925,7 +925,10 @@ class _XyPipeline(_XyPipelineMixin, SkrubLearner):
             return (result, {}) if return_predictions else result
         env = self._get_env(X, y)
         scorers = evaluate(
-            score_node._skrub_impl.scorers, mode="fit_transform", environment=env
+            score_node._skrub_impl.scorers,
+            mode="fit_transform",
+            environment=env,
+            ancestor_data_op=self.data_op,
         )
         all_scores = []
         cache = dict(env.get("_skrub_predictions", {}))
@@ -982,7 +985,13 @@ def _compute_X_y_and_cv(data_op, environment):
             # the estimator requests a y so some node must have been
             # marked as y
             raise ValueError('DataOp should have a node marked with "mark_as_y()"')
-    values = evaluate(nodes, mode="fit_transform", environment=environment, clear=True)
+    values = evaluate(
+        nodes,
+        mode="fit_transform",
+        environment=environment,
+        clear=True,
+        ancestor_data_op=data_op,
+    )
     if "y" in nodes:
         msg = (
             "\nAre `.skb.subsample()` and `.skb.mark_as_*()` applied in the same order"

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -427,18 +427,15 @@ def _check_environment(environment):
         )
     # Notes about checking the env keys:
     #
-    # - env ⊂ variables: in some cases we could check that there are no extra
-    #   keys in `environment`, ie all keys in `environment` correspond to a
-    #   name in the DataOp. However in other cases we naturally end up
-    #   using a bigger environment than what is needed. For example we want to
-    #   evaluate a sub-DataOp (such as the `mark_as_X()` node), and to do
-    #   it we use the environment that was passed to evaluate the full
-    #   DataOp. So if we want such a verification it should be a separate
-    #   check done at a higher level (eg in the estimators' `fit`, `predict`
-    #   etc.) where we know we are not working with a sub-DataOp. We do perform
-    #   such a check when a key is missing from the env to provide a better
-    #   message, but it is only used for the content of the message rather than
-    #   enforcing no extra keys ahead of time.
+    # - env ⊂ variables: we could check that there are no extra keys in
+    #   `environment`, i.e. all keys in `environment` correspond to a name in
+    #   the DataOp. However in some cases we naturally end up using a bigger
+    #   environment than what is needed. For example we want to evaluate a
+    #   sub-DataOp (such as the result of `.skb.find()` or `.skb.find_X_y()`),
+    #   and to do it we use the environment created to evaluate the full
+    #   DataOp. We do perform this check when a key is missing from the env to
+    #   provide a better error message, but it is only used for the content of
+    #   the message rather than enforcing no extra keys ahead of time.
     #
     # - variables ⊂ env: we cannot check that all variables in the DataOp
     #   have a matching key in the `environment`, because depending on the
@@ -531,9 +528,11 @@ def _uninitialized_variable_msg(error, data_op, environment):
     var_names = list(named_nodes(data_op).keys())
     choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
     unused = list(
-        {k for k in environment.keys() if not k.startswith("_skrub_")}.difference(
-            var_names + choice_names
-        )
+        {
+            k
+            for k in environment.keys()
+            if isinstance(k, str) and not k.startswith("_skrub_")
+        }.difference(var_names + choice_names)
     )
 
     msg = (

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -514,7 +514,11 @@ def evaluate(
             # user passed an explicit environment rather than using the
             # variables' preview values.
             e.add_note(
-                _uninitialized_variable_msg(e, data_op, environment, ancestor_data_op)
+                _uninitialized_variable_msg(
+                    e,
+                    ancestor_data_op if ancestor_data_op is not None else data_op,
+                    environment,
+                )
             )
         raise
     finally:
@@ -522,9 +526,8 @@ def evaluate(
             clear_results(data_op, mode=mode)
 
 
-def _uninitialized_variable_msg(error, data_op, environment, ancestor_data_op):
+def _uninitialized_variable_msg(error, data_op, environment):
     missing_name = error.name
-    data_op = ancestor_data_op if ancestor_data_op is not None else data_op
     var_names = list(named_nodes(data_op).keys())
     choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
     unused = list(

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -501,19 +501,18 @@ def _uninitialized_variable_msg(error, data_op, environment):
     var_names = list(data_op.skb.get_vars().keys())
     choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
     unused = list(set(environment.keys()).difference(var_names + choice_names))
-    if unused:
-        msg = (
-            "- The following keys were passed in the environment but "
-            f"have no corresponding variable in the DataOp:\n  {unused}\n"
-        )
-    else:
-        msg = ""
-    msg = msg + (
-        "- Note that all values are dropped by .skb.make_learner()\n"
-        "  by default and need to be passed explicitly in the environment.\n"
+
+    msg = (
+        "- Note that all values are dropped by .skb.make_learner() "
+        "by default\n  and need to be passed explicitly in the environment.\n"
         f"  (You can use skrub.var({missing_name!r}, value=..., becomes_default=True)\n"
         "  to always retain the passed value as a default.)"
     )
+    if unused:
+        msg += (
+            "\n- WARNING: the following keys were passed in the environment but "
+            f"have no corresponding variable in the DataOp:\n  {unused}"
+        )
     return msg
 
 

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -488,7 +488,7 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
             data_op
         )
     except UninitializedVariable as e:
-        if hasattr(e, "add_note"):
+        if hasattr(e, "add_note") and environment is not None:
             e.add_note(_uninitialized_variable_msg(e, data_op, environment))
         raise
     finally:

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -435,7 +435,10 @@ def _check_environment(environment):
     #   it we use the environment that was passed to evaluate the full
     #   DataOp. So if we want such a verification it should be a separate
     #   check done at a higher level (eg in the estimators' `fit`, `predict`
-    #   etc.) where we know we are not working with a sub-DataOp.
+    #   etc.) where we know we are not working with a sub-DataOp. We do perform
+    #   such a check when a key is missing from the env to provide a better
+    #   message, but it is only used for the content of the message rather than
+    #   enforcing no extra keys ahead of time.
     #
     # - variables ⊂ env: we cannot check that all variables in the DataOp
     #   have a matching key in the `environment`, because depending on the

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -26,6 +26,7 @@ from ._data_ops import (
     DataOp,
     Scoring,
     SplitX,
+    UninitializedVariable,
     Value,
     Var,
 )
@@ -429,7 +430,7 @@ def _check_environment(environment):
     # - env ⊂ variables: in some cases we could check that there are no extra
     #   keys in `environment`, ie all keys in `environment` correspond to a
     #   name in the DataOp. However in other cases we naturally end up
-    #   using a bigger environment than what is needed. For example we want tu
+    #   using a bigger environment than what is needed. For example we want to
     #   evaluate a sub-DataOp (such as the `mark_as_X()` node), and to do
     #   it we use the environment that was passed to evaluate the full
     #   DataOp. So if we want such a verification it should be a separate
@@ -486,9 +487,34 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
         return _Evaluator(mode=mode, environment=environment, callbacks=callbacks).run(
             data_op
         )
+    except UninitializedVariable as e:
+        if hasattr(e, "add_note"):
+            e.add_note(_uninitialized_variable_msg(e, data_op, environment))
+        raise
     finally:
         if clear:
             clear_results(data_op, mode=mode)
+
+
+def _uninitialized_variable_msg(error, data_op, environment):
+    missing_name = error.name
+    var_names = list(data_op.skb.get_vars().keys())
+    choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
+    unused = list(set(environment.keys()).difference(var_names + choice_names))
+    if unused:
+        msg = (
+            "- The following keys were passed in the environment but "
+            f"have no corresponding variable in the DataOp:\n  {unused}\n"
+        )
+    else:
+        msg = ""
+    msg = msg + (
+        "- Note that all values are dropped by .skb.make_learner()\n"
+        "  by default and need to be passed explicitly in the environment.\n"
+        f"  (You can use skrub.var({missing_name!r}, value=..., becomes_default=True)\n"
+        "  to always retain the passed value as a default.)"
+    )
+    return msg
 
 
 def _cache_pruner(data_op, mode):

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -532,7 +532,8 @@ def _uninitialized_variable_msg(error, data_op, environment, ancestor_data_op):
 
     msg = (
         "- Note that preview values passed to initialize skrub variables\n"
-        "  are ignored by default when we pass an explicit 'environment' dictionary,\n"
+        "  are ignored by default whenever we pass "
+        "an explicit 'environment' dictionary,\n"
         "  for example when calling SkrubLearner.fit({'X': ..., 'y': ...}).\n"
         f"  Please pass a value for {missing_name!r} in the environment.\n"
         "  You can also use "

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -451,7 +451,14 @@ def _check_environment(environment):
 # consistent with .skb.eval() in evaluate's params
 
 
-def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=()):
+def evaluate(
+    data_op,
+    mode="preview",
+    environment=None,
+    clear=False,
+    callbacks=(),
+    ancestor_data_op=None,
+):
     """Evaluate a DataOp.
 
     Parameters
@@ -476,6 +483,14 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
         Each will be called, in the provided order, after evaluating each node.
         The signature is callback(data_op, result) where data_op is the DataOp
         that was just evaluated and result is the resulting value.
+
+    ancestor_data_op : DataOp or None
+        When we are evaluating a part of a DataOp (e.g. the X node only), pass
+        this so that we can look at all the variable names of the full DataOp
+        when producing error messages about missing or extra keys in the
+        environment. It is not used for other purposes than inspecting the
+        variable an choice names it contains. In particular it is not
+        evaluated.
     """
     _check_environment(environment)
     if clear:
@@ -495,15 +510,18 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
         ):
             # user passed an explicit environment rather than using the
             # variables' preview values.
-            e.add_note(_uninitialized_variable_msg(e, data_op, environment))
+            e.add_note(
+                _uninitialized_variable_msg(e, data_op, environment, ancestor_data_op)
+            )
         raise
     finally:
         if clear:
             clear_results(data_op, mode=mode)
 
 
-def _uninitialized_variable_msg(error, data_op, environment):
+def _uninitialized_variable_msg(error, data_op, environment, ancestor_data_op):
     missing_name = error.name
+    data_op = ancestor_data_op if ancestor_data_op is not None else data_op
     var_names = list(named_nodes(data_op).keys())
     choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
     unused = list(

--- a/skrub/_data_ops/_evaluation.py
+++ b/skrub/_data_ops/_evaluation.py
@@ -30,7 +30,7 @@ from ._data_ops import (
     Value,
     Var,
 )
-from ._utils import NULL, X_NAME, Y_NAME, simple_repr
+from ._utils import IS_PREVIEW_DATA_ENV_NAME, NULL, X_NAME, Y_NAME, simple_repr
 
 _BUILTIN_SEQ = (list, tuple, set, frozenset)
 
@@ -488,7 +488,13 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
             data_op
         )
     except UninitializedVariable as e:
-        if hasattr(e, "add_note") and environment is not None:
+        if (
+            hasattr(e, "add_note")
+            and environment is not None
+            and not environment.get(IS_PREVIEW_DATA_ENV_NAME)
+        ):
+            # user passed an explicit environment rather than using the
+            # variables' preview values.
             e.add_note(_uninitialized_variable_msg(e, data_op, environment))
         raise
     finally:
@@ -498,15 +504,22 @@ def evaluate(data_op, mode="preview", environment=None, clear=False, callbacks=(
 
 def _uninitialized_variable_msg(error, data_op, environment):
     missing_name = error.name
-    var_names = list(data_op.skb.get_vars().keys())
+    var_names = list(named_nodes(data_op).keys())
     choice_names = [n for c in choices(data_op).values() if (n := c.name) is not None]
-    unused = list(set(environment.keys()).difference(var_names + choice_names))
+    unused = list(
+        {k for k in environment.keys() if not k.startswith("_skrub_")}.difference(
+            var_names + choice_names
+        )
+    )
 
     msg = (
-        "- Note that all values are dropped by .skb.make_learner() "
-        "by default\n  and need to be passed explicitly in the environment.\n"
-        f"  (You can use skrub.var({missing_name!r}, value=..., becomes_default=True)\n"
-        "  to always retain the passed value as a default.)"
+        "- Note that preview values passed to initialize skrub variables\n"
+        "  are ignored by default when we pass an explicit 'environment' dictionary,\n"
+        "  for example when calling SkrubLearner.fit({'X': ..., 'y': ...}).\n"
+        f"  Please pass a value for {missing_name!r} in the environment.\n"
+        "  You can also use "
+        f"skrub.var({missing_name!r}, value=..., becomes_default=True)\n"
+        "  to always retain the initialization value as a default."
     )
     if unused:
         msg += (
@@ -698,6 +711,12 @@ def graph(data_op):
 
 def nodes(data_op):
     return list(graph(data_op)["nodes"].values())
+
+
+def named_nodes(data_op):
+    return {
+        name: op for op in nodes(data_op) if (name := op._skrub_impl.name) is not None
+    }
 
 
 def clear_results(data_op, mode=None):

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -1982,7 +1982,9 @@ class SkrubNamespace:
         if not fitted:
             return learner
         return learner.fit(
-            env_with_subsampling(self._data_op, self.get_data(), keep_subsampling)
+            env_with_subsampling(
+                self._data_op, self._env_or_preview_data(None), keep_subsampling
+            )
         )
 
     @_check_before
@@ -2300,7 +2302,9 @@ class SkrubNamespace:
         if not fitted:
             return search
         return search.fit(
-            env_with_subsampling(self._data_op, self.get_data(), keep_subsampling)
+            env_with_subsampling(
+                self._data_op, self._env_or_preview_data(None), keep_subsampling
+            )
         )
 
     @_check_before
@@ -2587,7 +2591,9 @@ class SkrubNamespace:
         if not fitted:
             return search
         return search.fit(
-            env_with_subsampling(self._data_op, self.get_data(), keep_subsampling)
+            env_with_subsampling(
+                self._data_op, self._env_or_preview_data(None), keep_subsampling
+            )
         )
 
     @_check_before

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -144,7 +144,7 @@ class SkrubNamespace:
     def __init__(self, data_op):
         self._data_op = data_op
 
-    def _env_or_preview_data(self, environment):
+    def _get_env(self, environment=None):
         if environment is not None:
             return environment
         return self.get_data() | {IS_PREVIEW_DATA_ENV_NAME: True}
@@ -1127,7 +1127,7 @@ class SkrubNamespace:
                 f"got: '{type(environment)}'"
             )
         if environment is None:
-            environment = self._env_or_preview_data(None)
+            environment = self._get_env()
         else:
             environment = {
                 **environment,
@@ -1982,9 +1982,7 @@ class SkrubNamespace:
         if not fitted:
             return learner
         return learner.fit(
-            env_with_subsampling(
-                self._data_op, self._env_or_preview_data(None), keep_subsampling
-            )
+            env_with_subsampling(self._data_op, self._get_env(), keep_subsampling)
         )
 
     @_check_before
@@ -2115,7 +2113,7 @@ class SkrubNamespace:
                 category=FutureWarning,
             )
             split_func = splitter
-        environment = self._env_or_preview_data(environment)
+        environment = self._get_env(environment)
         return train_test_split(
             self._data_op,
             environment,
@@ -2188,7 +2186,7 @@ class SkrubNamespace:
         >>> accuracies
         [1.0, 0.0, 1.0]
         """
-        environment = self._env_or_preview_data(environment)
+        environment = self._get_env(environment)
         yield from iter_cv_splits(
             self._data_op, environment, keep_subsampling=keep_subsampling, cv=cv
         )
@@ -2302,9 +2300,7 @@ class SkrubNamespace:
         if not fitted:
             return search
         return search.fit(
-            env_with_subsampling(
-                self._data_op, self._env_or_preview_data(None), keep_subsampling
-            )
+            env_with_subsampling(self._data_op, self._get_env(), keep_subsampling)
         )
 
     @_check_before
@@ -2591,9 +2587,7 @@ class SkrubNamespace:
         if not fitted:
             return search
         return search.fit(
-            env_with_subsampling(
-                self._data_op, self._env_or_preview_data(None), keep_subsampling
-            )
+            env_with_subsampling(self._data_op, self._get_env(), keep_subsampling)
         )
 
     @_check_before
@@ -2814,7 +2808,7 @@ class SkrubNamespace:
         4    0.90
         Name: test_score, dtype: float64
         """
-        environment = self._env_or_preview_data(environment)
+        environment = self._get_env(environment)
 
         return cross_validate(
             self.make_learner(),

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -1489,12 +1489,12 @@ class SkrubNamespace:
         """
         from ._data_ops import Var
 
-        all_named_nodes = named_nodes(self._data_op)
+        found_nodes = named_nodes(self._data_op)
         if all_named_ops:
-            return all_named_nodes
+            return found_nodes
         return {
             name: op
-            for name, op in all_named_nodes.items()
+            for name, op in found_nodes.items()
             if isinstance(op._skrub_impl, Var)
         }
 

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -42,6 +42,7 @@ from ._evaluation import (
     find_node_by_name,
     find_node_by_uuid,
     find_X_y_and_cv,
+    named_nodes,
     nodes,
 )
 from ._inspection import (
@@ -51,7 +52,7 @@ from ._inspection import (
 )
 from ._optuna import OptunaParamSearch
 from ._subsampling import SubsamplePreviews, env_with_subsampling
-from ._utils import NULL, attribute_error
+from ._utils import IS_PREVIEW_DATA_ENV_NAME, NULL, attribute_error
 
 # By default, select all columns
 _SELECT_ALL_COLUMNS = s.all()
@@ -142,6 +143,11 @@ class SkrubNamespace:
 
     def __init__(self, data_op):
         self._data_op = data_op
+
+    def _env_or_preview_data(self, environment):
+        if environment is not None:
+            return environment
+        return self.get_data() | {IS_PREVIEW_DATA_ENV_NAME: True}
 
     def _apply(
         self,
@@ -1121,7 +1127,7 @@ class SkrubNamespace:
                 f"got: '{type(environment)}'"
             )
         if environment is None:
-            environment = self.get_data()
+            environment = self._env_or_preview_data(None)
         else:
             environment = {
                 **environment,
@@ -1482,18 +1488,13 @@ class SkrubNamespace:
         SkrubLearner(data_op=<BinOp: add>)
         """
         from ._data_ops import Var
-        from ._evaluation import nodes
 
-        named_nodes = {
-            name: op
-            for op in nodes(self._data_op)
-            if (name := op._skrub_impl.name) is not None
-        }
+        all_named_nodes = named_nodes(self._data_op)
         if all_named_ops:
-            return named_nodes
+            return all_named_nodes
         return {
             name: op
-            for name, op in named_nodes.items()
+            for name, op in all_named_nodes.items()
             if isinstance(op._skrub_impl, Var)
         }
 
@@ -2112,8 +2113,7 @@ class SkrubNamespace:
                 category=FutureWarning,
             )
             split_func = splitter
-        if environment is None:
-            environment = self.get_data()
+        environment = self._env_or_preview_data(environment)
         return train_test_split(
             self._data_op,
             environment,
@@ -2186,8 +2186,7 @@ class SkrubNamespace:
         >>> accuracies
         [1.0, 0.0, 1.0]
         """
-        if environment is None:
-            environment = self.get_data()
+        environment = self._env_or_preview_data(environment)
         yield from iter_cv_splits(
             self._data_op, environment, keep_subsampling=keep_subsampling, cv=cv
         )
@@ -2809,8 +2808,7 @@ class SkrubNamespace:
         4    0.90
         Name: test_score, dtype: float64
         """
-        if environment is None:
-            environment = self.get_data()
+        environment = self._env_or_preview_data(environment)
 
         return cross_validate(
             self.make_learner(),

--- a/skrub/_data_ops/_utils.py
+++ b/skrub/_data_ops/_utils.py
@@ -12,6 +12,7 @@ FITTED_PREDICTOR_METHODS = ("predict", "predict_proba", "decision_function", "sc
 FITTED_ESTIMATOR_METHODS = FITTED_PREDICTOR_METHODS + ("transform",)
 X_NAME = "_skrub_X"
 Y_NAME = "_skrub_y"
+IS_PREVIEW_DATA_ENV_NAME = "_skrub_is_preview_data_env"
 
 
 class Sentinels(enum.Enum):

--- a/skrub/_data_ops/tests/test_errors.py
+++ b/skrub/_data_ops/tests/test_errors.py
@@ -662,6 +662,8 @@ def test_missing_var_message():
     )
     assert "skrub.var('a', value=..., becomes_default=True)" in full_msg
 
+    # Test case were we do use the preview values (no environment is passed)
+
     with pytest.raises(KeyError) as exc:
         (data_op + skrub.var("d")).skb.make_learner(fitted=True)
 
@@ -684,6 +686,8 @@ def test_missing_var_message_train_test_split():
     with pytest.raises(KeyError) as exc:
         X.skb.train_test_split()
     full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))
+    print(full_msg)
+    assert "No value has been provided for 'a'" in full_msg
     assert (
         "ignored by default whenever we pass an explicit 'environment' dictionary"
         not in full_msg

--- a/skrub/_data_ops/tests/test_errors.py
+++ b/skrub/_data_ops/tests/test_errors.py
@@ -645,15 +645,46 @@ def test_mark_as_X_missing_cv():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="no add_note")
 def test_missing_var_message():
-    learner = (
+    data_op = (
         skrub.var("a", "a value")
         + skrub.var("var_b_name", "b value", becomes_default=True)
         + skrub.choose_from(["?", "!"], name="c")
-    ).skb.make_learner()
+    )
+    learner = data_op.skb.make_learner()
     with pytest.raises(KeyError) as exc:
         learner.fit({"bad_key": "another value"})
     full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))
     assert "bad_key" in full_msg
     assert "var_b_name" not in full_msg
-    assert "all values are dropped" in full_msg
+    assert (
+        "ignored by default whenever we pass an explicit 'environment' dictionary"
+        in full_msg
+    )
     assert "skrub.var('a', value=..., becomes_default=True)" in full_msg
+
+    with pytest.raises(KeyError) as exc:
+        (data_op + skrub.var("d")).skb.make_learner(fitted=True)
+
+    full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))
+    assert (
+        "ignored by default whenever we pass an explicit 'environment' dictionary"
+        not in full_msg
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="no add_note")
+def test_missing_var_message_train_test_split():
+    X = (skrub.var("x", np.arange(20)) + skrub.var("a")).skb.mark_as_X() + skrub.var(
+        "b"
+    )
+    # 'z' is extra but not 'b', even though 'b' is not needed for collecting X
+    # it still exists in the DataOp as a whole.
+    with pytest.raises(KeyError, match=r"\['z'\]"):
+        X.skb.train_test_split({"z": 0, "b": 1})
+    with pytest.raises(KeyError) as exc:
+        X.skb.train_test_split()
+    full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))
+    assert (
+        "ignored by default whenever we pass an explicit 'environment' dictionary"
+        not in full_msg
+    )

--- a/skrub/_data_ops/tests/test_errors.py
+++ b/skrub/_data_ops/tests/test_errors.py
@@ -1,5 +1,6 @@
 import pickle
 import re
+import sys
 import traceback
 
 import numpy as np
@@ -640,3 +641,19 @@ def test_unhashable():
 def test_mark_as_X_missing_cv():
     with pytest.raises(TypeError, match=".*you must also provide a splitter"):
         skrub.var("a").skb.mark_as_X(split_kwargs={"groups": None})
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="no add_note")
+def test_missing_var_message():
+    learner = (
+        skrub.var("a", "a value")
+        + skrub.var("var_b_name", "b value", becomes_default=True)
+        + skrub.choose_from(["?", "!"], name="c")
+    ).skb.make_learner()
+    with pytest.raises(KeyError) as exc:
+        learner.fit({"bad_key": "another value"})
+    full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))
+    assert "bad_key" in full_msg
+    assert "var_b_name" not in full_msg
+    assert "all values are dropped" in full_msg
+    assert "skrub.var('a', value=..., becomes_default=True)" in full_msg

--- a/skrub/_data_ops/tests/test_errors.py
+++ b/skrub/_data_ops/tests/test_errors.py
@@ -676,13 +676,16 @@ def test_missing_var_message():
 
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="no add_note")
 def test_missing_var_message_train_test_split():
-    X = (skrub.var("x", np.arange(20)) + skrub.var("a")).skb.mark_as_X() + skrub.var(
-        "b"
-    )
+    b = skrub.var("b")
+    X = (skrub.var("x", np.arange(20)) + skrub.var("a")).skb.mark_as_X() + b
     # 'z' is extra but not 'b', even though 'b' is not needed for collecting X
     # it still exists in the DataOp as a whole.
     with pytest.raises(KeyError, match=r"\['z'\]"):
         X.skb.train_test_split({"z": 0, "b": 1})
+    # check that we still get the correct error when the env contains int (ID)
+    # keys
+    with pytest.raises(KeyError, match=r"\['z'\]") as exc:
+        X.skb.train_test_split({"z": 0, b.skb.id: 1})
     with pytest.raises(KeyError) as exc:
         X.skb.train_test_split()
     full_msg = "\n".join(traceback.format_exception(exc.value, exc.value, exc.tb))

--- a/skrub/_data_ops/tests/test_estimators.py
+++ b/skrub/_data_ops/tests/test_estimators.py
@@ -908,8 +908,14 @@ def test_train_test_split(with_y):
                 "n": 8,
                 "_skrub_X": [0, 1, 2, 3, 4, 5],
                 "_skrub_y": [8, 9, 10, 11, 12, 13],
+                "_skrub_is_preview_data_env": True,
             },
-            "test": {"n": 8, "_skrub_X": [6, 7], "_skrub_y": [14, 15]},
+            "test": {
+                "n": 8,
+                "_skrub_X": [6, 7],
+                "_skrub_y": [14, 15],
+                "_skrub_is_preview_data_env": True,
+            },
             "X_train": [0, 1, 2, 3, 4, 5],
             "X_test": [6, 7],
             "y_train": [8, 9, 10, 11, 12, 13],
@@ -917,8 +923,16 @@ def test_train_test_split(with_y):
         }
     else:
         assert split == {
-            "train": {"n": 8, "_skrub_X": [0, 1, 2, 3, 4, 5]},
-            "test": {"n": 8, "_skrub_X": [6, 7]},
+            "train": {
+                "n": 8,
+                "_skrub_X": [0, 1, 2, 3, 4, 5],
+                "_skrub_is_preview_data_env": True,
+            },
+            "test": {
+                "n": 8,
+                "_skrub_X": [6, 7],
+                "_skrub_is_preview_data_env": True,
+            },
             "X_train": [0, 1, 2, 3, 4, 5],
             "X_test": [6, 7],
         }


### PR DESCRIPTION
closes #2210 

```python
import skrub

data_path = skrub.var("data_path", value="data")
learner = data_path.skb.make_learner()
learner.fit({"data_dir": "data"})
```

```
skrub._data_ops._data_ops.UninitializedVariable: No value has been provided for 'data_path'
Evaluation of node <Var 'data_path'> failed. See above for full traceback. This node was defined here:
      File "/home/jerome/workspace/scratch/2026/07/scratch.py", line 14, in <module>
        data_path = skrub.var("data_path", value="data")
- Note that preview values passed to initialize skrub variables
  are ignored by default when we pass an explicit 'environment' dictionary,
  for example when calling SkrubLearner.fit({'X': ..., 'y': ...}).
  Please pass a value for 'data_path' in the environment.
  You can also use skrub.var('data_path', value=..., becomes_default=True)
  to always retain the initialization value as a default.
- WARNING: the following keys were passed in the environment but have no corresponding variable in the DataOp:
  ['data_dir']
```