### PR TITLE
Allow DropSimilar with Polars without PyArrow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,9 +38,8 @@ Changes
 
 Bugfixes
 --------
-- :class:`DropSimilar` and :func:`column_associations` now work with Polars
-  dataframes when PyArrow is not installed. In that case, Pearson's correlation
-  is omitted from the computed associations.
+- :class:`DropSimilar` now works with Polars dataframes when PyArrow is not
+  installed by avoiding the unused Pearson's correlation computation.
   :pr:`2216` by :user:`Shreyansh Goyal <ShreyanshGoyal>`.
 
 - The parallel coordinate plot created by :meth:`ParamSearch.show_results` could

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,11 @@ Changes
 
 Bugfixes
 --------
+- :class:`DropSimilar` and :func:`column_associations` now work with Polars
+  dataframes when PyArrow is not installed. In that case, Pearson's correlation
+  is omitted from the computed associations.
+  :pr:`2216` by :user:`Shreyansh Goyal <ShreyanshGoyal>`.
+
 - The parallel coordinate plot created by :meth:`ParamSearch.show_results` could
   have incorrect tick labels in some cases. This has been fixed in :pr:`2215` by
   :user:`Jérôme Dockès <jeromedockes>`.

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -13,18 +13,23 @@ _N_BINS = 10
 _CATEGORICAL_THRESHOLD = 30
 
 
-def column_associations(df):
+def column_associations(df, *, compute_pearson=True):
     """Get measures of statistical associations between all pairs of columns.
 
-    Reported metrics include Cramer's V statistic and Pearson's Correlation
-    Coefficient. The result is returned as a dataframe that contains the column
-    name and idx for the left and right table and both associations; results
-    are sorted in descending order by Cramer's V association.
+    Reported metrics include Cramer's V statistic and, unless disabled,
+    Pearson's Correlation Coefficient. The result is returned as a dataframe
+    that contains the column name and idx for the left and right table and the
+    requested associations; results are sorted in descending order by Cramer's
+    V association.
 
     Parameters
     ----------
     df : dataframe
         The dataframe whose columns will be compared to each other.
+    compute_pearson : bool, default=True
+        Whether to compute Pearson's Correlation Coefficient. Setting this to
+        ``False`` avoids converting Polars dataframes to pandas and therefore
+        does not require PyArrow.
 
     Returns
     -------
@@ -36,7 +41,8 @@ def column_associations(df):
     The result is returned as a dataframe with columns:
 
     ``['left_column_name', 'left_column_idx', 'right_column_name',
-    'right_column_idx', 'cramer_v', 'pearson_corr']``
+    'right_column_idx', 'cramer_v', 'pearson_corr']``. When
+    ``compute_pearson=False``, the ``'pearson_corr'`` column is omitted.
 
     As the function is commutative, each pair of columns appears only once
     (either ``col_1``, ``col_2`` or ``col_2``, ``col_1`` but not both).
@@ -108,6 +114,8 @@ def column_associations(df):
         _cramer_v_matrix(df),
         df,
     )
+    if not compute_pearson:
+        return cramer_v_table
     pearson_c_table = _compute_pearson(df)
     on = ["left_column_name", "right_column_name"]
     return _join_utils.left_join(

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -16,11 +16,10 @@ _CATEGORICAL_THRESHOLD = 30
 def column_associations(df, *, compute_pearson=True):
     """Get measures of statistical associations between all pairs of columns.
 
-    Reported metrics include Cramer's V statistic and, unless disabled,
-    Pearson's Correlation Coefficient. The result is returned as a dataframe
-    that contains the column name and idx for the left and right table and the
-    requested associations; results are sorted in descending order by Cramer's
-    V association.
+    Reported metrics include Cramer's V statistic and Pearson's Correlation
+    Coefficient. The result is returned as a dataframe that contains the column
+    name and idx for the left and right table and the requested associations;
+    results are sorted in descending order by Cramer's V association.
 
     Parameters
     ----------
@@ -29,7 +28,8 @@ def column_associations(df, *, compute_pearson=True):
     compute_pearson : bool, default=True
         Whether to compute Pearson's Correlation Coefficient. Setting this to
         ``False`` avoids converting Polars dataframes to pandas and therefore
-        does not require PyArrow.
+        does not require PyArrow. This parameter is set to ``False`` when the
+        dataframe is Polars and PyArrow is not available.
 
     Returns
     -------
@@ -41,8 +41,9 @@ def column_associations(df, *, compute_pearson=True):
     The result is returned as a dataframe with columns:
 
     ``['left_column_name', 'left_column_idx', 'right_column_name',
-    'right_column_idx', 'cramer_v', 'pearson_corr']``. When
-    ``compute_pearson=False``, the ``'pearson_corr'`` column is omitted.
+    'right_column_idx', 'cramer_v', 'pearson_corr']``.
+
+    When ``compute_pearson=False``, the ``'pearson_corr'`` column is omitted.
 
     As the function is commutative, each pair of columns appears only once
     (either ``col_1``, ``col_2`` or ``col_2``, ``col_1`` but not both).
@@ -110,6 +111,12 @@ def column_associations(df, *, compute_pearson=True):
     >>> pd.reset_option('display.max_columns')
     >>> pd.reset_option('display.precision')
     """  # noqa: E501
+    if compute_pearson and sbd.is_polars(df):
+        try:
+            import pyarrow  # noqa: F401
+        except ImportError:
+            compute_pearson = False
+
     cramer_v_table = _stack_symmetric_associations(
         _cramer_v_matrix(df),
         df,

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -28,8 +28,7 @@ def column_associations(df, *, compute_pearson=True):
     compute_pearson : bool, default=True
         Whether to compute Pearson's Correlation Coefficient. Setting this to
         ``False`` avoids converting Polars dataframes to pandas and therefore
-        does not require PyArrow. This parameter is set to ``False`` when the
-        dataframe is Polars and PyArrow is not available.
+        does not require PyArrow.
 
     Returns
     -------
@@ -111,12 +110,6 @@ def column_associations(df, *, compute_pearson=True):
     >>> pd.reset_option('display.max_columns')
     >>> pd.reset_option('display.precision')
     """  # noqa: E501
-    if compute_pearson and sbd.is_polars(df):
-        try:
-            import pyarrow  # noqa: F401
-        except ImportError:
-            compute_pearson = False
-
     cramer_v_table = _stack_symmetric_associations(
         _cramer_v_matrix(df),
         df,

--- a/skrub/_column_associations.py
+++ b/skrub/_column_associations.py
@@ -26,9 +26,7 @@ def column_associations(df, *, compute_pearson=True):
     df : dataframe
         The dataframe whose columns will be compared to each other.
     compute_pearson : bool, default=True
-        Whether to compute Pearson's Correlation Coefficient. Setting this to
-        ``False`` avoids converting Polars dataframes to pandas and therefore
-        does not require PyArrow.
+        Whether to compute Pearson's Correlation Coefficient. Currently, computing Pearson correlations for polars DataFrames requires PyArrow to be installed and internally converts the dataframe to pandas.
 
     Returns
     -------

--- a/skrub/_drop_similar.py
+++ b/skrub/_drop_similar.py
@@ -139,16 +139,7 @@ class DropSimilar(TransformerMixin, SkrubBaseEstimator):
                 f"Threshold must be a number between 0 and 1, got {self.threshold!r}."
             )
 
-        if sbd.is_polars(X):
-            try:
-                import pyarrow  # noqa F401
-            except ImportError:
-                raise ImportError(
-                    "DropSimilar requires the Pyarrow package to run on Polars"
-                    " dataframes."
-                )
-
-        association_df = column_associations(X)
+        association_df = column_associations(X, compute_pearson=False)
         self.column_associations_ = s.select(
             association_df, ["left_column_name", "right_column_name", "cramer_v"]
         )

--- a/skrub/_drop_similar.py
+++ b/skrub/_drop_similar.py
@@ -139,7 +139,7 @@ class DropSimilar(TransformerMixin, SkrubBaseEstimator):
                 f"Threshold must be a number between 0 and 1, got {self.threshold!r}."
             )
 
-        association_df = column_associations(X)
+        association_df = column_associations(X, compute_pearson=False)
         self.column_associations_ = s.select(
             association_df, ["left_column_name", "right_column_name", "cramer_v"]
         )

--- a/skrub/_drop_similar.py
+++ b/skrub/_drop_similar.py
@@ -139,7 +139,7 @@ class DropSimilar(TransformerMixin, SkrubBaseEstimator):
                 f"Threshold must be a number between 0 and 1, got {self.threshold!r}."
             )
 
-        association_df = column_associations(X, compute_pearson=False)
+        association_df = column_associations(X)
         self.column_associations_ = s.select(
             association_df, ["left_column_name", "right_column_name", "cramer_v"]
         )

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -28,6 +28,20 @@ def test_column_associations(df_module):
     )
 
 
+def test_column_associations_without_pearson(df_module):
+    df = df_module.make_dataframe({"x": [0, 1], "y": [0, 1]})
+
+    associations = column_associations(df, compute_pearson=False)
+
+    assert sbd.column_names(associations) == [
+        "left_column_name",
+        "left_column_idx",
+        "right_column_name",
+        "right_column_idx",
+        "cramer_v",
+    ]
+
+
 @skip_polars_installed_without_pyarrow
 def test_infinite(df_module):
     # non-regression test for https://github.com/skrub-data/skrub/issues/1133

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -1,3 +1,5 @@
+import builtins
+import sys
 import warnings
 
 import numpy as np
@@ -32,6 +34,31 @@ def test_column_associations_without_pearson(df_module):
     df = df_module.make_dataframe({"x": [0, 1], "y": [0, 1]})
 
     associations = column_associations(df, compute_pearson=False)
+
+    assert sbd.column_names(associations) == [
+        "left_column_name",
+        "left_column_idx",
+        "right_column_name",
+        "right_column_idx",
+        "cramer_v",
+    ]
+
+
+def test_column_associations_polars_without_pyarrow(monkeypatch):
+    """Pearson correlation is disabled by default when PyArrow is unavailable."""
+    pl = pytest.importorskip("polars")
+    df = pl.DataFrame({"x": [0, 1], "y": [0, 1]})
+    monkeypatch.delitem(sys.modules, "pyarrow", raising=False)
+    builtin_import = builtins.__import__
+
+    def _import(name, *args, **kwargs):
+        if name == "pyarrow" or name.startswith("pyarrow."):
+            raise ImportError(name)
+        return builtin_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+
+    associations = column_associations(df)
 
     assert sbd.column_names(associations) == [
         "left_column_name",

--- a/skrub/tests/test_column_associations.py
+++ b/skrub/tests/test_column_associations.py
@@ -44,8 +44,8 @@ def test_column_associations_without_pearson(df_module):
     ]
 
 
-def test_column_associations_polars_without_pyarrow(monkeypatch):
-    """Pearson correlation is disabled by default when PyArrow is unavailable."""
+def test_column_associations_polars_without_pyarrow_raises(monkeypatch):
+    """Requesting Pearson correlation without PyArrow raises an exception."""
     pl = pytest.importorskip("polars")
     df = pl.DataFrame({"x": [0, 1], "y": [0, 1]})
     monkeypatch.delitem(sys.modules, "pyarrow", raising=False)
@@ -58,15 +58,8 @@ def test_column_associations_polars_without_pyarrow(monkeypatch):
 
     monkeypatch.setattr(builtins, "__import__", _import)
 
-    associations = column_associations(df)
-
-    assert sbd.column_names(associations) == [
-        "left_column_name",
-        "left_column_idx",
-        "right_column_name",
-        "right_column_idx",
-        "cramer_v",
-    ]
+    with pytest.raises(ImportError):
+        column_associations(df)
 
 
 @skip_polars_installed_without_pyarrow

--- a/skrub/tests/test_drop_similar.py
+++ b/skrub/tests/test_drop_similar.py
@@ -9,7 +9,6 @@ from skrub.conftest import skip_polars_installed_without_pyarrow
 
 _THRESHOLD_ERROR = "Threshold must be a number between 0 and 1"
 _TYPE_ERROR = "Threshold must be a number"
-_PYARROW_ERROR = "DropSimilar requires the Pyarrow package to run on Polars dataframes."
 
 
 @pytest.fixture
@@ -120,27 +119,19 @@ def test_wrong_threshold(df_module, threshold, error):
 
 
 def test_without_pyarrow(monkeypatch):
-    """
-    DropSimilar requires Pandas dataframes. If the user is working with Polars
-    but does not have the Pyarrow module to convert their dataframe to Pandas,
-    it is expected that `DropSimilar.fit_transform` should fail.
-
-    This test forces this specific import configuration using monkeypatch and
-    a custom `import` function, and checks that the method does indeed fail.
-    """
+    """DropSimilar works with Polars without importing PyArrow."""
     pl = pytest.importorskip("polars")
-    example_dataframe = pl.DataFrame({"a": [1, 2, 3]})
+    example_dataframe = pl.DataFrame({"original": [1, 2, 3], "duplicate": [1, 2, 3]})
     monkeypatch.delitem(sys.modules, "pyarrow", raising=False)
-    assert "pyarrow" not in sys.modules
-    ds = DropSimilar()
-
     builtin_import = builtins.__import__
 
     def _import(name, *args, **kwargs):
-        if name == "pyarrow":
+        if name == "pyarrow" or name.startswith("pyarrow."):
             raise ImportError(name)
         return builtin_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", _import)
-    with pytest.raises(ImportError, match=_PYARROW_ERROR):
-        ds.fit_transform(example_dataframe)
+
+    result = DropSimilar().fit_transform(example_dataframe)
+
+    assert result.columns == ["original"]


### PR DESCRIPTION
Fixes #2187.

## Summary

- add a backward-compatible option to skip Pearson correlation in column_associations
- have DropSimilar explicitly skip its unused Pearson correlation computation
- preserve the existing exception when Pearson correlation is requested for Polars without PyArrow
- allow DropSimilar to process Polars dataframes when PyArrow is not installed
- add regression coverage and document the user-facing change in CHANGES.rst

## Rationale

DropSimilar discarded the pearson_corr column immediately after calling column_associations, but computing that unused column converted Polars dataframes to pandas and made PyArrow mandatory. DropSimilar now requests only the Cramers V association it uses. Direct column_associations calls retain their requested behavior and raise if Pearson correlation cannot be computed.

## Test plan

- [x] Run the affected test files (25 passed, 2 skipped)
- [x] Confirm DropSimilar works with Polars while PyArrow imports are blocked
- [x] Confirm column_associations raises when Pearson is requested while PyArrow imports are blocked
- [x] Check the patch for whitespace errors