### PR TITLE
Fix Issue 2114: Accept estimators that don't inherit from sklearn.BaseEstimator in tabular_pipeline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,9 +44,15 @@ Changes
   :user:`Jérôme Dockès <jeromedockes>`.
 
 - Made the following changes to :func:`tabular_pipeline`:
-  - Estimators are no longer required to inherit from :class:`sklearn.BaseEstimator`. Instead, scikit-learn compatibility check is based on presence of `get_params` and `set_params` attributes.
-  - Requirement for special treatment for tree ensemble/HGBT models is determined based on class name substring matching, rather than exact type matching.
-  - Parameters are provided to override default heuristics and enforce special treatment for tree ensemble/HGBT models.
+  - Estimators are no longer required to inherit from :class:`sklearn.BaseEstimator`.
+    Instead, scikit-learn compatibility check is based on presence of `get_params`
+    and `set_params` attributes.
+  - Requirement for special treatment for tree ensemble/HGBT models is determined
+    based on class name substring matching, rather than exact type matching.
+  - Parameters are provided to override default heuristics and enforce special
+    treatment for tree ensemble/HGBT models.
+
+  :pr:`2225` by :user:`Laurence Dyer <ljdyer>`. 
 
 Bugfixes
 --------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,12 +49,10 @@ Changes
 
 - Made the following changes to :func:`tabular_pipeline`:
   - Estimators are no longer required to inherit from :class:`sklearn.BaseEstimator`.
-    Instead, scikit-learn compatibility check is based on presence of `get_params`
-    and `set_params` attributes.
+    Instead, scikit-learn compatibility check is based on presence of the methods:
+    `get_params`, `set_params`, `fit`, `predict`.
   - Requirement for special treatment for tree ensemble/HGBT models is determined
     based on class name substring matching, rather than exact type matching.
-  - Parameters are provided to override default heuristics and enforce special
-    treatment for tree ensemble/HGBT models.
 
   :pr:`2225` by :user:`Laurence Dyer <ljdyer>`. 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ Changes
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
 
+- Made the following changes to :func:`tabular_pipeline`:
+  - Estimators are no longer required to inherit from :class:`sklearn.BaseEstimator`. Instead, scikit-learn compatibility check is based on presence of `get_params` and `set_params` attributes.
+  - Requirement for special treatment for tree ensemble/HGBT models is determined based on class name substring matching, rather than exact type matching.
+  - Parameters are provided to override default heuristics and enforce special treatment for tree ensemble/HGBT models.
 
 Bugfixes
 --------

--- a/doc/modules/default_wrangling/tabular_pipeline.rst
+++ b/doc/modules/default_wrangling/tabular_pipeline.rst
@@ -15,7 +15,7 @@
 Building robust ML baselines with |tabular_pipeline|
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The |tabular_pipeline| is a function that, given a scikit-learn estimator,
+The |tabular_pipeline| is a function that, given a scikit-learn compatible estimator,
 returns a full scikit-learn |Pipeline| that contains a |TableVectorizer|
 followed by the given estimator.
 If the estimator is a linear model (e.g., ``Ridge``, ``LogisticRegression``),
@@ -50,8 +50,8 @@ problems, but may not beat properly tuned ad-hoc pipelines.
    :widths: 25 25 25 25
 
    * - Parameter
-     - ``RandomForest`` models
-     - ``HistGradientBoosting`` models
+     - Tree ensemble models (e.g. ``RandomForest``)
+     - ``HistGradientBoosting`` models 
      - Linear models and others
    * - Low-cardinality encoder
      - :class:`~sklearn.preprocessing.OrdinalEncoder`

--- a/skrub/_tabular_pipeline.py
+++ b/skrub/_tabular_pipeline.py
@@ -1,5 +1,4 @@
 from sklearn import ensemble
-from sklearn.base import BaseEstimator
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import OrdinalEncoder
@@ -26,7 +25,7 @@ _TREE_ENSEMBLE_CLASSES = (
 def tabular_pipeline(estimator, *, n_jobs=None):
     """Get a simple machine-learning pipeline for tabular data.
 
-    Given either a scikit-learn estimator or one of the special-cased strings
+    Given either a scikit-learn compatible estimator or one of the special-cased strings
     ``'regressor'``, ``'regression'``, ``'classifier'``, ``'classification'``, this
     function creates a scikit-learn pipeline that extracts numeric features, imputes
     missing values and scales the data if necessary, then applies the estimator.
@@ -47,7 +46,9 @@ def tabular_pipeline(estimator, *, n_jobs=None):
 
     Parameters
     ----------
-    estimator : {"regressor", "regression", "classifier", "classification"} or sklearn.base.BaseEstimator
+    estimator : {"regressor", "regression", "classifier", "classification"} or scikit-learn
+        compatible estimator
+
         The estimator to use as the final step in the pipeline. Based on the type of
         estimator, the previous preprocessing steps and their respective parameters are
         chosen. The possible values are:
@@ -58,7 +59,8 @@ def tabular_pipeline(estimator, *, n_jobs=None):
         - ``'classifier'`` or ``'classification'``: a
           :obj:`~sklearn.ensemble.HistGradientBoostingClassifier` is used as the final
           step;
-        - a scikit-learn estimator: the provided estimator is used as the final step.
+        - a scikit-learn compatible estimator: the provided estimator is used as the final
+          step.
 
     n_jobs : int, default=None
         Number of jobs to run in parallel in the :obj:`TableVectorizer` step. ``None``
@@ -240,16 +242,22 @@ def tabular_pipeline(estimator, *, n_jobs=None):
             "If ``estimator`` is a string it should be 'regressor', 'regression',"
             " 'classifier' or 'classification'."
         )
-    if isinstance(estimator, type) and issubclass(estimator, BaseEstimator):
+
+    if isinstance(estimator, type):
         raise TypeError(
-            "tabular_pipeline expects a scikit-learn estimator as its first"
-            f" argument. Pass an instance of {estimator.__name__} rather than the class"
-            " itself."
+            "tabular_pipeline expects a scikit-learn compatible estimator instance as"
+            " its first argument, but you have passed a type. Pass an instance of the"
+            " estimator rather than the class itself."
         )
-    if not isinstance(estimator, BaseEstimator):
+
+    is_scikit_learn_compatible = hasattr(estimator, "get_params") and hasattr(
+        estimator, "set_params"
+    )
+    if not is_scikit_learn_compatible:
         raise TypeError(
-            "tabular_pipeline expects a scikit-learn estimator, 'regressor',"
-            " or 'classifier' as its first argument."
+            "tabular_pipeline expects a scikit-learn compatible estimator as its first"
+            " argument. The estimator object must have 'get_params' and 'set_params'"
+            " attributes."
         )
 
     is_estimator_from_tabicl = estimator.__class__.__name__ in (

--- a/skrub/_tabular_pipeline.py
+++ b/skrub/_tabular_pipeline.py
@@ -19,7 +19,9 @@ _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS = (
 )
 
 
-def tabular_pipeline(estimator, *, n_jobs=None):
+def tabular_pipeline(
+    estimator, *, n_jobs=None, is_tree_ensemble_estimator=None, is_hgbt_estimator=None
+):
     """Get a simple machine-learning pipeline for tabular data.
 
     Given either a scikit-learn compatible estimator or one of the special-cased strings
@@ -63,6 +65,16 @@ def tabular_pipeline(estimator, *, n_jobs=None):
         Number of jobs to run in parallel in the :obj:`TableVectorizer` step. ``None``
         means 1 unless in a joblib ``parallel_backend`` context. ``-1`` means using all
         processors.
+
+    is_tree_ensemble_estimator : bool, default=None
+        Set to ``True`` to override the default class-name based heuristic and enforce
+        tree ensemble estimator treatment. The default heuristic should catch most common
+        tree ensembles; this parameter can be used otherwise.
+
+    is_hgbt_estimator : bool, default=None
+        Set to ``True`` to override the default class-name based heuristic and enforce
+        histogram-based gradient boosting model treatment. The default heuristic should
+        catch most common HBGTs; this parameter can be used otherwise.
 
     Returns
     -------
@@ -261,24 +273,24 @@ def tabular_pipeline(estimator, *, n_jobs=None):
         "TabICLClassifier",
         "TabICLRegressor",
     )
-    is_hgbt_estimator = any(
+    _is_hgbt_estimator = any(
         x.lower() in estimator.__class__.__name__.lower()
         for x in _HGBT_CLASS_NAME_SUBSTRINGS
-    )
-    is_tree_ensemble_estimator = any(
+    ) or (is_hgbt_estimator is True)
+    _is_tree_ensemble_estimator = any(
         x.lower() in estimator.__class__.__name__.lower()
         for x in _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS
-    )
+    ) or (is_tree_ensemble_estimator is True)
 
     if (
-        is_hgbt_estimator
+        _is_hgbt_estimator
         and getattr(estimator, "categorical_features", None) == "from_dtype"
     ):
         vectorizer.set_params(
             low_cardinality=ToCategorical(),
             high_cardinality=StringEncoder(),
         )
-    elif is_tree_ensemble_estimator:
+    elif _is_tree_ensemble_estimator:
         vectorizer.set_params(
             low_cardinality=OrdinalEncoder(
                 handle_unknown="use_encoded_value",
@@ -299,7 +311,7 @@ def tabular_pipeline(estimator, *, n_jobs=None):
     if not is_estimator_from_tabicl:
         if not get_tags(estimator).input_tags.allow_nan:
             steps.append(SimpleImputer(add_indicator=True))
-        if not is_tree_ensemble_estimator:
+        if not _is_tree_ensemble_estimator:
             steps.append(SquashingScaler(max_absolute_value=5))
 
     steps.append(estimator)

--- a/skrub/_tabular_pipeline.py
+++ b/skrub/_tabular_pipeline.py
@@ -10,15 +10,12 @@ from ._string_encoder import StringEncoder
 from ._table_vectorizer import TableVectorizer
 from ._to_categorical import ToCategorical
 
-_HGBT_CLASSES = (
-    ensemble.HistGradientBoostingClassifier,
-    ensemble.HistGradientBoostingRegressor,
-)
-_TREE_ENSEMBLE_CLASSES = (
-    ensemble.HistGradientBoostingClassifier,
-    ensemble.HistGradientBoostingRegressor,
-    ensemble.RandomForestClassifier,
-    ensemble.RandomForestRegressor,
+_HGBT_CLASS_NAME_SUBSTRINGS = ("HistGradientBoosting",)
+_TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS = (
+    "HistGradientBoosting",
+    "RandomForest",
+    "XGB",
+    "LGBM",
 )
 
 
@@ -264,15 +261,24 @@ def tabular_pipeline(estimator, *, n_jobs=None):
         "TabICLClassifier",
         "TabICLRegressor",
     )
+    is_hgbt_estimator = any(
+        x.lower() in estimator.__class__.__name__.lower()
+        for x in _HGBT_CLASS_NAME_SUBSTRINGS
+    )
+    is_tree_ensemble_estimator = any(
+        x.lower() in estimator.__class__.__name__.lower()
+        for x in _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS
+    )
+
     if (
-        isinstance(estimator, _HGBT_CLASSES)
+        is_hgbt_estimator
         and getattr(estimator, "categorical_features", None) == "from_dtype"
     ):
         vectorizer.set_params(
             low_cardinality=ToCategorical(),
             high_cardinality=StringEncoder(),
         )
-    elif isinstance(estimator, _TREE_ENSEMBLE_CLASSES):
+    elif is_tree_ensemble_estimator:
         vectorizer.set_params(
             low_cardinality=OrdinalEncoder(
                 handle_unknown="use_encoded_value",
@@ -293,7 +299,7 @@ def tabular_pipeline(estimator, *, n_jobs=None):
     if not is_estimator_from_tabicl:
         if not get_tags(estimator).input_tags.allow_nan:
             steps.append(SimpleImputer(add_indicator=True))
-        if not isinstance(estimator, _TREE_ENSEMBLE_CLASSES):
+        if not is_tree_ensemble_estimator:
             steps.append(SquashingScaler(max_absolute_value=5))
 
     steps.append(estimator)

--- a/skrub/_tabular_pipeline.py
+++ b/skrub/_tabular_pipeline.py
@@ -19,9 +19,7 @@ _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS = (
 )
 
 
-def tabular_pipeline(
-    estimator, *, n_jobs=None, is_tree_ensemble_estimator=None, is_hgbt_estimator=None
-):
+def tabular_pipeline(estimator, *, n_jobs=None):
     """Get a simple machine-learning pipeline for tabular data.
 
     Given either a scikit-learn compatible estimator or one of the special-cased strings
@@ -65,16 +63,6 @@ def tabular_pipeline(
         Number of jobs to run in parallel in the :obj:`TableVectorizer` step. ``None``
         means 1 unless in a joblib ``parallel_backend`` context. ``-1`` means using all
         processors.
-
-    is_tree_ensemble_estimator : bool, default=None
-        Set to ``True`` to override the default class-name based heuristic and enforce
-        tree ensemble estimator treatment. The default heuristic should catch most common
-        tree ensembles; this parameter can be used otherwise.
-
-    is_hgbt_estimator : bool, default=None
-        Set to ``True`` to override the default class-name based heuristic and enforce
-        histogram-based gradient boosting model treatment. The default heuristic should
-        catch most common HBGTs; this parameter can be used otherwise.
 
     Returns
     -------
@@ -273,24 +261,24 @@ def tabular_pipeline(
         "TabICLClassifier",
         "TabICLRegressor",
     )
-    _is_hgbt_estimator = any(
+    is_hgbt_estimator = any(
         x.lower() in estimator.__class__.__name__.lower()
         for x in _HGBT_CLASS_NAME_SUBSTRINGS
-    ) or (is_hgbt_estimator is True)
-    _is_tree_ensemble_estimator = any(
+    )
+    is_tree_ensemble_estimator = any(
         x.lower() in estimator.__class__.__name__.lower()
         for x in _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS
-    ) or (is_tree_ensemble_estimator is True)
+    )
 
     if (
-        _is_hgbt_estimator
+        is_hgbt_estimator
         and getattr(estimator, "categorical_features", None) == "from_dtype"
     ):
         vectorizer.set_params(
             low_cardinality=ToCategorical(),
             high_cardinality=StringEncoder(),
         )
-    elif _is_tree_ensemble_estimator:
+    elif is_tree_ensemble_estimator:
         vectorizer.set_params(
             low_cardinality=OrdinalEncoder(
                 handle_unknown="use_encoded_value",
@@ -311,7 +299,7 @@ def tabular_pipeline(
     if not is_estimator_from_tabicl:
         if not get_tags(estimator).input_tags.allow_nan:
             steps.append(SimpleImputer(add_indicator=True))
-        if not _is_tree_ensemble_estimator:
+        if not is_tree_ensemble_estimator:
             steps.append(SquashingScaler(max_absolute_value=5))
 
     steps.append(estimator)

--- a/skrub/_tabular_pipeline.py
+++ b/skrub/_tabular_pipeline.py
@@ -19,6 +19,21 @@ _TREE_ENSEMBLE_CLASS_NAME_SUBSTRINGS = (
 )
 
 
+def is_scikit_learn_compatible_estimator(estimator) -> tuple[bool, str | None]:
+    """Determine whether a candidate object is a valid scikit learn-compatiable
+    estimator. Return True or False, plus an optional string stating the failure
+    reason."""
+
+    REQUIRED_METHOD_NAMES = ["get_params", "set_params", "fit", "predict"]
+    for method_name in REQUIRED_METHOD_NAMES:
+        if not hasattr(estimator, method_name):
+            return False, f"The estimator must have a {method_name} attribute."
+    for method_name in REQUIRED_METHOD_NAMES:
+        if not callable(getattr(estimator, method_name)):
+            return False, f"The estimator's {method_name} attribute must be callable."
+    return True, None
+
+
 def tabular_pipeline(estimator, *, n_jobs=None):
     """Get a simple machine-learning pipeline for tabular data.
 
@@ -247,14 +262,13 @@ def tabular_pipeline(estimator, *, n_jobs=None):
             " estimator rather than the class itself."
         )
 
-    is_scikit_learn_compatible = hasattr(estimator, "get_params") and hasattr(
-        estimator, "set_params"
+    is_scikit_learn_compatible, incompatable_reason = (
+        is_scikit_learn_compatible_estimator(estimator)
     )
     if not is_scikit_learn_compatible:
         raise TypeError(
             "tabular_pipeline expects a scikit-learn compatible estimator as its first"
-            " argument. The estimator object must have 'get_params' and 'set_params'"
-            " attributes."
+            " argument. " + incompatable_reason
         )
 
     is_estimator_from_tabicl = estimator.__class__.__name__ in (
@@ -297,8 +311,14 @@ def tabular_pipeline(estimator, *, n_jobs=None):
         vectorizer.set_params(datetime=DatetimeEncoder(periodic_encoding="spline"))
     steps = [vectorizer]
     if not is_estimator_from_tabicl:
-        if not get_tags(estimator).input_tags.allow_nan:
+        # Check whether we need imputation
+        try:
+            allow_nan = get_tags(estimator).input_tags.allow_nan
+        except AttributeError:
+            allow_nan = False
+        if not allow_nan:
             steps.append(SimpleImputer(add_indicator=True))
+        # Check whether we need squashing scalar
         if not is_tree_ensemble_estimator:
             steps.append(SquashingScaler(max_absolute_value=5))
 

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -5,6 +5,7 @@ from sklearn.impute import SimpleImputer
 from sklearn.linear_model import Ridge
 from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
 
+import skrub._tabular_pipeline
 from skrub import (
     SquashingScaler,
     StringEncoder,
@@ -12,6 +13,19 @@ from skrub import (
     ToCategorical,
     tabular_pipeline,
 )
+
+
+def fake_get_tags(_):
+    """Allows dummy estimators to get past
+    `if not get_tags(estimator).input_tags.allow_nan:` check for tests"""
+
+    class fake_input_tags:
+        allow_nan = None
+
+    class fake_estimator:
+        input_tags = fake_input_tags()
+
+    return fake_estimator()
 
 
 @pytest.mark.parametrize(
@@ -52,12 +66,10 @@ def test_sklearn_incompatible_learner_fails():
         tabular_pipeline(sklearn_incompatible_learner)
 
 
-def test_no_type_error_for_sklearn_compatible_learner():
+def test_sklearn_compatible_learner_succeeds(monkeypatch):
     sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
-    # Still fails - because this is a dummy class for testing - but not with TypeError
-    with pytest.raises(Exception) as e:
-        tabular_pipeline(sklearn_compatible_learner)
-    assert not isinstance(e.value, TypeError)
+    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
+    _ = tabular_pipeline(sklearn_compatible_learner)
 
 
 def test_linear_learner():

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -36,12 +36,28 @@ def test_bad_learner():
         match=".*should be 'regressor', 'regression', 'classifier' or 'classification'",
     ):
         tabular_pipeline("bad")
-    with pytest.raises(
-        TypeError, match=".*Pass an instance of HistGradientBoostingRegressor"
-    ):
+    with pytest.raises(TypeError, match=".*Pass an instance"):
         tabular_pipeline(ensemble.HistGradientBoostingRegressor)
-    with pytest.raises(TypeError, match=".*expects a scikit-learn estimator"):
+    with pytest.raises(
+        TypeError, match=".*expects a scikit-learn compatible estimator"
+    ):
         tabular_pipeline(object())
+
+
+def test_sklearn_incompatible_learner_fails():
+    sklearn_incompatible_learner = type("", (), {"get_params": 123})()
+    with pytest.raises(
+        TypeError, match=".*expects a scikit-learn compatible estimator"
+    ):
+        tabular_pipeline(sklearn_incompatible_learner)
+
+
+def test_no_type_error_for_sklearn_compatible_learner():
+    sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
+    # Still fails - because this is a dummy class for testing - but not with TypeError
+    with pytest.raises(Exception) as e:
+        tabular_pipeline(sklearn_compatible_learner)
+    assert not isinstance(e.value, TypeError)
 
 
 def test_linear_learner():

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -59,6 +59,8 @@ def test_bad_learner():
 
 
 def test_sklearn_incompatible_learner_fails():
+    """Test that a TypeError is raised when the estimator does not have a
+    `set_params` attribute"""
     sklearn_incompatible_learner = type("", (), {"get_params": 123})()
     with pytest.raises(
         TypeError, match=".*expects a scikit-learn compatible estimator"
@@ -67,6 +69,8 @@ def test_sklearn_incompatible_learner_fails():
 
 
 def test_sklearn_compatible_learner_succeeds(monkeypatch):
+    """Test that no error is raised when the estimate have both `get_params`
+    and `set_params` attributes"""
     sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     _ = tabular_pipeline(sklearn_compatible_learner)
@@ -95,6 +99,8 @@ def test_tree_learner():
 
 
 def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
+    """Test that special treatment for tree ensemble models is applied when
+    substring 'RandomForest' appears in estimator class name"""
     IAmARandomForestEstimator = type(
         "IAmARandomForestEstimator", (), {"get_params": 123, "set_params": 456}
     )
@@ -109,6 +115,8 @@ def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
 
 
 def test_tree_ensemble_treatment_for_xgboost(monkeypatch):
+    """Test that special treatment for tree ensemble models is applied when
+    substring 'XGB' appears in estimator class name"""
     IAmXGB = type("IAmXGB", (), {"get_params": 123, "set_params": 456})
     original_learner = IAmXGB()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -59,6 +59,8 @@ def test_bad_learner():
 
 
 def test_sklearn_incompatible_learner_fails():
+    """Test that a TypeError is raised when the estimator does not have a
+    `set_params` attribute"""
     sklearn_incompatible_learner = type("", (), {"get_params": 123})()
     with pytest.raises(
         TypeError, match=".*expects a scikit-learn compatible estimator"
@@ -67,6 +69,8 @@ def test_sklearn_incompatible_learner_fails():
 
 
 def test_sklearn_compatible_learner_succeeds(monkeypatch):
+    """Test that no error is raised when the estimate have both `get_params`
+    and `set_params` attributes"""
     sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     _ = tabular_pipeline(sklearn_compatible_learner)
@@ -95,6 +99,8 @@ def test_tree_learner():
 
 
 def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
+    """Test that special treatment for tree ensemble models is applied when
+    substring 'RandomForest' appears in estimator class name"""
     IAmARandomForestEstimator = type(
         "IAmARandomForestEstimator", (), {"get_params": 123, "set_params": 456}
     )
@@ -109,10 +115,46 @@ def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
 
 
 def test_tree_ensemble_treatment_for_xgboost(monkeypatch):
+    """Test that special treatment for tree ensemble models is applied when
+    substring 'XGB' appears in estimator class name"""
     IAmXGB = type("IAmXGB", (), {"get_params": 123, "set_params": 456})
     original_learner = IAmXGB()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     p = tabular_pipeline(original_learner)
+    tv, learner = (e for _, e in p.steps)
+    assert learner is original_learner
+    assert isinstance(tv.high_cardinality, StringEncoder)
+    assert isinstance(tv.low_cardinality, OrdinalEncoder)
+    assert tv.datetime.periodic_encoding is None
+
+
+def test_no_tree_ensemble_treatment_for_arbitrary_name(monkeypatch):
+    """Test that special treatment for tree ensemble models is not applied
+    when no relevant substring appears in estimator class name"""
+    NothingToSeeHere = type(
+        "NothingToSeeHere", (), {"get_params": 123, "set_params": 456}
+    )
+    original_learner = NothingToSeeHere()
+    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
+    p = tabular_pipeline(original_learner)
+    tv, scaler, learner = (e for _, e in p.steps)
+    assert learner is original_learner
+    assert isinstance(tv.high_cardinality, StringEncoder)
+    assert isinstance(tv.low_cardinality, OneHotEncoder)
+    assert isinstance(scaler, SquashingScaler)
+    assert tv.datetime.periodic_encoding == "spline"
+
+
+def test_tree_ensemble_treatment_when_requested(monkeypatch):
+    """Test that special treatment for tree ensemble models is applied when
+    called with `is_tree_ensemble_estimator=True`, even when no relevant substring
+    appears in estimator class name"""
+    NothingToSeeHere = type(
+        "NothingToSeeHere", (), {"get_params": 123, "set_params": 456}
+    )
+    original_learner = NothingToSeeHere()
+    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
+    p = tabular_pipeline(original_learner, is_tree_ensemble_estimator=True)
     tv, learner = (e for _, e in p.steps)
     assert learner is original_learner
     assert isinstance(tv.high_cardinality, StringEncoder)

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -20,7 +20,7 @@ def fake_get_tags(_):
     `if not get_tags(estimator).input_tags.allow_nan:` check for tests"""
 
     class fake_input_tags:
-        allow_nan = None
+        allow_nan = True
 
     class fake_estimator:
         input_tags = fake_input_tags()
@@ -86,6 +86,32 @@ def test_linear_learner():
 
 def test_tree_learner():
     original_learner = ensemble.RandomForestClassifier()
+    p = tabular_pipeline(original_learner)
+    tv, learner = (e for _, e in p.steps)
+    assert learner is original_learner
+    assert isinstance(tv.high_cardinality, StringEncoder)
+    assert isinstance(tv.low_cardinality, OrdinalEncoder)
+    assert tv.datetime.periodic_encoding is None
+
+
+def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
+    IAmARandomForestEstimator = type(
+        "IAmARandomForestEstimator", (), {"get_params": 123, "set_params": 456}
+    )
+    original_learner = IAmARandomForestEstimator()
+    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
+    p = tabular_pipeline(original_learner)
+    tv, learner = (e for _, e in p.steps)
+    assert learner is original_learner
+    assert isinstance(tv.high_cardinality, StringEncoder)
+    assert isinstance(tv.low_cardinality, OrdinalEncoder)
+    assert tv.datetime.periodic_encoding is None
+
+
+def test_tree_ensemble_treatment_for_xgboost(monkeypatch):
+    IAmXGB = type("IAmXGB", (), {"get_params": 123, "set_params": 456})
+    original_learner = IAmXGB()
+    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     p = tabular_pipeline(original_learner)
     tv, learner = (e for _, e in p.steps)
     assert learner is original_learner

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -1,11 +1,11 @@
+import numpy as np
+import pandas as pd
 import pytest
 from sklearn import ensemble
-from sklearn.base import BaseEstimator
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import Ridge
 from sklearn.preprocessing import OneHotEncoder, OrdinalEncoder
 
-import skrub._tabular_pipeline
 from skrub import (
     SquashingScaler,
     StringEncoder,
@@ -13,19 +13,6 @@ from skrub import (
     ToCategorical,
     tabular_pipeline,
 )
-
-
-def fake_get_tags(_):
-    """Allows dummy estimators to get past
-    `if not get_tags(estimator).input_tags.allow_nan:` check for tests"""
-
-    class fake_input_tags:
-        allow_nan = True
-
-    class fake_estimator:
-        input_tags = fake_input_tags()
-
-    return fake_estimator()
 
 
 @pytest.mark.parametrize(
@@ -58,22 +45,70 @@ def test_bad_learner():
         tabular_pipeline(object())
 
 
-def test_sklearn_incompatible_learner_fails():
-    """Test that a TypeError is raised when the estimator does not have a
-    `set_params` attribute"""
-    sklearn_incompatible_learner = type("", (), {"get_params": 123})()
+def test_missing_required_attribute():
+    """Test that a TypeError is raised when the estimator does not have one of the
+    attributes required of a scikit learn-compatible estimator"""
+
+    class MissingSetParams:
+        def fit(self, X, y=None):
+            return self
+
+        def predict(self, X):
+            return np.zeros(X.shape[0])
+
+        def get_params(self):
+            return {}
+
     with pytest.raises(
-        TypeError, match=".*expects a scikit-learn compatible estimator"
+        TypeError, match=".*expects a scikit-learn compatible estimator.*set_params"
     ):
-        tabular_pipeline(sklearn_incompatible_learner)
+        tabular_pipeline(MissingSetParams())
 
 
-def test_sklearn_compatible_learner_succeeds(monkeypatch):
+def test_required_attribute_is_not_callable():
+    """Test that a TypeError is raised when the estimator has all of the required
+    attributes, but one of them is not callable"""
+
+    class PredictNotCallable:
+        def fit(self, X, y=None):
+            return self
+
+        predict = 1
+
+        def get_params(self):
+            return {}
+
+        def set_params(self, **params):
+            return self
+
+    with pytest.raises(
+        TypeError, match=".*expects a scikit-learn compatible estimator.*predict"
+    ):
+        tabular_pipeline(PredictNotCallable())
+
+
+class Regressor:
+    """Dummy regressor used for tests"""
+
+    def fit(self, X, y=None):
+        return self
+
+    def predict(self, X):
+        return np.zeros(X.shape[0])
+
+    def get_params(self):
+        return {}
+
+    def set_params(self, **params):
+        return self
+
+
+def test_sklearn_compatible_learner_returns_correct_pipeline():
     """Test that no error is raised when the estimate have both `get_params`
     and `set_params` attributes"""
-    sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
-    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
-    _ = tabular_pipeline(sklearn_compatible_learner)
+    pipeline = tabular_pipeline(Regressor())
+    X = pd.DataFrame({"feature": [1, 2, 3]})
+    pipeline.fit(X)
 
 
 def test_linear_learner():
@@ -98,30 +133,34 @@ def test_tree_learner():
     assert tv.datetime.periodic_encoding is None
 
 
-def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
+def test_tree_ensemble_treatment_for_any_random_forest():
     """Test that special treatment for tree ensemble models is applied when
     substring 'RandomForest' appears in estimator class name"""
-    IAmARandomForestEstimator = type(
-        "IAmARandomForestEstimator", (), {"get_params": 123, "set_params": 456}
-    )
+
+    class IAmARandomForestEstimator(Regressor):
+        pass
+
     original_learner = IAmARandomForestEstimator()
-    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     p = tabular_pipeline(original_learner)
-    tv, learner = (e for _, e in p.steps)
+    _, tv = p.steps[0]
+    _, learner = p.steps[-1]
     assert learner is original_learner
     assert isinstance(tv.high_cardinality, StringEncoder)
     assert isinstance(tv.low_cardinality, OrdinalEncoder)
     assert tv.datetime.periodic_encoding is None
 
 
-def test_tree_ensemble_treatment_for_xgboost(monkeypatch):
+def test_tree_ensemble_treatment_for_xgboost():
     """Test that special treatment for tree ensemble models is applied when
     substring 'XGB' appears in estimator class name"""
-    IAmXGB = type("IAmXGB", (), {"get_params": 123, "set_params": 456})
+
+    class IAmXGB(Regressor):
+        pass
+
     original_learner = IAmXGB()
-    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     p = tabular_pipeline(original_learner)
-    tv, learner = (e for _, e in p.steps)
+    _, tv = p.steps[0]
+    _, learner = p.steps[-1]
     assert learner is original_learner
     assert isinstance(tv.high_cardinality, StringEncoder)
     assert isinstance(tv.low_cardinality, OrdinalEncoder)
@@ -139,13 +178,13 @@ def test_from_dtype():
     assert isinstance(p.named_steps["tablevectorizer"].low_cardinality, ToCategorical)
 
 
-class TabICLClassifier(BaseEstimator):
+class TabICLClassifier(Regressor):
     """Dummy class which pretends to be `tabicl.TabICLClassifier`"""
 
     pass
 
 
-class TabICLRegressor(BaseEstimator):
+class TabICLRegressor(Regressor):
     """Dummy class which pretends to be `tabicl.TabICLRegressor`"""
 
     pass

--- a/skrub/tests/test_tabular_pipeline.py
+++ b/skrub/tests/test_tabular_pipeline.py
@@ -59,8 +59,6 @@ def test_bad_learner():
 
 
 def test_sklearn_incompatible_learner_fails():
-    """Test that a TypeError is raised when the estimator does not have a
-    `set_params` attribute"""
     sklearn_incompatible_learner = type("", (), {"get_params": 123})()
     with pytest.raises(
         TypeError, match=".*expects a scikit-learn compatible estimator"
@@ -69,8 +67,6 @@ def test_sklearn_incompatible_learner_fails():
 
 
 def test_sklearn_compatible_learner_succeeds(monkeypatch):
-    """Test that no error is raised when the estimate have both `get_params`
-    and `set_params` attributes"""
     sklearn_compatible_learner = type("", (), {"get_params": 123, "set_params": 456})()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     _ = tabular_pipeline(sklearn_compatible_learner)
@@ -99,8 +95,6 @@ def test_tree_learner():
 
 
 def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
-    """Test that special treatment for tree ensemble models is applied when
-    substring 'RandomForest' appears in estimator class name"""
     IAmARandomForestEstimator = type(
         "IAmARandomForestEstimator", (), {"get_params": 123, "set_params": 456}
     )
@@ -115,46 +109,10 @@ def test_tree_ensemble_treatment_for_any_random_forest(monkeypatch):
 
 
 def test_tree_ensemble_treatment_for_xgboost(monkeypatch):
-    """Test that special treatment for tree ensemble models is applied when
-    substring 'XGB' appears in estimator class name"""
     IAmXGB = type("IAmXGB", (), {"get_params": 123, "set_params": 456})
     original_learner = IAmXGB()
     monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
     p = tabular_pipeline(original_learner)
-    tv, learner = (e for _, e in p.steps)
-    assert learner is original_learner
-    assert isinstance(tv.high_cardinality, StringEncoder)
-    assert isinstance(tv.low_cardinality, OrdinalEncoder)
-    assert tv.datetime.periodic_encoding is None
-
-
-def test_no_tree_ensemble_treatment_for_arbitrary_name(monkeypatch):
-    """Test that special treatment for tree ensemble models is not applied
-    when no relevant substring appears in estimator class name"""
-    NothingToSeeHere = type(
-        "NothingToSeeHere", (), {"get_params": 123, "set_params": 456}
-    )
-    original_learner = NothingToSeeHere()
-    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
-    p = tabular_pipeline(original_learner)
-    tv, scaler, learner = (e for _, e in p.steps)
-    assert learner is original_learner
-    assert isinstance(tv.high_cardinality, StringEncoder)
-    assert isinstance(tv.low_cardinality, OneHotEncoder)
-    assert isinstance(scaler, SquashingScaler)
-    assert tv.datetime.periodic_encoding == "spline"
-
-
-def test_tree_ensemble_treatment_when_requested(monkeypatch):
-    """Test that special treatment for tree ensemble models is applied when
-    called with `is_tree_ensemble_estimator=True`, even when no relevant substring
-    appears in estimator class name"""
-    NothingToSeeHere = type(
-        "NothingToSeeHere", (), {"get_params": 123, "set_params": 456}
-    )
-    original_learner = NothingToSeeHere()
-    monkeypatch.setattr(skrub._tabular_pipeline, "get_tags", fake_get_tags)
-    p = tabular_pipeline(original_learner, is_tree_ensemble_estimator=True)
     tv, learner = (e for _, e in p.steps)
     assert learner is original_learner
     assert isinstance(tv.high_cardinality, StringEncoder)


### PR DESCRIPTION
# Fix Issue 2114: Accept estimators that don't inherit from sklearn.BaseEstimator in tabular_pipeline

## Description

All suggestions in the issue comments made sense, so I implemented them as specified. There were three main changes:

1. Loosened the requirement for estimator to inherit from sklearn.BaseEstimator

- Per the suggestion in the issue comments, the new implementation is to require a 'scikit-learn compatible' estimator, which is defined as an object that has get_params and set_params attributes
- Check made explicit with `is_scikit_learn_compatible` variable
- `isinstance(estimator, type)` check carried out before `is_scikit_learn_compatible` check since the validity check no longer makes sense for types. Class name no longer included in error message, since it may be displayed even for invalid types. Still serves its purpose of helping the user to spot the mistake.
- Tested (in `test_sklearn_incompatible_learner_fails` and `test_sklearn_incompatible_learner_succeeds`) with dummy classes that define `get_params`/`set_params`.

2. Replaced HGBT and tree ensemble estimator checks with class name-based checks

- Per suggestion in issue comments, replaced specific `isinstance` checks with broader substring match checks to determine need to HGBT/tree ensemble treatment (`HistGradientBoosting`, `RandomForest`)
- This ensures compatibility with libraries that use same class names as scikit-learn (e.g. cuml)
- `XGB` and `LGBM` included in substrings for tree ensemble check, for compatibility with xgboost and lightgbm libraries
- Checks are made explicit (`_is_hgbt_estimator`, `_is_tree_ensemble_estimator`)
- Existing tests pass with no modifications. 
- Added tests for tree ensemble treatment for dummy classes with `RandomForest`/`XGB` in their names

3. Added parameters to allow the caller to request tree ensemble/HBGT treatment, overriding default heuristics

- Added `is_hgbt_estimator`/`is_tree_ensemble_estimator` parameters, per the suggestion in the issue comments
- Explained in docstrings that default heuristics still apply and will work in most cases, but that these parameters can be used for overrides
- Added test to verify that `is_tree_ensemble_estimator` results in tree ensemble treatment in a case where this would not be triggered by the default heuristic

Addresses #2114

## Checklist

- [ X ] I have read the contributing guidelines
- [ X ] I have added tests that verify the bug fix
- [ X ] I have added an entry to CHANGES.rst describing the fix
- [ X ] My code follows the code style of this project
- [ X ] I have checked my code and corrected any misspellings

## How Has This Been Tested?

All existing and new tests in test_tabular_pipeline.py
(+ entire test suite)

## AI Disclosure

- [ X ] This PR contains AI-generated code
    - [ X ] I have tested the code generated in my PR
    - [ X ] I have read and understood every line that has been generated by the AI agent
    - [ X ] I can explain what the AI-generated code does