### PR TITLE
Fix UnboundLocalError in DatetimeEncoder(resolution=None, periodic_encoding=...)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,11 @@ Bugfixes
 - :class:`GapEncoder` with ``init="k-means"`` raised an error when the input
   column contained missing values. This has been fixed in :pr:`2238` by
   :user:`Achraf Ez <Hrafz>`.
+- :class:`DatetimeEncoder` no longer raises ``UnboundLocalError`` when
+  ``resolution=None`` is combined with ``periodic_encoding="circular"`` or
+  ``"spline"``, and no longer fits an unused ``weekday`` periodic encoder when
+  ``resolution`` is finer than ``"hour"``. :pr:`2240` by
+  :user:`Achraf Ez <Hrafz>`.
 
 Deprecations
 ------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ Bugfixes
 - The parallel coordinate plot created by :meth:`ParamSearch.show_results` could
   have incorrect tick labels in some cases. This has been fixed in :pr:`2215` by
   :user:`Jérôme Dockès <jeromedockes>`.
+- :class:`DatetimeEncoder` no longer raises ``UnboundLocalError`` when
+  ``resolution=None`` is combined with ``periodic_encoding="circular"`` or
+  ``"spline"``, and no longer fits an unused ``weekday`` periodic encoder when
+  ``resolution`` is finer than ``"hour"``. :pr:`2240` by
+  :user:`Achraf Ez <Hrafz>`.
 
 Deprecations
 ------------

--- a/skrub/_datetime_encoder.py
+++ b/skrub/_datetime_encoder.py
@@ -398,9 +398,11 @@ class DatetimeEncoder(SingleColumnTransformer):
         # Adding transformers for periodic encoding
         self._periodic_encoders = {}
         if self.periodic_encoding is not None:
-            encoding_levels = list(_DEFAULT_ENCODING_PERIODS.keys())[0:idx_level]
-            if self.add_weekday:
-                encoding_levels += ["weekday"]
+            encoding_levels = [
+                feature
+                for feature in self.extracted_features_
+                if feature in _DEFAULT_ENCODING_PERIODS
+            ]
             for enc_feature in encoding_levels:
                 if self.periodic_encoding == "circular":
                     self._periodic_encoders[enc_feature] = _CircularEncoder(

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -8,6 +8,7 @@ from skrub import ApplyToCols, DatetimeEncoder
 from skrub import _dataframe as sbd
 from skrub import selectors as s
 from skrub._datetime_encoder import (
+    _TIME_LEVELS,
     _CircularEncoder,
     _get_dt_feature,
     _is_date,
@@ -293,6 +294,22 @@ def test_extracted_features_choice(datetime_cols, params, extracted_features):
                 "weekday_circular_1",
             ],
         ),
+        (
+            dict(
+                resolution=None,
+                periodic_encoding="circular",
+            ),
+            ["total_seconds"],
+        ),
+        (
+            dict(
+                resolution=None,
+                add_weekday=True,
+                add_total_seconds=False,
+                periodic_encoding="circular",
+            ),
+            ["weekday_circular_0", "weekday_circular_1"],
+        ),
     ],
 )
 def test_all_outputs_choice(datetime_cols, params, all_outputs):
@@ -301,6 +318,27 @@ def test_all_outputs_choice(datetime_cols, params, all_outputs):
     assert enc.all_outputs_ == [f"when_{f}" for f in all_outputs]
     assert enc.get_feature_names_out() == [f"when_{f}" for f in all_outputs]
     assert sbd.column_names(res) == [f"{f}" for f in enc.all_outputs_]
+
+
+@pytest.mark.parametrize("periodic_encoding", ["circular", "spline"])
+@pytest.mark.parametrize("resolution", [*_TIME_LEVELS, None])
+def test_periodic_encoders_match_extracted_features(
+    datetime_cols, resolution, periodic_encoding
+):
+    # A periodic encoder is only ever applied to a feature that was extracted, so
+    # fitting one for any other feature is wasted work. The levels to encode are
+    # therefore taken from ``extracted_features_``; deriving them by slicing
+    # ``_DEFAULT_ENCODING_PERIODS`` with an index into ``_TIME_LEVELS`` does not work,
+    # because the two are not ordered the same.
+    for column in (datetime_cols.datetime, datetime_cols.date):
+        for add_weekday in (False, True):
+            enc = DatetimeEncoder(
+                resolution=resolution,
+                periodic_encoding=periodic_encoding,
+                add_weekday=add_weekday,
+            )
+            enc.fit(column)
+            assert set(enc._periodic_encoders) <= set(enc.extracted_features_)
 
 
 def test_time_not_extracted_from_date_col(datetime_cols):

--- a/skrub/tests/test_datetime_encoder.py
+++ b/skrub/tests/test_datetime_encoder.py
@@ -325,11 +325,11 @@ def test_all_outputs_choice(datetime_cols, params, all_outputs):
 def test_periodic_encoders_match_extracted_features(
     datetime_cols, resolution, periodic_encoding
 ):
-    # A periodic encoder is only ever applied to a feature that was extracted, so
-    # fitting one for any other feature is wasted work. The levels to encode are
-    # therefore taken from ``extracted_features_``; deriving them by slicing
-    # ``_DEFAULT_ENCODING_PERIODS`` with an index into ``_TIME_LEVELS`` does not work,
-    # because the two are not ordered the same.
+    # A periodic encoder is only ever applied to a feature that was extracted, so we
+    # check that no unnecessary features are encoded. The levels to encode are
+    # therefore taken from ``extracted_features_``. When ``resolution`` is ``None``,
+    # the only periodic feature that should be encoded is ``weekday`` if the flag is
+    # set.
     for column in (datetime_cols.datetime, datetime_cols.date):
         for add_weekday in (False, True):
             enc = DatetimeEncoder(


### PR DESCRIPTION
# Bug Fix Pull Request

## Description

Fixes https://github.com/skrub-data/skrub/issues/2239

`DatetimeEncoder(resolution=None, periodic_encoding="circular")` raises `UnboundLocalError` instead of transforming:

```python
import pandas as pd
from skrub import DatetimeEncoder

s = pd.to_datetime(pd.Series(["2024-04-14", "2024-05-15"], name="birthday"))
DatetimeEncoder(resolution=None, periodic_encoding="circular").fit_transform(s)
```

```
Traceback (most recent call last):
  File ".../skrub/_datetime_encoder.py", line 401, in fit_transform
    encoding_levels = list(_DEFAULT_ENCODING_PERIODS.keys())[0:idx_level]
                                                               ^^^^^^^^^
UnboundLocalError: cannot access local variable 'idx_level' where it is not associated with a value
```

`periodic_encoding="spline"` fails the same way. `resolution=None` and `periodic_encoding` are each documented and accepted by `_check_params`, so this is a reachable crash on a valid call, not a rejected combination.

### Cause

`encoding_levels` is built by slicing `_DEFAULT_ENCODING_PERIODS` with `idx_level`, which is an index into `_TIME_LEVELS`. `idx_level` is only assigned in the `else` branch of `if self.resolution is None`, hence the crash.

That coupling has a second consequence. The two collections are not ordered the same:

```python
_TIME_LEVELS              = ["year", "month", "day", "hour", "minute", "second", "microsecond", "nanosecond"]
_DEFAULT_ENCODING_PERIODS = {"month": 12, "day": 30, "hour": 24, "weekday": 7}
```

They line up only for `idx_level <= 3`. Any resolution finer than `"hour"` reaches the 4th key, `"weekday"`, and fits a weekday encoder even when `add_weekday=False`:

| `resolution` | `idx_level` | encoders fitted | in `extracted_features_`? |
|---|---|---|---|
| `hour` | 3 | `month, day, hour` | all |
| `minute` | 4 | `month, day, hour, weekday` | weekday is not |
| `second` and finer | 5+ | `month, day, hour, weekday` | weekday is not |

The output is unaffected — `transform` iterates `extracted_features_`, so the weekday encoder is never reached — but it is fitted, and for `periodic_encoding="spline"` that is a `SplineTransformer` fit that is then discarded. Thanks to @Sanjays2402 for pointing this out on the first version of this PR.

### Fix

Build `encoding_levels` from `extracted_features_`, keeping the features that have a defined period:

```python
encoding_levels = [
    feature
    for feature in self.extracted_features_
    if feature in _DEFAULT_ENCODING_PERIODS
]
```

This removes the index coupling rather than working around it, and fixes both symptoms at once: nothing reads `idx_level` outside the branch that assigns it, and only extracted features get an encoder. The explicit `add_weekday` append is no longer needed, since `"weekday"` is in `extracted_features_` exactly when it is requested — which also removes a duplicate entry in the `resolution` finer than `"hour"` plus `add_weekday=True` case.

Source diff is 3 lines removed, 5 added.

After the fix:

```python
>>> DatetimeEncoder(resolution=None, periodic_encoding="circular").fit_transform(s)
   birthday_total_seconds
0            1.713053e+09
1            1.715731e+09
```

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

**Behavioural diff over the full documented parameter grid.** 2 column dtypes × 9 `resolution` values × 3 `periodic_encoding` values × `add_weekday` × `add_day_of_year` × `add_total_seconds` = 432 combinations, recorded on `main` and on this branch and compared:

- 32 raised `UnboundLocalError` on `main` and now return a frame
- 32 fitted an unused weekday encoder on `main` and no longer do
- the remaining 368 are unchanged
- **no column set and no output value changed anywhere in the grid**

**Tests added.** Two cases in the existing `test_all_outputs_choice` parametrization cover the crash — plain `resolution=None` with `periodic_encoding="circular"`, and the same with `add_weekday=True`, which pins that weekday periodic encoding still works under `resolution=None` rather than a plausible-but-wrong fix that skips periodic encoding entirely.

`test_periodic_encoders_match_extracted_features` asserts the invariant this fix restores — every fitted periodic encoder corresponds to an extracted feature — over every resolution and both encodings, for date and datetime columns, with `add_weekday` both ways.

On unmodified `main` the new tests fail 30 times: 6 with the `UnboundLocalError` and 24 on the weekday assertion at `minute`, `second`, `microsecond` and `nanosecond`.

**Suites.** `skrub/tests/test_datetime_encoder.py`: 185 passed on this branch.

`pytest -q skrub/tests skrub/_dataframe/tests --ignore=skrub/tests/test_docstrings.py` (the excluded module needs an optional dependency I do not have installed):

| | |
|---|---|
| `main` | 2014 passed, 57 skipped, 9 xfailed, 62 xpassed |
| this branch | 2074 passed, 57 skipped, 9 xfailed, 62 xpassed |

+60 passed, matching the new parametrizations; no other status changed.

`ruff check`, `ruff format --check` and `codespell` on the changed files: clean.
