### PR TITLE
fix tick text of parallel coord in log space

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Changes
 
 Bugfixes
 --------
+- The parallel coordinate plot created by :meth:`ParamSearch.show_results` could
+  have incorrect tick labels in some cases. This has been fixed in :pr:`2215` by
+  :user:`Jérôme Dockès <jeromedockes>`.
 
 Deprecations
 ------------

--- a/skrub/_data_ops/_parallel_coord.py
+++ b/skrub/_data_ops/_parallel_coord.py
@@ -130,6 +130,7 @@ def _pick_format(vals):
     if len(set(map(fmt.format, vals))) == len(vals):
         return fmt
     # if still getting duplicate strings, revert to default representation
+    # normally this should not happen.
     return "{}"
 
 

--- a/skrub/_data_ops/_parallel_coord.py
+++ b/skrub/_data_ops/_parallel_coord.py
@@ -115,22 +115,25 @@ def _prepare_obj_column(col):
 
 
 def _pick_format(vals):
-    # vals must be finite, unique and sorted
+    # vals must be finite, unique and sorted.
+
     if len(vals) < 2 or any("e" in f"{v}" for v in vals):
-        # only one value, or scientific notation -- bail for simplicity
+        # only one value, or scientific notation: return default format for simplicity
         return "{}"
     delta = np.diff(vals).min()
-    # try to guess the necessary number of digits
+    # Try to guess the necessary number of digits
     n = max(1, -int(np.floor(np.log10(delta))))
     fmt = f"{{:.{n}f}}"
+    # Check if this format caused several values to end up with the same
+    # representation
     if len(set(map(fmt.format, vals))) == len(vals):
         return fmt
-    # if this caused collisions, increment n
+    # If we got duplicate labels, add one more digit and check again
     fmt = f"{{:.{n + 1}f}}"
     if len(set(map(fmt.format, vals))) == len(vals):
         return fmt
-    # if still getting duplicate strings, revert to default representation
-    # normally this should not happen.
+    # If still getting duplicate strings for some reason, revert to default
+    # representation. Normally this should not happen.
     return "{}"
 
 

--- a/skrub/_data_ops/_parallel_coord.py
+++ b/skrub/_data_ops/_parallel_coord.py
@@ -115,13 +115,22 @@ def _prepare_obj_column(col):
 
 
 def _pick_format(vals):
-    delta = (vals.max() - vals.min()) / (len(vals) + 1)
-    if delta == 0.0 or any("e" in f"{v:g}" for v in vals):
-        # only one values, or scientific notation -- bail for simplicity
-        return "{:g}"
-    # guess the necessary number of digits
-    n = max(0, -int(np.floor(np.log10(delta))))
-    return f"{{:.{n}f}}"
+    # vals must be finite, unique and sorted
+    if len(vals) < 2 or any("e" in f"{v}" for v in vals):
+        # only one value, or scientific notation -- bail for simplicity
+        return "{}"
+    delta = np.diff(vals).min()
+    # try to guess the necessary number of digits
+    n = max(1, -int(np.floor(np.log10(delta))))
+    fmt = f"{{:.{n}f}}"
+    if len(set(map(fmt.format, vals))) == len(vals):
+        return fmt
+    # if this caused collisions, increment n
+    fmt = f"{{:.{n + 1}f}}"
+    if len(set(map(fmt.format, vals))) == len(vals):
+        return fmt
+    # if still getting duplicate strings, revert to default representation
+    return "{}"
 
 
 def _prepare_numeric_column(col, *, is_log_scale, is_int):

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -242,7 +242,7 @@ def test_bad_filtering_params(classif_grid_search):
         )
 
 
-def test_pick_format(monkeypatch):
+def test_pick_format():
     vals = np.array([0.001, 0.01, 0.1, 1.0])
     assert list(map(_pick_format(vals).format, vals)) == [
         "0.001",

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -5,7 +5,7 @@ from sklearn.datasets import make_classification
 from sklearn.dummy import DummyClassifier
 
 import skrub
-from skrub._data_ops._parallel_coord import _add_jitter, _prepare_column
+from skrub._data_ops._parallel_coord import _add_jitter, _pick_format, _prepare_column
 
 
 def _has_plotly():
@@ -240,3 +240,10 @@ def test_bad_filtering_params(classif_grid_search):
         classif_grid_search.plot_results(
             show_choices=["choose_float(1.0, 2.0, n_steps=3)"]
         )
+
+
+def test_pick_format():
+    vals = np.array([0.001, 0.01, 0.1, 1.0])
+    fmt = _pick_format(vals)
+    assert list(map(fmt.format, vals)) == ["0.001", "0.010", "0.100", "1.000"]
+    assert _pick_format(vals[:1]) == "{}"

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -126,7 +126,7 @@ def test_column_preparation(is_log_scale, is_int):
         prepared["values"],
         [prepared["tickvals"][0], expected_value, prepared["tickvals"][0]],
     )
-    assert prepared["ticktext"] == ["NaN", "2"]
+    assert prepared["ticktext"] == ["NaN", "2" if is_int else "2.0"]
 
     # All nans
     column = pd.Series(np.array([np.nan, np.nan, np.nan]), name="test")
@@ -144,7 +144,7 @@ def test_column_preparation(is_log_scale, is_int):
     prepared = _prepare_column(column, is_log_scale=is_log_scale, is_int=is_int)
     jittered = _add_jitter(prepared)
 
-    assert prepared["ticktext"] == ["1"]
+    assert prepared["ticktext"] == ["1" if is_int else "1.0"]
     if is_log_scale:
         assert np.all(prepared["values"] == np.log(1.0))
         assert np.all(jittered["values"] == np.log(1.0))

--- a/skrub/_data_ops/tests/test_parallel_coord.py
+++ b/skrub/_data_ops/tests/test_parallel_coord.py
@@ -242,8 +242,24 @@ def test_bad_filtering_params(classif_grid_search):
         )
 
 
-def test_pick_format():
+def test_pick_format(monkeypatch):
     vals = np.array([0.001, 0.01, 0.1, 1.0])
-    fmt = _pick_format(vals)
-    assert list(map(fmt.format, vals)) == ["0.001", "0.010", "0.100", "1.000"]
+    assert list(map(_pick_format(vals).format, vals)) == [
+        "0.001",
+        "0.010",
+        "0.100",
+        "1.000",
+    ]
+
     assert _pick_format(vals[:1]) == "{}"
+
+    vals = np.array([0.005, 0.015])
+    assert list(map(_pick_format(vals).format, vals)) == ["0.005", "0.015"]
+
+    # hack to cover corner case that should not normally happen
+
+    class _array(list):
+        def __len__(self):
+            return 100
+
+    assert _pick_format(_array(vals)) == "{}"


### PR DESCRIPTION
in some cases in log scales the tick text formatting could create duplicate tick texts resulting in incorrect ticks

before

<img width="1058" height="256" alt="screenshot_2026-07-15T16:46:11+02:00" src="https://github.com/user-attachments/assets/1eb9870e-2c1c-4a60-8d3a-ead10038d34f" />


after

<img width="1082" height="275" alt="screenshot_2026-07-15T16:45:37+02:00" src="https://github.com/user-attachments/assets/8a1bc7b0-1429-442d-b90e-d4b675b56af5" />
