### PR TITLE
MAINT - add a command for testing all docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,7 @@ check = { cmd = "python build_tools/generate_data_ops_stub.py | diff - skrub/_da
 [tool.pixi.feature.test.tasks]
 test = { cmd = "pytest -vsl --cov=skrub --cov-report=xml skrub" }
 test-user-guide = { cmd = "pytest doc/**/*.rst" }
+test-docstrings = { cmd = "pytest -doctest-modules skrub doc/modules --ignore-glob=\"*/test_*.py\" --doctest-glob=\"*.rst\"" }
 
 [tool.pixi.environments]
 lint = ["lint"]
@@ -367,7 +368,7 @@ filterwarnings = [
   # Ignore polars warning about horizontal concatenation being deprecated
   # We always expect dataframes to concatenate to have the same length, so the
   # intended behavior starting from version 1.42 is already what we want
-  "ignore:the default behavior of `how='horizontal'`.*:DeprecationWarning"
+  "ignore:the default behavior of `how='horizontal'`.*:DeprecationWarning",
 ]
 log_cli_level = "INFO"
 xfail_strict = true


### PR DESCRIPTION
Adding a command that tests all docstrings without running tests.

This should make it easier to debug and fix doctests in the documentation and the docstrings when they're worked on: checks can be run locally and skip running the actual tests. 