### PR TITLE
split returned by .skb.train_test_split: return last by default + allow choosing the split

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,12 +13,28 @@ Release 0.10.0
 New Features
 ------------
 
-
 Changes
 -------
 - The error message when a key is missing from the environment passed to a
   :class:`DataOp` or :class:`SkrubLearner` has been improved.
   :pr:`2211` by :user:`Jérôme Dockès <jeromedockes>`.
+- When a cross-validation splitter has been passed to
+  :meth:`DataOp.skb.mark_as_X`, it it now possible to select a specific split
+  from it when calling :meth:`DataOp.skb.train_test_split` by passing
+  ``split_index``; for example ``data_op.skb.train_test_split(split_index=3)``
+  to get the third split.
+
+  The split that is returned by default when ``split_index`` is not specified is
+  now the *last* split produced by the splitter (it was the first before).
+
+  Moreover, the keys ``row_indices_train`` and ``row_indices_test`` are added to
+  the returned dictionary when using the ``mark_as_X`` splitter. And the keys
+  ``X`` (and ``y`` when it exists) are added to the dictionaries returned by
+  :meth:`DataOp.skb.train_test_split` and :meth:`DataOp.skb.iter_cv_splits`,
+  containing the full X and y before splitting.
+
+  :pr:`2213` by :user:`Jérôme Dockès <jeromedockes>`.
+
 
 Bugfixes
 --------

--- a/doc/modules/data_ops/validation/tuning_validating_data_ops.rst
+++ b/doc/modules/data_ops/validation/tuning_validating_data_ops.rst
@@ -107,7 +107,7 @@ scikit-learn's :func:`sklearn.model_selection.train_test_split`).
 
 >>> split = pred.skb.train_test_split(shuffle=False)
 >>> split.keys()
-dict_keys(['train', 'test', 'X_train', 'X_test', 'y_train', 'y_test'])
+dict_keys(['X_train', 'X_test', 'y_train', 'y_test', 'train', 'test', 'X', 'y'])
 
 ``train`` and ``test`` are the full dictionaries corresponding to the training
 and testing data. The corresponding ``X`` and ``y`` are the values, in those
@@ -181,18 +181,18 @@ cross-validation we must group products by seller. We do it with
 The train set only contains data from the "supermarket.com" seller.
 
 >>> split["X_train"]
-   description  price
-0       screen    100
-2     keyboard     20
-5  screwdriver     12
-
-The test set only contains data from the "bestproducts.com" seller.
-
->>> split["X_test"]
   description  price
 1      hammer     15
 3     usb key      9
 4     charger     13
+
+The test set only contains data from the "bestproducts.com" seller.
+
+>>> split["X_test"]
+   description  price
+0       screen    100
+2     keyboard     20
+5  screwdriver     12
 
 Passing additional arguments to the scorer
 ==========================================

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1,5 +1,6 @@
 # Scikit-learn-ish interface to the skrub DataOps
 import copy
+import itertools
 import numbers
 from functools import partial
 
@@ -1027,15 +1028,27 @@ class _Splitter:
         del groups
         return self.splitter.get_n_splits(X, y, **self.split_kwargs)
 
-    def __call__(self, X, y=None):
-        # Can be used as a callable to get a single train/test split (the first
-        # CV split)
-        train, test = next(iter(self.split(X, y)))
-        X_train, X_test = _safe_indexing(X, train), _safe_indexing(X, test)
+    def get_single_split(self, X, y=None, split_index=-1):
+        if not isinstance(split_index, numbers.Integral):
+            raise TypeError(f"split_index should be an int, got: {split_index!r}")
+        raw_split_index = split_index
+        n_splits = self.get_n_splits(X, y)
+        if split_index < 0:
+            split_index = n_splits + split_index
+        if not 0 <= split_index < n_splits:
+            raise IndexError(
+                f"split_index {raw_split_index} out of range for splitter "
+                f"{self.splitter} with {n_splits} splits."
+            )
+        train, test = next(itertools.islice(self.split(X, y), split_index, None))
+        result = {"row_indices_train": train, "row_indices_test": test}
+        result["X_train"] = _safe_indexing(X, train)
+        result["X_test"] = _safe_indexing(X, test)
         if y is None:
-            return X_train, X_test
-        y_train, y_test = _safe_indexing(y, train), _safe_indexing(y, test)
-        return X_train, X_test, y_train, y_test
+            return result
+        result["y_train"] = _safe_indexing(y, train)
+        result["y_test"] = _safe_indexing(y, test)
+        return result
 
 
 def _compute_cv_data(data_op, environment, cv):
@@ -1049,24 +1062,6 @@ def _compute_cv_data(data_op, environment, cv):
             _Splitter(check_cv(data["cv"]), data["split_kwargs"]),
         )
     return data["X"], data["y"], None
-
-
-def _compute_train_test_split_data(data_op, environment, split_func, split_func_kwargs):
-    data = _compute_X_y_and_cv(data_op, environment)
-    if split_func is not None:
-        return data["X"], data["y"], split_func, split_func_kwargs
-    if "cv" in data:
-        return (
-            data["X"],
-            data["y"],
-            _Splitter(check_cv(data["cv"]), data["split_kwargs"]),
-            {},
-        )
-    # kwargs fall through to the default split_func when no splitter is set and
-    # no split_func is passed. This allows something like
-    # data_op.skb.train_test_split(shuffle=False), without having to import &
-    # pass sklearn.model_selection.train_test_split explicitly.
-    return data["X"], data["y"], model_selection.train_test_split, split_func_kwargs
 
 
 def _rename_cv_param_learner_to_estimator(kwargs):
@@ -1199,27 +1194,41 @@ def train_test_split(
     details and examples.
     """
     environment = env_with_subsampling(data_op, environment, keep_subsampling)
-    X, y, split_func, split_func_kwargs = _compute_train_test_split_data(
-        data_op, environment, split_func, split_func_kwargs
-    )
-    if y is None:
-        X_train, X_test = split_func(X, **split_func_kwargs)
+    data = _compute_X_y_and_cv(data_op, environment)
+    X, y = data["X"], data["y"]
+    if split_func is None and "cv" in data:
+        extra_kwargs = set(split_func_kwargs).difference({"split_index"})
+        if extra_kwargs:
+            raise ValueError(
+                "When using the splitter passed to .skb.mark_as_X(),\n"
+                "the only split_func_kwarg accepted "
+                "by .skb.train_test_split() is 'split_index'.\n"
+                f"The splitter passed to .skb.mark_as_X() was:\n{data['cv']}\n"
+                f"Got extra kwargs: {list(extra_kwargs)}."
+            )
+        splitter = _Splitter(check_cv(data["cv"]), data["split_kwargs"])
+        split = splitter.get_single_split(X, y, **split_func_kwargs)
     else:
-        X_train, X_test, y_train, y_test = split_func(X, y, **split_func_kwargs)
-    train_env = {**environment, X_NAME: X_train}
-    test_env = {**environment, X_NAME: X_test}
-    result = {
-        "train": train_env,
-        "test": test_env,
-        "X_train": X_train,
-        "X_test": X_test,
-    }
+        split_func = (
+            model_selection.train_test_split if split_func is None else split_func
+        )
+        if y is None:
+            split = dict(zip(("X_train", "X_test"), split_func(X, **split_func_kwargs)))
+        else:
+            split = dict(
+                zip(
+                    ("X_train", "X_test", "y_train", "y_test"),
+                    split_func(X, y, **split_func_kwargs),
+                )
+            )
+    split["train"] = {**environment, X_NAME: split["X_train"]}
+    split["test"] = {**environment, X_NAME: split["X_test"]}
+    split["X"] = X
     if y is not None:
-        train_env[Y_NAME] = y_train
-        test_env[Y_NAME] = y_test
-        result["y_train"] = y_train
-        result["y_test"] = y_test
-    return result
+        split["train"][Y_NAME] = split["y_train"]
+        split["test"][Y_NAME] = split["y_test"]
+        split["y"] = y
+    return split
 
 
 def iter_cv_splits(data_op, environment, *, keep_subsampling=False, cv=None):
@@ -1239,6 +1248,7 @@ def iter_cv_splits(data_op, environment, *, keep_subsampling=False, cv=None):
         split_info = {
             "train": train_env,
             "test": test_env,
+            "X": X,
             "X_train": X_train,
             "X_test": X_test,
             "row_indices_train": train_idx,
@@ -1251,6 +1261,7 @@ def iter_cv_splits(data_op, environment, *, keep_subsampling=False, cv=None):
             )
             train_env[Y_NAME] = y_train
             test_env[Y_NAME] = y_test
+            split_info["y"] = y
             split_info["y_train"] = y_train
             split_info["y_test"] = y_test
         yield split_info

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1242,7 +1242,7 @@ def iter_cv_splits(data_op, environment, *, keep_subsampling=False, cv=None):
     X, y, splitter = _compute_cv_data(data_op, environment, cv)
     cv = check_cv(splitter)
     for train_idx, test_idx in cv.split(X, y):
-        X_train, X_test = sbd.select_rows(X, train_idx), sbd.select_rows(X, test_idx)
+        X_train, X_test = _safe_indexing(X, train_idx), _safe_indexing(X, test_idx)
         train_env = {**environment, X_NAME: X_train}
         test_env = {**environment, X_NAME: X_test}
         split_info = {

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -15,7 +15,6 @@ from sklearn.model_selection import check_cv
 from sklearn.utils.fixes import parse_version
 from sklearn.utils.validation import check_is_fitted
 
-from .. import _dataframe as sbd
 from .. import _join_utils
 from .._base import SkrubBaseEstimator
 from .._sklearn_compat import _safe_indexing, _VisualBlock
@@ -1031,24 +1030,15 @@ class _Splitter:
     def get_single_split(self, X, y=None, split_index=-1):
         if not isinstance(split_index, numbers.Integral):
             raise TypeError(f"split_index should be an int, got: {split_index!r}")
-        raw_split_index = split_index
         n_splits = self.get_n_splits(X, y)
-        if split_index < 0:
-            split_index = n_splits + split_index
-        if not 0 <= split_index < n_splits:
+        if not -n_splits <= split_index < n_splits:
             raise IndexError(
-                f"split_index {raw_split_index} out of range for splitter "
+                f"split_index {split_index} out of range for splitter "
                 f"{self.splitter} with {n_splits} splits."
             )
-        train, test = next(itertools.islice(self.split(X, y), split_index, None))
-        result = {"row_indices_train": train, "row_indices_test": test}
-        result["X_train"] = _safe_indexing(X, train)
-        result["X_test"] = _safe_indexing(X, test)
-        if y is None:
-            return result
-        result["y_train"] = _safe_indexing(y, train)
-        result["y_test"] = _safe_indexing(y, test)
-        return result
+        if split_index < 0:
+            split_index = n_splits + split_index
+        return next(itertools.islice(self.split(X, y), split_index, None))
 
 
 def _compute_cv_data(data_op, environment, cv):
@@ -1179,6 +1169,32 @@ def cross_validate(learner, environment, *, keep_subsampling=False, cv=None, **k
     return pd.DataFrame(result)
 
 
+def _build_split_dict(environment, X, y, train_idx, test_idx):
+    X_train, X_test = _safe_indexing(X, train_idx), _safe_indexing(X, test_idx)
+    train_env = {**environment, X_NAME: X_train}
+    test_env = {**environment, X_NAME: X_test}
+    split_info = {
+        "train": train_env,
+        "test": test_env,
+        "X": X,
+        "X_train": X_train,
+        "X_test": X_test,
+        "row_indices_train": train_idx,
+        "row_indices_test": test_idx,
+    }
+    if y is not None:
+        y_train, y_test = (
+            _safe_indexing(y, train_idx),
+            _safe_indexing(y, test_idx),
+        )
+        train_env[Y_NAME] = y_train
+        test_env[Y_NAME] = y_test
+        split_info["y"] = y
+        split_info["y_train"] = y_train
+        split_info["y_test"] = y_test
+    return split_info
+
+
 def train_test_split(
     data_op,
     environment,
@@ -1207,20 +1223,19 @@ def train_test_split(
                 f"Got extra kwargs: {list(extra_kwargs)}."
             )
         splitter = _Splitter(check_cv(data["cv"]), data["split_kwargs"])
-        split = splitter.get_single_split(X, y, **split_func_kwargs)
+        train_idx, test_idx = splitter.get_single_split(X, y, **split_func_kwargs)
+        return _build_split_dict(environment, X, y, train_idx, test_idx)
+
+    split_func = model_selection.train_test_split if split_func is None else split_func
+    if y is None:
+        split = dict(zip(("X_train", "X_test"), split_func(X, **split_func_kwargs)))
     else:
-        split_func = (
-            model_selection.train_test_split if split_func is None else split_func
-        )
-        if y is None:
-            split = dict(zip(("X_train", "X_test"), split_func(X, **split_func_kwargs)))
-        else:
-            split = dict(
-                zip(
-                    ("X_train", "X_test", "y_train", "y_test"),
-                    split_func(X, y, **split_func_kwargs),
-                )
+        split = dict(
+            zip(
+                ("X_train", "X_test", "y_train", "y_test"),
+                split_func(X, y, **split_func_kwargs),
             )
+        )
     split["train"] = {**environment, X_NAME: split["X_train"]}
     split["test"] = {**environment, X_NAME: split["X_test"]}
     split["X"] = X
@@ -1242,29 +1257,7 @@ def iter_cv_splits(data_op, environment, *, keep_subsampling=False, cv=None):
     X, y, splitter = _compute_cv_data(data_op, environment, cv)
     cv = check_cv(splitter)
     for train_idx, test_idx in cv.split(X, y):
-        X_train, X_test = _safe_indexing(X, train_idx), _safe_indexing(X, test_idx)
-        train_env = {**environment, X_NAME: X_train}
-        test_env = {**environment, X_NAME: X_test}
-        split_info = {
-            "train": train_env,
-            "test": test_env,
-            "X": X,
-            "X_train": X_train,
-            "X_test": X_test,
-            "row_indices_train": train_idx,
-            "row_indices_test": test_idx,
-        }
-        if y is not None:
-            y_train, y_test = (
-                sbd.select_rows(y, train_idx),
-                sbd.select_rows(y, test_idx),
-            )
-            train_env[Y_NAME] = y_train
-            test_env[Y_NAME] = y_test
-            split_info["y"] = y
-            split_info["y_train"] = y_train
-            split_info["y_test"] = y_test
-        yield split_info
+        yield _build_split_dict(environment, X, y, train_idx, test_idx)
 
 
 class _BaseParamSearch(_DataOpWrapperMixin, SkrubBaseEstimator):

--- a/skrub/_data_ops/_estimator.py
+++ b/skrub/_data_ops/_estimator.py
@@ -1038,6 +1038,10 @@ class _Splitter:
             )
         if split_index < 0:
             split_index = n_splits + split_index
+        # Get the (train_idx, test_idx) pair at position split_index without
+        # materializing the sequence in memory. islice() iterates over all
+        # items starting from split_index and next() gets the first item from
+        # that.
         return next(itertools.islice(self.split(X, y), split_index, None))
 
 

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2009,11 +2009,24 @@ class SkrubNamespace:
             default subsampling is not applied and all the data is used.
 
         split_func : function, optional, default=None
-            The function used to split X and y once they have been computed. By
-            default, :func:`~sklearn.model_selection.train_test_split` is used.
+            The function used to split X and y once they have been computed. If
+            ``split_func`` is not provided,
+
+            - If a cross-validation splitter has been set with
+              :meth:`DataOp.skb.mark_as_X`, that splitter is used.
+              In this case the only accepted kwarg in ``split_func_kwargs`` is
+              ``'split_index'``, which indicates which split to use. By default
+              ``'split_index'`` is -1, i.e. the last split is used.
+            - Otherwise :func:`~sklearn.model_selection.train_test_split` is
+              used (and ``split_func_kwargs`` are forwarded to it).
 
         split_func_kwargs
-            Additional named arguments to pass to the splitting function.
+            Additional named arguments to pass to the splitting function. When
+            relying on the splitter passed to :meth:`DataOp.skb.mark_as_X`,
+            the only accepted kwarg is ``'split_index'`` which indicates which
+            split to use.
+            Kwargs for the ``split()`` method itself should be passed to
+            ``mark_as_X``.
 
         Returns
         -------
@@ -2023,6 +2036,12 @@ class SkrubNamespace:
 
             - train: a dictionary containing the training environment
             - test: a dictionary containing the test environment
+            - X: the value of the variable marked with
+              :meth:`~DataOp.skb.mark_as_X()` in ``environment``, before splitting.
+            - y: the value of the variable marked with
+              :meth:`~DataOp.skb.mark_as_y()` in ``environment``, before
+              splitting, if there is one (may not be the case for unsupervised
+              learning).
             - X_train: the value of the variable marked with
               :func:`~DataOp.skb.mark_as_X()` in the train environment
             - X_test: the value of the variable marked with
@@ -2035,6 +2054,13 @@ class SkrubNamespace:
               :func:`~DataOp.skb.mark_as_y()` in
               the test environment, if there is one (may not be the case for
               unsupervised learning).
+
+            If relying on the splitter passed to :meth:`DataOp.skb.mark_as_X`,
+            the following keys are added:
+
+            - row_indices_train: the row indices (in X and y) of the training samples.
+            - row_indices_test: the row indices (in X and y) of the testing samples.
+
 
         See Also
         --------
@@ -2070,7 +2096,7 @@ class SkrubNamespace:
 
         >>> split = delayed.skb.train_test_split(random_state=0, test_size=0.2)
         >>> split.keys()
-        dict_keys(['train', 'test', 'X_train', 'X_test', 'y_train', 'y_test'])
+        dict_keys(['X_train', 'X_test', 'y_train', 'y_test', 'train', 'test', 'X', 'y'])
         >>> learner = delayed.skb.make_learner()
         >>> learner.fit(split["train"])
         SkrubLearner(data_op=<Apply DummyClassifier>)
@@ -2086,11 +2112,9 @@ class SkrubNamespace:
         0.0
 
         If :func:`~skrub.DataOp.skb.mark_as_X` was defined to use a specific
-        splitting function, the splitter will be used by ``train_test_split``.
-
-        Note that if a ``cv`` is passed to ``train_test_split``, the splitter
-        defined in ``mark_as_X`` is ignored, and the one passed to ``train_test_split``
-        is used instead.
+        cross-validation splitter, that splitter will be used by ``train_test_split``,
+        which will return a split produced by the splitter. By default it is
+        the last; that can be controlled by passing ``split_index``.
 
         >>> from sklearn.model_selection import LeaveOneOut
         >>> X = orders.skb.drop("delayed").skb.mark_as_X(cv=LeaveOneOut())
@@ -2100,8 +2124,17 @@ class SkrubNamespace:
         ... )
         >>> split = delayed.skb.train_test_split()
         >>> split["y_test"]
-        0    False
+        3    False
         Name: delayed, dtype: bool
+
+        >>> split = delayed.skb.train_test_split(split_index=2)
+        >>> split["y_test"]
+        2    True
+        Name: delayed, dtype: bool
+
+        Note that if a ``split_func`` is passed to ``train_test_split``, it
+        overrides ``mark_as_X``: the splitter defined in ``mark_as_X`` is
+        ignored, and the function passed to ``train_test_split`` is used instead.
         """
         if (splitter := split_func_kwargs.pop("splitter", None)) is not None:
             warnings.warn(
@@ -2150,6 +2183,12 @@ class SkrubNamespace:
 
             - train: a dictionary containing the training environment
             - test: a dictionary containing the test environment
+            - X: the value of the variable marked with
+              :meth:`~DataOp.skb.mark_as_X()` in ``environment``, before splitting.
+            - y: the value of the variable marked with
+              :meth:`~DataOp.skb.mark_as_y()` in ``environment``, before
+              splitting, if there is one (may not be the case for unsupervised
+              learning).
             - X_train: the value of the variable marked with
               :func:`~DataOp.skb.mark_as_X()` in the train environment
             - X_test: the value of the variable marked with
@@ -2956,21 +2995,21 @@ class SkrubNamespace:
         >>> pred = X.skb.apply(DummyClassifier(), y=y)
         >>> split = pred.skb.train_test_split()
 
-        The train set only contains data from the "supermarket.com" seller.
+        The train set only contains data from the "bestproducts.com" seller.
 
         >>> split["X_train"]
-           description  price
-        0       screen    100
-        2     keyboard     20
-        5  screwdriver     12
-
-        The test set only contains data from the "bestproducts.com" seller.
-
-        >>> split["X_test"]
           description  price
         1      hammer     15
         3     usb key      9
         4     charger     13
+
+        The test set only contains data from the "supermarket.com" seller.
+
+        >>> split["X_test"]
+           description  price
+        0       screen    100
+        2     keyboard     20
+        5  screwdriver     12
         """
         if cv is None:
             if split_kwargs is not None:

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2013,16 +2013,16 @@ class SkrubNamespace:
             ``split_func`` is not provided,
 
             - If a cross-validation splitter has been set with
-              :meth:`DataOp.skb.mark_as_X`, that splitter is used.
+              :meth:`~DataOp.skb.mark_as_X`, that splitter is used.
               In this case the only accepted kwarg in ``split_func_kwargs`` is
               ``'split_index'``, which indicates which split to use. By default
               ``'split_index'`` is -1, i.e. the last split is used.
-            - Otherwise :func:`~sklearn.model_selection.train_test_split` is
+            - Otherwise :func:`sklearn.model_selection.train_test_split` is
               used (and ``split_func_kwargs`` are forwarded to it).
 
         split_func_kwargs
             Additional named arguments to pass to the splitting function. When
-            relying on the splitter passed to :meth:`DataOp.skb.mark_as_X`,
+            relying on the splitter passed to :meth:`~DataOp.skb.mark_as_X`,
             the only accepted kwarg is ``'split_index'`` which indicates which
             split to use.
             Kwargs for the ``split()`` method itself should be passed to
@@ -2055,7 +2055,7 @@ class SkrubNamespace:
               the test environment, if there is one (may not be the case for
               unsupervised learning).
 
-            If relying on the splitter passed to :meth:`DataOp.skb.mark_as_X`,
+            If relying on the splitter passed to :meth:`~DataOp.skb.mark_as_X`,
             the following keys are added:
 
             - row_indices_train: the row indices (in X and y) of the training samples.

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2019,7 +2019,7 @@ class SkrubNamespace:
               ``'split_index'`` is -1, i.e. the last split is used.
 
               Note: the default split is the last one because when using a
-              time series splitter it typically is the one that uses the most data; 
+              time series splitter it typically is the one that uses the most data;
               this is particularly important if the train part will be further
               subdivided e.g. for hyperparameter search. (For other splitters
               split ordering is usually arbitrary.)

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2018,9 +2018,9 @@ class SkrubNamespace:
               ``'split_index'``, which indicates which split to use. By default
               ``'split_index'`` is -1, i.e. the last split is used.
 
-              Note: the default is the last one because for time series
-              splitter it typically is the one that uses the most data, which
-              is particularly important if the train part will be further
+              Note: the default split is the last one because when using a
+              time series splitter it typically is the one that uses the most data; 
+              this is particularly important if the train part will be further
               subdivided e.g. for hyperparameter search. (For other splitters
               split ordering is usually arbitrary.)
 

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -2017,6 +2017,13 @@ class SkrubNamespace:
               In this case the only accepted kwarg in ``split_func_kwargs`` is
               ``'split_index'``, which indicates which split to use. By default
               ``'split_index'`` is -1, i.e. the last split is used.
+
+              Note: the default is the last one because for time series
+              splitter it typically is the one that uses the most data, which
+              is particularly important if the train part will be further
+              subdivided e.g. for hyperparameter search. (For other splitters
+              split ordering is usually arbitrary.)
+
             - Otherwise :func:`sklearn.model_selection.train_test_split` is
               used (and ``split_func_kwargs`` are forwarded to it).
 
@@ -2060,6 +2067,10 @@ class SkrubNamespace:
 
             - row_indices_train: the row indices (in X and y) of the training samples.
             - row_indices_test: the row indices (in X and y) of the testing samples.
+
+            Those are not available otherwise, as
+            :func:`sklearn.model_selection.train_test_split` only returns
+            X_train, X_test, etc. data, not the indices.
 
 
         See Also

--- a/skrub/_data_ops/tests/test_estimators.py
+++ b/skrub/_data_ops/tests/test_estimators.py
@@ -30,6 +30,7 @@ from sklearn.model_selection import (
     GridSearchCV,
     KFold,
     LeaveOneGroupOut,
+    TimeSeriesSplit,
     cross_validate,
     train_test_split,
 )
@@ -916,6 +917,8 @@ def test_train_test_split(with_y):
                 "_skrub_y": [14, 15],
                 "_skrub_is_preview_data_env": True,
             },
+            "X": list(range(8)),
+            "y": list(range(8, 16)),
             "X_train": [0, 1, 2, 3, 4, 5],
             "X_test": [6, 7],
             "y_train": [8, 9, 10, 11, 12, 13],
@@ -933,6 +936,7 @@ def test_train_test_split(with_y):
                 "_skrub_X": [6, 7],
                 "_skrub_is_preview_data_env": True,
             },
+            "X": list(range(8)),
             "X_train": [0, 1, 2, 3, 4, 5],
             "X_test": [6, 7],
         }
@@ -941,6 +945,8 @@ def test_train_test_split(with_y):
         assert split == {
             "train": {"n": 4, "_skrub_X": [0, 1, 2], "_skrub_y": [4, 5, 6]},
             "test": {"n": 4, "_skrub_X": [3], "_skrub_y": [7]},
+            "X": list(range(4)),
+            "y": list(range(4, 8)),
             "X_train": [0, 1, 2],
             "X_test": [3],
             "y_train": [4, 5, 6],
@@ -953,6 +959,7 @@ def test_train_test_split(with_y):
         assert split == {
             "train": {"n": 4, "_skrub_X": [0, 1, 2]},
             "test": {"n": 4, "_skrub_X": [3]},
+            "X": list(range(4)),
             "X_train": [0, 1, 2],
             "X_test": [3],
         }
@@ -974,6 +981,89 @@ def test_train_test_split_X_y_aligned():
     data_op = X.skb.apply(Ridge(), y=y)
     split = data_op.skb.train_test_split()
     assert (split["X_train"]["a"].to_numpy() == split["y_train"].to_numpy()).all()
+
+
+@pytest.mark.parametrize("with_y", [False, True])
+def test_train_test_split_split_index(with_y):
+    """
+    train_test_split using the mark_as_X() splitter allows selecting the split
+    index.
+    """
+    X = np.arange(20)[:, None] * 10
+    y = X[:, 0]
+
+    data_op = skrub.var("X", X).skb.mark_as_X(cv=TimeSeriesSplit())
+    if with_y:
+        data_op = data_op.skb.apply(
+            DummyRegressor(), y=skrub.var("y", y).skb.mark_as_y()
+        )
+
+    # by default we get the last split
+    assert list(data_op.skb.train_test_split()["X_test"].ravel()) == [170, 180, 190]
+    # we also get the row indices
+    assert list(data_op.skb.train_test_split()["row_indices_test"]) == [17, 18, 19]
+
+    # we can ask for a specific split.
+    assert list(
+        data_op.skb.train_test_split(split_index=0)["X_test"].ravel(),
+    ) == [50, 60, 70]
+    assert list(
+        data_op.skb.train_test_split(split_index=1)["X_test"].ravel(),
+    ) == [80, 90, 100]
+
+    # we can still override the split function and pass the kwargs our
+    # function expects.
+    assert list(
+        data_op.skb.train_test_split(
+            split_func=train_test_split,
+            test_size=5,
+            shuffle=True,
+            random_state=0,
+        )["X_test"].ravel()
+    ) == [180, 10, 190, 80, 100]
+
+
+def test_train_test_split_bad_kwarg():
+    """
+    Check error message when an unrecognized kwarg is passed to
+    skb.train_test_split() when using the mark_as_X splitter.
+    """
+    X = np.arange(20)[:, None]
+    y = X[:, 0]
+
+    pred = (
+        skrub.var("X", X)
+        .skb.mark_as_X(cv=TimeSeriesSplit())
+        .skb.apply(DummyRegressor(), y=skrub.var("y", y).skb.mark_as_y())
+    )
+    with pytest.raises(
+        ValueError,
+        match=r"(?s).*using the splitter passed to \.skb.mark_as_X\(\)"
+        r".*Got extra kwargs: \['random_state'\]",
+    ):
+        pred.skb.train_test_split(random_state=0)
+
+
+def test_train_test_split_bad_split_index():
+    """
+    Check error message when a bad split_index is passed to
+    skb.train_test_split() when using the mark_as_X splitter.
+    """
+    X = np.arange(20)[:, None]
+    y = X[:, 0]
+
+    pred = (
+        skrub.var("X", X)
+        .skb.mark_as_X(cv=TimeSeriesSplit())
+        .skb.apply(DummyRegressor(), y=skrub.var("y", y).skb.mark_as_y())
+    )
+    with pytest.raises(TypeError, match="split_index should be an int"):
+        pred.skb.train_test_split(split_index=None)
+    with pytest.raises(
+        IndexError,
+        match="split_index 100 out of range.*TimeSeriesSplit.* with 5 splits",
+    ):
+        pred.skb.train_test_split(split_index=100)
 
 
 def test_iter_cv_splits():
@@ -1081,8 +1171,8 @@ def test_mark_as_X_splitter():
     assert pred_with_groups.skb.make_grid_search(fitted=True).n_splits_ == 2
 
     split = pred_with_groups.skb.train_test_split()
-    assert list(split["X_train"]["x"]) == train[0]
-    assert list(split["X_test"]["x"]) == test[0]
+    assert list(split["X_train"]["x"]) == train[-1]
+    assert list(split["X_test"]["x"]) == test[-1]
 
     # Override with another splitter
     cv_results = pred_with_groups.skb.cross_validate(return_indices=True, cv=7)


### PR DESCRIPTION
Currently, when a splitter has been added with `.skb.mark_as_X(cv=the_splitter)`, if `.skb.train_test_split` is not passed an explicit `split_func` function, it defaults to the first split of the registered splitter.

With this PR,

- When no splitter has been added with mark_as_X or when we pass a split_func to .skb.train_test_split (ie when we are not using the mark_as_X splitter, either because there isn't one or we are overriding it), the behavior is unchanged (except the result contains new keys X and y, see below)
- When using the mark_as_X splitter, now by default the last split is returned rather than the first. it is usually what we want for timeseries splits (and for other splitters we typically don't care). Moreover it is possible to select a specific split by passing `split_index=3` to get the third split. Also row_indices_train and row_indices_test are added to the resulting dict, like they are in iter_cv_splits

Moreover, X and y (the full matrices before splitting) are now always added to the dicts returned by both train_test_split and iter_cv_splits . this can be useful for example to visualize the splits, makes the returned row indices more useful, and should usually come at no memory cost (X and y are already in memory anyway, for example iter_cv_splits keeps a reference to them until the generator is exhausted) -- and we can always select the subset of the dict we need and discard the rest

```python
import skrub
from sklearn import model_selection
from sklearn.dummy import DummyRegressor
import numpy as np

X = np.arange(30)[:, None]
y = X[:, 0]

pred = (
    skrub.var("X", X)
    .skb.mark_as_X(cv=model_selection.TimeSeriesSplit())
    .skb.apply(DummyRegressor(), y=skrub.var("y", y).skb.mark_as_y())
)
```

```
by default we now get the last split

>>> pred.skb.train_test_split()["y_test"]
array([25, 26, 27, 28, 29])

we can ask for a specific split. (split_index=0 gets the old behavior)

>>> pred.skb.train_test_split(split_index=0)["y_test"]
array([5, 6, 7, 8, 9])
>>> pred.skb.train_test_split(split_index=1)["y_test"]
array([10, 11, 12, 13, 14])

as before, we can still override the split function and pass the kwargs our
function expects.

>>> pred.skb.train_test_split(
...     split_func=model_selection.train_test_split,
...     test_size=12,
...     shuffle=True,
...     random_state=0,
... )["y_test"]
array([ 2, 28, 13, 10, 26, 24, 27, 11, 17, 22,  5, 16])
```