### PR TITLE
DOC simplify ToFloat import example

### DIFF
--- a/skrub/_to_float.py
+++ b/skrub/_to_float.py
@@ -77,7 +77,7 @@ class ToFloat(SingleColumnTransformer):
     Examples
     --------
     >>> import pandas as pd
-    >>> from skrub._to_float import ToFloat
+    >>> from skrub import ToFloat
 
     A column that does not contain floats is converted if possible:
 


### PR DESCRIPTION
Fixes #2130.

This updates the ToFloat docstring example to import ToFloat from the public skrub API instead of the private skrub._to_float module.