### PR TITLE
Fix GapEncoder(init="k-means") crash on columns containing nulls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,9 @@ Bugfixes
 - The parallel coordinate plot created by :meth:`ParamSearch.show_results` could
   have incorrect tick labels in some cases. This has been fixed in :pr:`2215` by
   :user:`Jérôme Dockès <jeromedockes>`.
+- :class:`GapEncoder` with ``init="k-means"`` raised an error when the input
+  column contained missing values. This has been fixed in :pr:`2238` by
+  :user:`Achraf Ez <Hrafz>`.
 
 Deprecations
 ------------

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -269,7 +269,7 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
                 )
         _, self.n_vocab = unq_V.shape
         # Init the topics W given the n-grams counts V
-        self.W_, self.A_, self.B_ = self._init_w(unq_V[lookup], X)
+        self.W_, self.A_, self.B_ = self._init_w(unq_V[lookup], unq_X[lookup])
         # Init the activations unq_H of each unique input string
         unq_H = _rescale_h(unq_V, np.ones((len(unq_X), self.n_components)))
         # Update self.H_dict_ with unique input strings and their activations

--- a/skrub/tests/test_gap_encoder.py
+++ b/skrub/tests/test_gap_encoder.py
@@ -217,7 +217,8 @@ def test_score(generate_data):
     assert score_1 == score_2
 
 
-def test_missing_values(df_module):
+@pytest.mark.parametrize("init", ["k-means++", "random", "k-means"])
+def test_missing_values(df_module, init):
     """Test what happens when missing values are in the data."""
     if df_module.name == "pandas":
         m1, m2 = pd.NA, np.nan
@@ -225,7 +226,7 @@ def test_missing_values(df_module):
         m1, m2 = None, None
     observations = ["alice", "bob", None, "alice", m1, m2]
     observations = df_module.make_column("", observations)
-    enc = GapEncoder(n_components=3)
+    enc = GapEncoder(n_components=3, init=init)
     enc.fit_transform(observations)
     enc.transform(observations)
     enc.partial_fit(observations)


### PR DESCRIPTION
Addresses issue  
https://github.com/skrub-data/skrub/issues/2237

## Description

`GapEncoder(init="k-means")` crashes on any column containing a missing
value, while the two other `init` options fit the same column fine:

```python
import pandas as pd
from skrub import GapEncoder

s = pd.Series(["alice", "bob", None, "alice", pd.NA, float("nan")], name="s")

GapEncoder(n_components=3, init="k-means++").fit_transform(s)  # OK
GapEncoder(n_components=3, init="random").fit_transform(s)     # OK
GapEncoder(n_components=3, init="k-means").fit_transform(s)
# AttributeError: 'NAType' object has no attribute 'lower'
```

Expected: `init="k-means"` handles the column's nulls the same way the other
two `init` options do (nulls are treated as the empty string throughout
`GapEncoder`, see `skrub._utils.unique_strings` and the existing
`test_missing_values`).

Actual: it raises from scikit-learn's text preprocessor. The exception type
depends on the column's dtype rather than on which sentinel appears first:

| column | `init="k-means"` raises |
|---|---|
| object dtype containing `np.nan` | `ValueError: np.nan is an invalid document, expected byte or unicode string.` |
| object dtype containing `None` | `ValueError: np.nan is an invalid document, expected byte or unicode string.` |
| `string` dtype containing `pd.NA` | `AttributeError: 'NAType' object has no attribute 'lower'` |

`init="k-means++"` and `init="random"` fit all three without error.

Cause: `_init_vars` builds the null-substituted array `unq_X` via
`unique_strings(X, is_null)` and uses it everywhere else in the method, but
was calling `self._init_w(unq_V[lookup], X)` with the raw `X` (still
containing the original null). Only the `"k-means"` branch touches `X`
directly — it re-vectorizes it from scratch inside `get_kmeans_prototypes`,
which is where the null reaches the preprocessor. `"k-means++"` and
`"random"` only ever consume the already-vectorized `V`.

Fix: pass `unq_X[lookup]` instead of `X` — the same null-substituted,
per-sample reconstruction already used throughout the rest of the method.
When there are no nulls, `unq_X[lookup] == X`, so this is a no-op for the
common case.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

`test_missing_values` is now parametrized over `init`, so it also exercises
`"k-means"` (previously only the default `"k-means++"`).

Before the fix (test change only, source untouched):
```
skrub/tests/test_gap_encoder.py::test_missing_values[pandas-numpy-dtypes-k-means] FAILED
skrub/tests/test_gap_encoder.py::test_missing_values[pandas-nullable-dtypes-k-means] FAILED
2 failed, 4 passed, 44 deselected
```

After the fix:
```
skrub/tests/test_gap_encoder.py -q
50 passed
```

The full `skrub/tests` suite passes with no failures and no change in the
skipped/xfailed/xpassed counts beyond the newly-passing parametrizations.
