### PR TITLE
Remove confusing contributor note from SingleColumnTransformer.fit docstring

### DIFF
--- a/skrub/_single_column_transformer.py
+++ b/skrub/_single_column_transformer.py
@@ -173,8 +173,6 @@ class SingleColumnTransformer(SkrubBaseEstimator):
         This default implementation simply calls ``fit_transform()`` and
         returns ``self``.
 
-        Subclasses should implement ``fit_transform`` and ``transform``.
-
         Parameters
         ----------
         column : a pandas or polars Series


### PR DESCRIPTION
Closes #2128.

The sentence `Subclasses should implement fit_transform and transform.` in `SingleColumnTransformer.fit` is directed at contributors, but appears in the user-facing documentation of `fit`, where it is confusing (as noted in the issue). The same information is already documented at the class level, so this removes it from the method docstring.

No behavior change.