### PR TITLE
Switch TextEncoder verbose from bool to int and fix documented default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,12 @@ New Features
 
 Changes
 -------
+- :class:`TextEncoder` now accepts an integer ``verbose`` parameter instead of
+  a boolean, for consistency with other estimators such as :class:`GapEncoder`
+  and :class:`TableReport`. Passing a boolean still works as before. The
+  documented default, which incorrectly stated ``True``, has been corrected to
+  ``0``.
+  :pr:`2223` by :user:`Jay Spark <jaysparkx>`.
 - The error message when a key is missing from the environment passed to a
   :class:`DataOp` or :class:`SkrubLearner` has been improved.
   :pr:`2211` by :user:`Jérôme Dockès <jeromedockes>`.

--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -108,9 +108,9 @@ class TextEncoder(SingleColumnTransformer):
         Used when the PCA dimension reduction mechanism is used, for reproducible
         results across multiple function calls.
 
-    verbose : bool, default=True
-        Verbose level, controls whether to show a progress bar or not during
-        ``transform``.
+    verbose : int, default=0
+        Verbose level. When greater than ``0``, a progress bar is displayed
+        during ``transform``.
 
     Attributes
     ----------
@@ -198,7 +198,7 @@ class TextEncoder(SingleColumnTransformer):
         cache_folder=None,
         store_weights_in_pickle=False,
         random_state=None,
-        verbose=False,
+        verbose=0,
     ):
         self.model_name = model_name
         self.n_components = n_components
@@ -329,7 +329,7 @@ class TextEncoder(SingleColumnTransformer):
             unique_x,
             normalize_embeddings=False,
             batch_size=self.batch_size,
-            show_progress_bar=self.verbose,
+            show_progress_bar=bool(self.verbose),
         )[indices_x]
 
     @functools.cached_property


### PR DESCRIPTION
Closes #2131.

### What
- Change `TextEncoder`'s `verbose` parameter from `bool` to `int`, for consistency with `GapEncoder`, `TableReport` and `patch_display`, which all expose `verbose` as an int.
- Fix the docstring, which stated `bool, default=True` while the real default is `0`/`False`.
- Pass `bool(self.verbose)` to sentence-transformers' `show_progress_bar` at the call site.

### Backward compatibility
`bool` is a subclass of `int`, so existing calls passing `True`/`False` continue to work unchanged.