### PR TITLE
DOC Remove redundant note from SingleColumnTransformer.fit

### DIFF
--- a/skrub/_single_column_transformer.py
+++ b/skrub/_single_column_transformer.py
@@ -173,8 +173,6 @@ class SingleColumnTransformer(SkrubBaseEstimator):
         This default implementation simply calls ``fit_transform()`` and
         returns ``self``.
 
-        Subclasses should implement ``fit_transform`` and ``transform``.
-
         Parameters
         ----------
         column : a pandas or polars Series


### PR DESCRIPTION
## Description

Removes the contributor-facing sentence from the
`SingleColumnTransformer.fit` docstring. The same guidance already appears in
the class docstring, while the method text is inherited by user-facing encoder
documentation.

Fixes #2128

## Checklist

- [x] I have read the contributing guidelines
- [x] Documentation renders correctly (if applicable)
- [ ] Links are working (not applicable)
- [ ] Code examples are correct and working (not applicable)
- [x] Spelling and grammar have been checked
- [x] My changes follow the documentation style of this project

## Type of Documentation Change

- [ ] New documentation
- [x] Documentation update
- [ ] Typo fix
- [ ] Other (please describe):

## Validation

- `python -m pytest -q skrub/tests/test_single_column_transformer.py`
- Focused numpydoc validation for `SingleColumnTransformer.fit`
- `pre-commit run --files skrub/_single_column_transformer.py`

