### PR TITLE
Add CategoricalEncoder combining OneHotEncoder and TargetEncoder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Release 0.10.0
 
 New Features
 ------------
+- Added :class:`CategoricalEncoder`, a single column transformer that combines
+  :class:`~sklearn.preprocessing.OneHotEncoder` and
+  :class:`~sklearn.preprocessing.TargetEncoder`.
+  :issue:`2065` by :user:`Tomasz <faithlesstomas@gmail.com>`.
 
 Changes
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ New Features
 - Added :class:`CategoricalEncoder`, a single column transformer that combines
   :class:`~sklearn.preprocessing.OneHotEncoder` and
   :class:`~sklearn.preprocessing.TargetEncoder`.
-  :issue:`2065` by :user:`Tomasz <faithlesstomas@gmail.com>`.
+  :pr:`2244` by :user:`Tomasz Kazimierczak <faithlesstomas>`.
 
 Changes
 -------

--- a/doc/api_reference.py
+++ b/doc/api_reference.py
@@ -83,6 +83,7 @@ API_REFERENCE = {
                     " details."
                 ),
                 "autosummary": [
+                    "CategoricalEncoder",
                     "StringEncoder",
                     "TextEncoder",
                     "MinHashEncoder",

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -37,6 +37,7 @@ from ._data_ops import (
     var,
     y,
 )
+from ._categorical_encoder import CategoricalEncoder
 from ._datetime_encoder import DatetimeEncoder
 from ._deduplicate import deduplicate
 from ._drop_similar import DropSimilar
@@ -78,6 +79,7 @@ __all__ = [
     "TableReport",
     "tabular_pipeline",
     "ApplyToCols",
+    "CategoricalEncoder",
     "DatetimeEncoder",
     "DurationToFloat",
     "ToDatetime",

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -17,6 +17,7 @@ from pathlib import Path as _Path
 from . import core, selectors
 from ._agg_joiner import AggJoiner, AggTarget
 from ._apply_to_cols import ApplyToCols
+from ._categorical_encoder import CategoricalEncoder
 from ._column_associations import column_associations
 from ._config import config_context, get_config, set_config
 from ._data_ops import (
@@ -37,7 +38,6 @@ from ._data_ops import (
     var,
     y,
 )
-from ._categorical_encoder import CategoricalEncoder
 from ._datetime_encoder import DatetimeEncoder
 from ._deduplicate import deduplicate
 from ._drop_similar import DropSimilar

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -107,14 +107,20 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         X_pandas = sbd.to_pandas(column).to_frame()
 
         if sbd.is_dataframe(y):
-            y_pandas = sbd.to_pandas(sbd.col_by_idx(y, 0))
-        elif sbd.is_column(y):
-            y_pandas = sbd.to_pandas(y)
+            y_col = sbd.col_by_idx(y, 0)
         else:
-            y_pandas = y
+            y_col = y
+
+        if sbd.is_column(y_col):
+            y_vec = sbd.to_numpy(y_col)
+        else:
+            y_vec = np.asarray(y_col)
+
+        if y_vec.ndim > 1:
+            y_vec = y_vec.ravel()
 
         ohe_res = self.one_hot_encoder_.fit_transform(X_pandas)
-        te_res = self.target_encoder_.fit_transform(X_pandas, y_pandas)
+        te_res = self.target_encoder_.fit_transform(X_pandas, y_vec)
 
         if hasattr(ohe_res, "toarray"):
             ohe_res = ohe_res.toarray()

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -87,9 +87,7 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
             DataFrame containing one-hot and target-encoded features.
         """
         if y is None:
-            raise ValueError(
-                "Target y must be provided to fit CategoricalEncoder."
-            )
+            raise ValueError("Target y must be provided to fit CategoricalEncoder.")
 
         if self.one_hot_encoder is None:
             self.one_hot_encoder_ = OneHotEncoder(
@@ -123,9 +121,7 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         if te_res.ndim == 1:
             te_res = te_res.reshape(-1, 1)
 
-        ohe_names = list(
-            self.one_hot_encoder_.get_feature_names_out([col_name])
-        )
+        ohe_names = list(self.one_hot_encoder_.get_feature_names_out([col_name]))
         te_names = list(self.target_encoder_.get_feature_names_out([col_name]))
 
         ohe_df = sbd.make_dataframe_like(column, dict(zip(ohe_names, ohe_res.T)))
@@ -151,9 +147,7 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         res_df : Pandas or Polars DataFrame
             Transformed features.
         """
-        check_is_fitted(
-            self, ["one_hot_encoder_", "target_encoder_", "all_outputs_"]
-        )
+        check_is_fitted(self, ["one_hot_encoder_", "target_encoder_", "all_outputs_"])
 
         X_pandas = sbd.to_pandas(column).to_frame()
 

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -119,6 +119,12 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         if y_vec.ndim > 1:
             y_vec = y_vec.ravel()
 
+        if y_vec.dtype == object:
+            try:
+                y_vec = y_vec.astype(float)
+            except (ValueError, TypeError):
+                pass
+
         ohe_res = self.one_hot_encoder_.fit_transform(X_pandas)
         te_res = self.target_encoder_.fit_transform(X_pandas, y_vec)
 

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -1,0 +1,184 @@
+"""
+Implementation of CategoricalEncoder combining OneHotEncoder and TargetEncoder.
+"""
+
+import numpy as np
+from sklearn.base import TransformerMixin, clone
+from sklearn.preprocessing import OneHotEncoder, TargetEncoder
+from sklearn.utils.validation import check_is_fitted
+
+from . import _dataframe as sbd
+from ._single_column_transformer import SingleColumnTransformer
+
+__all__ = ["CategoricalEncoder"]
+
+
+class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
+    """Encode a single categorical column combining OneHotEncoder and TargetEncoder.
+
+    This transformer applies a :class:`~sklearn.preprocessing.OneHotEncoder`
+    to encode frequent categories into binary one-hot columns, and a
+    :class:`~sklearn.preprocessing.TargetEncoder` to target-encode the column.
+
+    Parameters
+    ----------
+    max_categories : int or None, default=10
+        Maximum number of categories for the ``OneHotEncoder``. If there are more
+        categories, the remaining ones are grouped into an infrequent category.
+        Ignored if a custom ``one_hot_encoder`` is provided.
+
+    one_hot_encoder : OneHotEncoder instance or None, default=None
+        Custom ``OneHotEncoder`` instance to use. If ``None``, a default
+        ``OneHotEncoder(max_categories=max_categories, sparse_output=False,
+        handle_unknown="ignore")`` will be used.
+
+    target_encoder : TargetEncoder instance or None, default=None
+        Custom ``TargetEncoder`` instance to use. If ``None``, a default
+        ``TargetEncoder()`` will be used.
+
+    Attributes
+    ----------
+    one_hot_encoder_ : OneHotEncoder
+        The fitted ``OneHotEncoder`` instance.
+
+    target_encoder_ : TargetEncoder
+        The fitted ``TargetEncoder`` instance.
+
+    all_outputs_ : list of str
+        The list of feature names created by the transformer.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from skrub._categorical_encoder import CategoricalEncoder
+    >>> s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
+    >>> y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+    >>> enc = CategoricalEncoder(max_categories=3)
+    >>> enc.fit_transform(s, y)
+       col_a  col_d  col_infrequent_sklearn  col
+    0    1.0    0.0                     0.0  ...
+    1    0.0    0.0                     1.0  ...
+    """
+
+    def __init__(self, max_categories=10, one_hot_encoder=None, target_encoder=None):
+        self.max_categories = max_categories
+        self.one_hot_encoder = one_hot_encoder
+        self.target_encoder = target_encoder
+
+    def fit_transform(self, column, y=None):
+        """Fit the encoder and transform a categorical column.
+
+        Parameters
+        ----------
+        column : Pandas or Polars Series
+            The single column to transform.
+
+        y : Pandas or Polars Series, DataFrame, or array-like
+            Target values for target encoding.
+
+        Returns
+        -------
+        res_df : Pandas or Polars DataFrame
+            DataFrame containing one-hot and target-encoded features.
+        """
+        if y is None:
+            raise ValueError(
+                "Target y must be provided to fit CategoricalEncoder."
+            )
+
+        if self.one_hot_encoder is None:
+            self.one_hot_encoder_ = OneHotEncoder(
+                max_categories=self.max_categories,
+                sparse_output=False,
+                handle_unknown="ignore",
+            )
+        else:
+            self.one_hot_encoder_ = clone(self.one_hot_encoder)
+
+        if self.target_encoder is None:
+            self.target_encoder_ = TargetEncoder()
+        else:
+            self.target_encoder_ = clone(self.target_encoder)
+
+        col_name = sbd.name(column) or "categorical_enc"
+        X_frame = sbd.to_frame(column)
+        X_pandas = sbd.to_pandas(X_frame)
+
+        if sbd.is_dataframe(y) or sbd.is_column(y):
+            y_pandas = sbd.to_pandas(y)
+        else:
+            y_pandas = y
+
+        ohe_res = self.one_hot_encoder_.fit_transform(X_pandas)
+        te_res = self.target_encoder_.fit_transform(X_pandas, y_pandas)
+
+        if hasattr(ohe_res, "toarray"):
+            ohe_res = ohe_res.toarray()
+        if te_res.ndim == 1:
+            te_res = te_res.reshape(-1, 1)
+
+        ohe_names = list(
+            self.one_hot_encoder_.get_feature_names_out([col_name])
+        )
+        te_names = list(self.target_encoder_.get_feature_names_out([col_name]))
+
+        ohe_df = sbd.make_dataframe_like(column, dict(zip(ohe_names, ohe_res.T)))
+        ohe_df = sbd.copy_index(column, ohe_df)
+
+        te_df = sbd.make_dataframe_like(column, dict(zip(te_names, te_res.T)))
+        te_df = sbd.copy_index(column, te_df)
+
+        res_df = sbd.concat(ohe_df, te_df, axis=1)
+        self.all_outputs_ = list(sbd.column_names(res_df))
+        return res_df
+
+    def transform(self, column):
+        """Transform a single column using fitted OneHotEncoder and TargetEncoder.
+
+        Parameters
+        ----------
+        column : Pandas or Polars Series
+            The column to transform.
+
+        Returns
+        -------
+        res_df : Pandas or Polars DataFrame
+            Transformed features.
+        """
+        check_is_fitted(
+            self, ["one_hot_encoder_", "target_encoder_", "all_outputs_"]
+        )
+
+        X_frame = sbd.to_frame(column)
+        X_pandas = sbd.to_pandas(X_frame)
+
+        ohe_res = self.one_hot_encoder_.transform(X_pandas)
+        te_res = self.target_encoder_.transform(X_pandas)
+
+        if hasattr(ohe_res, "toarray"):
+            ohe_res = ohe_res.toarray()
+        if te_res.ndim == 1:
+            te_res = te_res.reshape(-1, 1)
+
+        combined_res = np.hstack([ohe_res, te_res])
+        res_df = sbd.make_dataframe_like(
+            column, dict(zip(self.all_outputs_, combined_res.T))
+        )
+        res_df = sbd.copy_index(column, res_df)
+        return res_df
+
+    def get_feature_names_out(self, input_features=None):
+        """Return the names of all generated output features.
+
+        Parameters
+        ----------
+        input_features : array-like of str or None, default=None
+            Ignored.
+
+        Returns
+        -------
+        list of str
+            Feature names generated by the encoder.
+        """
+        check_is_fitted(self, "all_outputs_")
+        return self.all_outputs_

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -60,7 +60,12 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
     1    0.0    0.0                     1.0  ...
     """
 
-    def __init__(self, max_categories=10, one_hot_encoder=None, target_encoder=None):
+    def __init__(
+        self,
+        max_categories=10,
+        one_hot_encoder=None,
+        target_encoder=None,
+    ):
         self.max_categories = max_categories
         self.one_hot_encoder = one_hot_encoder
         self.target_encoder = target_encoder
@@ -101,10 +106,11 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
             self.target_encoder_ = clone(self.target_encoder)
 
         col_name = sbd.name(column) or "categorical_enc"
-        X_frame = sbd.to_frame(column)
-        X_pandas = sbd.to_pandas(X_frame)
+        X_pandas = sbd.to_pandas(column).to_frame()
 
-        if sbd.is_dataframe(y) or sbd.is_column(y):
+        if sbd.is_dataframe(y):
+            y_pandas = sbd.to_pandas(sbd.col_by_idx(y, 0))
+        elif sbd.is_column(y):
             y_pandas = sbd.to_pandas(y)
         else:
             y_pandas = y
@@ -149,8 +155,7 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
             self, ["one_hot_encoder_", "target_encoder_", "all_outputs_"]
         )
 
-        X_frame = sbd.to_frame(column)
-        X_pandas = sbd.to_pandas(X_frame)
+        X_pandas = sbd.to_pandas(column).to_frame()
 
         ohe_res = self.one_hot_encoder_.transform(X_pandas)
         te_res = self.target_encoder_.transform(X_pandas)

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -34,7 +34,10 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
 
     target_encoder : TargetEncoder instance or None, default=None
         Custom ``TargetEncoder`` instance to use. If ``None``, a default
-        ``TargetEncoder()`` will be used.
+        ``TargetEncoder()`` will be used. Depending on the installed scikit-learn
+        version and its cross-validation defaults, repeated calls to
+        ``fit_transform`` may produce different encodings. Pass a configured
+        ``TargetEncoder`` to control the cross-validation strategy.
 
     Attributes
     ----------
@@ -44,13 +47,20 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
     target_encoder_ : TargetEncoder
         The fitted ``TargetEncoder`` instance.
 
+    one_hot_outputs_ : list of str
+        Feature names created by the one-hot encoder.
+
+    target_outputs_ : list of str
+        Feature names created by the target encoder. Deterministic ``_target``
+        suffixes are added when names would collide with one-hot features.
+
     all_outputs_ : list of str
         The list of feature names created by the transformer.
 
     Examples
     --------
     >>> import pandas as pd
-    >>> from skrub._categorical_encoder import CategoricalEncoder
+    >>> from skrub import CategoricalEncoder
     >>> s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
     >>> y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
     >>> enc = CategoricalEncoder(max_categories=3)
@@ -107,6 +117,11 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         X_pandas = sbd.to_pandas(column).to_frame()
 
         if sbd.is_dataframe(y):
+            if sbd.shape(y)[1] != 1:
+                raise ValueError(
+                    "CategoricalEncoder expects y to contain exactly one column; "
+                    f"got {sbd.shape(y)[1]}."
+                )
             y_col = sbd.col_by_idx(y, 0)
         else:
             y_col = y
@@ -116,8 +131,13 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         else:
             y_vec = np.asarray(y_col)
 
-        if y_vec.ndim > 1:
-            y_vec = y_vec.ravel()
+        if y_vec.ndim == 2 and y_vec.shape[1] == 1:
+            y_vec = y_vec[:, 0]
+        elif y_vec.ndim != 1:
+            raise ValueError(
+                "CategoricalEncoder expects y to be one-dimensional or a "
+                f"single-column dataframe; got an array with shape {y_vec.shape}."
+            )
 
         if y_vec.dtype == object:
             try:
@@ -131,16 +151,15 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         if hasattr(ohe_res, "toarray"):
             ohe_res = ohe_res.toarray()
 
-        ohe_names = list(self.one_hot_encoder_.get_feature_names_out([col_name]))
-        te_names = list(self.target_encoder_.get_feature_names_out([col_name]))
+        self.one_hot_outputs_ = list(
+            self.one_hot_encoder_.get_feature_names_out([col_name])
+        )
+        target_outputs = list(self.target_encoder_.get_feature_names_out([col_name]))
+        self.target_outputs_ = _make_target_names_unique(
+            target_outputs, self.one_hot_outputs_
+        )
 
-        ohe_df = sbd.make_dataframe_like(column, dict(zip(ohe_names, ohe_res.T)))
-        ohe_df = sbd.copy_index(column, ohe_df)
-
-        te_df = sbd.make_dataframe_like(column, dict(zip(te_names, te_res.T)))
-        te_df = sbd.copy_index(column, te_df)
-
-        res_df = sbd.concat(ohe_df, te_df, axis=1)
+        res_df = self._make_output(column, ohe_res, te_res)
         self.all_outputs_ = list(sbd.column_names(res_df))
         return res_df
 
@@ -157,7 +176,16 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         res_df : Pandas or Polars DataFrame
             Transformed features.
         """
-        check_is_fitted(self, ["one_hot_encoder_", "target_encoder_", "all_outputs_"])
+        check_is_fitted(
+            self,
+            [
+                "one_hot_encoder_",
+                "target_encoder_",
+                "one_hot_outputs_",
+                "target_outputs_",
+                "all_outputs_",
+            ],
+        )
 
         X_pandas = sbd.to_pandas(column).to_frame()
 
@@ -167,12 +195,21 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         if hasattr(ohe_res, "toarray"):
             ohe_res = ohe_res.toarray()
 
-        combined_res = np.hstack([ohe_res, te_res])
-        res_df = sbd.make_dataframe_like(
-            column, dict(zip(self.all_outputs_, combined_res.T))
+        return self._make_output(column, ohe_res, te_res)
+
+    def _make_output(self, column, ohe_res, te_res):
+        """Build the output without coercing the encoders' individual dtypes."""
+        ohe_df = sbd.make_dataframe_like(
+            column, dict(zip(self.one_hot_outputs_, ohe_res.T))
         )
-        res_df = sbd.copy_index(column, res_df)
-        return res_df
+        ohe_df = sbd.copy_index(column, ohe_df)
+
+        te_df = sbd.make_dataframe_like(
+            column, dict(zip(self.target_outputs_, te_res.T))
+        )
+        te_df = sbd.copy_index(column, te_df)
+
+        return sbd.concat(ohe_df, te_df, axis=1)
 
     def get_feature_names_out(self, input_features=None):
         """Return the names of all generated output features.
@@ -189,3 +226,19 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
         """
         check_is_fitted(self, "all_outputs_")
         return self.all_outputs_
+
+
+def _make_target_names_unique(target_names, one_hot_names):
+    """Make target-encoded names unique with deterministic suffixes."""
+    used_names = set(one_hot_names)
+    unique_names = []
+    for name in target_names:
+        candidate = name
+        suffix_idx = 1
+        while candidate in used_names:
+            suffix = "target" if suffix_idx == 1 else f"target_{suffix_idx}"
+            candidate = f"{name}_{suffix}"
+            suffix_idx += 1
+        unique_names.append(candidate)
+        used_names.add(candidate)
+    return unique_names

--- a/skrub/_categorical_encoder.py
+++ b/skrub/_categorical_encoder.py
@@ -130,8 +130,6 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
 
         if hasattr(ohe_res, "toarray"):
             ohe_res = ohe_res.toarray()
-        if te_res.ndim == 1:
-            te_res = te_res.reshape(-1, 1)
 
         ohe_names = list(self.one_hot_encoder_.get_feature_names_out([col_name]))
         te_names = list(self.target_encoder_.get_feature_names_out([col_name]))
@@ -168,8 +166,6 @@ class CategoricalEncoder(TransformerMixin, SingleColumnTransformer):
 
         if hasattr(ohe_res, "toarray"):
             ohe_res = ohe_res.toarray()
-        if te_res.ndim == 1:
-            te_res = te_res.reshape(-1, 1)
 
         combined_res = np.hstack([ohe_res, te_res])
         res_df = sbd.make_dataframe_like(

--- a/skrub/tests/test_categorical_encoder.py
+++ b/skrub/tests/test_categorical_encoder.py
@@ -8,39 +8,20 @@ from skrub import ApplyToCols, CategoricalEncoder
 from skrub import _dataframe as sbd
 
 
-def test_categorical_encoder_pandas(df_module):
-    s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
-    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+def test_categorical_encoder(df_module):
+    s = df_module.make_column("col", ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"])
+    y = df_module.make_column("target", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
 
     enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
     res = enc.fit_transform(s, y)
 
     expected_names = ["col_a", "col_d", "col_infrequent_sklearn", "col"]
-    assert sbd.is_dataframe(res)
-    assert len(res) == len(s)
+    assert sbd.shape(res) == (10, 4)
     assert enc.get_feature_names_out() == expected_names
-    assert list(res.columns) == enc.all_outputs_
+    assert list(sbd.column_names(res)) == enc.all_outputs_
 
     res_trans = enc.transform(s[:5])
-    assert len(res_trans) == 5
-    assert list(res_trans.columns) == enc.all_outputs_
-
-
-def test_categorical_encoder_polars():
-    pl = pytest.importorskip("polars")
-    s = pl.Series("col", ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"])
-    y = pl.Series("target", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
-
-    enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
-    res = enc.fit_transform(s, y)
-
-    expected_names = ["col_a", "col_d", "col_infrequent_sklearn", "col"]
-    assert sbd.is_polars(res)
-    assert len(res) == len(s)
-    assert enc.get_feature_names_out() == expected_names
-
-    res_trans = enc.transform(s[:5])
-    assert len(res_trans) == 5
+    assert sbd.shape(res_trans) == (5, 4)
     assert list(sbd.column_names(res_trans)) == enc.all_outputs_
 
 
@@ -68,22 +49,23 @@ def test_categorical_encoder_custom_encoders():
     assert enc.target_encoder_ is not custom_te
 
 
-def test_categorical_encoder_apply_to_cols():
-    df = pd.DataFrame(
+def test_categorical_encoder_apply_to_cols(df_module):
+    df = df_module.make_dataframe(
         {
             "cat": ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"],
             "num": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         }
     )
-    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+    y = df_module.make_column("target", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
 
     enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
     apply = ApplyToCols(enc, cols="cat")
 
     res = apply.fit_transform(df, y)
-    assert "cat_a" in res.columns
-    assert "cat_d" in res.columns
-    assert "num" in res.columns
+    cols = sbd.column_names(res)
+    assert "cat_a" in cols
+    assert "cat_d" in cols
+    assert "num" in cols
 
 
 def test_categorical_encoder_sklearn_compat():

--- a/skrub/tests/test_categorical_encoder.py
+++ b/skrub/tests/test_categorical_encoder.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import pytest
+from sklearn.base import clone
+from sklearn.preprocessing import OneHotEncoder, TargetEncoder
+from sklearn.utils.validation import check_is_fitted
+
+from skrub import ApplyToCols, CategoricalEncoder
+from skrub import _dataframe as sbd
+
+
+def test_categorical_encoder_pandas(df_module):
+    s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
+    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+
+    enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
+    res = enc.fit_transform(s, y)
+
+    expected_names = ["col_a", "col_d", "col_infrequent_sklearn", "col"]
+    assert sbd.is_dataframe(res)
+    assert len(res) == len(s)
+    assert enc.get_feature_names_out() == expected_names
+    assert list(res.columns) == enc.all_outputs_
+
+    res_trans = enc.transform(s[:5])
+    assert len(res_trans) == 5
+    assert list(res_trans.columns) == enc.all_outputs_
+
+
+def test_categorical_encoder_polars():
+    pl = pytest.importorskip("polars")
+    s = pl.Series("col", ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"])
+    y = pl.Series("target", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+
+    enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
+    res = enc.fit_transform(s, y)
+
+    expected_names = ["col_a", "col_d", "col_infrequent_sklearn", "col"]
+    assert sbd.is_polars(res)
+    assert len(res) == len(s)
+    assert enc.get_feature_names_out() == expected_names
+
+    res_trans = enc.transform(s[:5])
+    assert len(res_trans) == 5
+    assert list(sbd.column_names(res_trans)) == enc.all_outputs_
+
+
+def test_categorical_encoder_y_none():
+    s = pd.Series(["a", "b", "a"], name="col")
+    enc = CategoricalEncoder()
+    with pytest.raises(ValueError, match="Target y must be provided"):
+        enc.fit_transform(s, y=None)
+
+
+def test_categorical_encoder_custom_encoders():
+    s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
+    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+
+    custom_ohe = OneHotEncoder(sparse_output=False, handle_unknown="ignore")
+    custom_te = TargetEncoder(cv=2)
+
+    enc = CategoricalEncoder(one_hot_encoder=custom_ohe, target_encoder=custom_te)
+    _ = enc.fit_transform(s, y)
+
+    assert hasattr(enc, "one_hot_encoder_")
+    assert hasattr(enc, "target_encoder_")
+    # Verify original estimators were not mutated (cloned)
+    assert enc.one_hot_encoder_ is not custom_ohe
+    assert enc.target_encoder_ is not custom_te
+
+
+def test_categorical_encoder_apply_to_cols():
+    df = pd.DataFrame(
+        {
+            "cat": ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"],
+            "num": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
+    y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
+
+    enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
+    apply = ApplyToCols(enc, cols="cat")
+
+    res = apply.fit_transform(df, y)
+    assert "cat_a" in res.columns
+    assert "cat_d" in res.columns
+    assert "num" in res.columns
+
+
+def test_categorical_encoder_sklearn_compat():
+    enc = CategoricalEncoder()
+    with pytest.raises(Exception):
+        check_is_fitted(enc)
+
+    cloned = clone(enc)
+    assert cloned.max_categories == enc.max_categories

--- a/skrub/tests/test_categorical_encoder.py
+++ b/skrub/tests/test_categorical_encoder.py
@@ -1,8 +1,9 @@
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import OneHotEncoder, TargetEncoder
-from sklearn.utils.validation import check_is_fitted
 
 from skrub import ApplyToCols, CategoricalEncoder
 from skrub import _dataframe as sbd
@@ -49,6 +50,48 @@ def test_categorical_encoder_custom_encoders():
     assert enc.target_encoder_ is not custom_te
 
 
+def test_categorical_encoder_dataframe_target_and_unnamed_column():
+    s = pd.Series(["a", "b", "c"] * 5, name=None)
+    y = pd.DataFrame({"target": np.asarray(["0", "1", "2"] * 5, dtype=object)})
+
+    enc = CategoricalEncoder(max_categories=2)
+    res = enc.fit_transform(s, y)
+
+    assert res.columns.tolist() == [
+        "categorical_enc_c",
+        "categorical_enc_infrequent_sklearn",
+        "categorical_enc_0.0",
+        "categorical_enc_1.0",
+        "categorical_enc_2.0",
+    ]
+    assert res.shape == (15, 5)
+    assert enc.target_encoder_.target_type_ == "multiclass"
+
+
+def test_categorical_encoder_2d_string_target_and_sparse_output():
+    s = pd.Series(["a", "b", "c"] * 5, name="col")
+    y = np.asarray(["one", "two", "three"] * 5, dtype=object).reshape(-1, 1)
+    one_hot_encoder = OneHotEncoder(
+        sparse_output=True,
+        handle_unknown="ignore",
+    )
+
+    enc = CategoricalEncoder(one_hot_encoder=one_hot_encoder)
+    res = enc.fit_transform(s, y)
+
+    assert res.columns.tolist() == [
+        "col_a",
+        "col_b",
+        "col_c",
+        "col_one",
+        "col_three",
+        "col_two",
+    ]
+    transformed = enc.transform(pd.Series(["a", "new"], name="col"))
+    assert transformed.shape == (2, 6)
+    assert transformed.columns.tolist() == res.columns.tolist()
+
+
 def test_categorical_encoder_apply_to_cols(df_module):
     df = df_module.make_dataframe(
         {
@@ -70,8 +113,10 @@ def test_categorical_encoder_apply_to_cols(df_module):
 
 def test_categorical_encoder_sklearn_compat():
     enc = CategoricalEncoder()
-    with pytest.raises(Exception):
-        check_is_fitted(enc)
+    with pytest.raises(NotFittedError):
+        enc.transform(pd.Series(["a"], name="col"))
+    with pytest.raises(NotFittedError):
+        enc.get_feature_names_out()
 
     cloned = clone(enc)
     assert cloned.max_categories == enc.max_categories

--- a/skrub/tests/test_categorical_encoder.py
+++ b/skrub/tests/test_categorical_encoder.py
@@ -5,6 +5,7 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 from sklearn.preprocessing import OneHotEncoder, TargetEncoder
 
+import skrub
 from skrub import ApplyToCols, CategoricalEncoder
 from skrub import _dataframe as sbd
 
@@ -24,6 +25,30 @@ def test_categorical_encoder(df_module):
     res_trans = enc.transform(s[:5])
     assert sbd.shape(res_trans) == (5, 4)
     assert list(sbd.column_names(res_trans)) == enc.all_outputs_
+
+
+def test_categorical_encoder_values_and_unknown_category(df_module):
+    s = df_module.make_column("col", ["a", "b"] * 10)
+    y = df_module.make_column("target", [1, 0] * 10)
+
+    enc = CategoricalEncoder(target_encoder=TargetEncoder(cv=2))
+    res = enc.fit_transform(s, y)
+
+    expected = np.column_stack(
+        [
+            [1.0, 0.0] * 10,
+            [0.0, 1.0] * 10,
+            [1.0, 0.0] * 10,
+        ]
+    )
+    np.testing.assert_allclose(sbd.to_numpy(res), expected)
+
+    new = df_module.make_column("col", ["a", "unknown"])
+    transformed = enc.transform(new)
+    np.testing.assert_allclose(
+        sbd.to_numpy(transformed),
+        [[1.0, 0.0, 1.0], [0.0, 0.0, 0.5]],
+    )
 
 
 def test_categorical_encoder_y_none():
@@ -68,6 +93,24 @@ def test_categorical_encoder_dataframe_target_and_unnamed_column():
     assert enc.target_encoder_.target_type_ == "multiclass"
 
 
+@pytest.mark.parametrize(
+    "y, expected_message",
+    [
+        (
+            pd.DataFrame({"first": [0, 1] * 5, "second": [1, 0] * 5}),
+            "exactly one column",
+        ),
+        (np.ones((10, 2)), "one-dimensional"),
+        (np.asarray(1), "one-dimensional"),
+    ],
+)
+def test_categorical_encoder_rejects_non_1d_target(y, expected_message):
+    s = pd.Series(["a", "b"] * 5, name="col")
+
+    with pytest.raises(ValueError, match=expected_message):
+        CategoricalEncoder().fit_transform(s, y)
+
+
 def test_categorical_encoder_2d_string_target_and_sparse_output():
     s = pd.Series(["a", "b", "c"] * 5, name="col")
     y = np.asarray(["one", "two", "three"] * 5, dtype=object).reshape(-1, 1)
@@ -92,23 +135,108 @@ def test_categorical_encoder_2d_string_target_and_sparse_output():
     assert transformed.columns.tolist() == res.columns.tolist()
 
 
+def test_categorical_encoder_preserves_dtypes(df_module):
+    s = df_module.make_column("col", ["a", "b"] * 10)
+    y = df_module.make_column("target", [1.0, 0.0] * 10)
+    one_hot_encoder = OneHotEncoder(
+        dtype=np.float32,
+        sparse_output=False,
+        handle_unknown="ignore",
+    )
+    enc = CategoricalEncoder(
+        one_hot_encoder=one_hot_encoder,
+        target_encoder=TargetEncoder(cv=2),
+    )
+
+    fitted = enc.fit_transform(s, y)
+    transformed = enc.transform(s)
+
+    for name in enc.all_outputs_:
+        assert sbd.dtype(sbd.col(fitted, name)) == sbd.dtype(sbd.col(transformed, name))
+    assert sbd.to_numpy(sbd.col(fitted, "col_a")).dtype == np.float32
+
+
+def test_categorical_encoder_stable_names_on_collision(df_module):
+    s = df_module.make_column("col", ["a", "b", "c"] * 5)
+    y = df_module.make_column("target", ["a", "b", "c"] * 5)
+    expected_names = [
+        "col_a",
+        "col_b",
+        "col_c",
+        "col_a_target",
+        "col_b_target",
+        "col_c_target",
+    ]
+
+    first = CategoricalEncoder().fit_transform(s, y)
+    second = CategoricalEncoder().fit_transform(s, y)
+
+    assert list(sbd.column_names(first)) == expected_names
+    assert list(sbd.column_names(second)) == expected_names
+
+
+def test_categorical_encoder_preserves_pandas_index():
+    index = pd.Index([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+    s = pd.Series(["a", "b"] * 5, name="col", index=index)
+    y = pd.Series([1, 0] * 5, index=index)
+    enc = CategoricalEncoder(target_encoder=TargetEncoder(cv=2))
+
+    fitted = enc.fit_transform(s, y)
+    transformed = enc.transform(s)
+
+    assert fitted.index.equals(index)
+    assert transformed.index.equals(index)
+
+
 def test_categorical_encoder_apply_to_cols(df_module):
     df = df_module.make_dataframe(
         {
             "cat": ["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"],
+            "other": ["x", "y"] * 5,
             "num": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
         }
     )
     y = df_module.make_column("target", [1, 0, 1, 0, 1, 0, 1, 0, 1, 0])
 
     enc = CategoricalEncoder(max_categories=3, target_encoder=TargetEncoder(cv=2))
-    apply = ApplyToCols(enc, cols="cat")
+    apply = ApplyToCols(enc, cols=["cat", "other"])
 
     res = apply.fit_transform(df, y)
-    cols = sbd.column_names(res)
-    assert "cat_a" in cols
-    assert "cat_d" in cols
-    assert "num" in cols
+    assert list(sbd.column_names(res)) == [
+        "cat_a",
+        "cat_d",
+        "cat_infrequent_sklearn",
+        "cat",
+        "other_x",
+        "other_y",
+        "other",
+        "num",
+    ]
+
+
+def test_categorical_encoder_data_op_orders_outputs_by_input_column():
+    df = pd.DataFrame(
+        {
+            "first": ["a", "b"] * 5,
+            "second": ["x", "y"] * 5,
+        }
+    )
+    y = pd.Series([1, 0] * 5)
+
+    result = (
+        skrub.as_data_op(df)
+        .skb.apply(CategoricalEncoder(target_encoder=TargetEncoder(cv=2)), y=y)
+        .skb.eval()
+    )
+
+    assert result.columns.tolist() == [
+        "first_a",
+        "first_b",
+        "first",
+        "second_x",
+        "second_y",
+        "second",
+    ]
 
 
 def test_categorical_encoder_sklearn_compat():


### PR DESCRIPTION
# New Feature Pull Request

## Description

This PR introduces `CategoricalEncoder`, a single-column transformer that combines `OneHotEncoder` (for encoding frequent categories into one-hot binary columns) and `TargetEncoder` (for encoding categories using the target variable `y`).

Fixes #2065

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the feature works
- [x] I have added necessary documentation:
  - [x] Docstrings for new functions/classes
  - [x] API documentation if applicable
  - [ ] Example notebook or script demonstrating usage
- [x] I have added an entry to CHANGES.rst describing the feature
- [x] My code follows the code style of this project
- [ ] I have checked my code and corrected any misspellings

If the feature inherits from `SingleColumnTransformer`:
- [x] `get_feature_names_out` has been implemented

## How Has This Been Tested?

- Added unit tests in `skrub/tests/test_categorical_encoder.py` covering:
  - Transformation on both Pandas and Polars Series.
  - Validation when target `y` is missing (`y=None`).
  - Cloning and isolation when custom `one_hot_encoder` or `target_encoder` instances are provided.
  - Integration with `ApplyToCols`.
  - Scikit-learn estimator compatibility (`check_is_fitted`, `clone`).
- Ran local test suites (`pytest skrub/tests/test_categorical_encoder.py` and `pytest skrub/tests/test_single_column_transformer.py`).
- Verified code style and formatting with `ruff check`.

## Example Usage

```python
import pandas as pd
from skrub import CategoricalEncoder

s = pd.Series(["a", "b", "a", "c", "d", "e", "a", "b", "c", "d"], name="col")
y = pd.Series([1, 0, 1, 0, 1, 0, 1, 0, 1, 0])

enc = CategoricalEncoder(max_categories=3)
res = enc.fit_transform(s, y)
print(res)