### PR TITLE
Adding examples for DataOps numeric choice methods

### DIFF
--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -953,7 +953,7 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     --------
     >>> import skrub
     >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
-    - choose_int(0, 2): choose_float(0, 2)
+    - choose_int(0, 2): choose_int(0, 2)
     >>> skrub.choose_bool().default()
     np.int64(1)
 

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -871,7 +871,7 @@ def choose_float(low, high, *, log=False, n_steps=None, name=None, default=None)
     >>> print(skrub.choose_float(0,2).as_data_op().skb.describe_param_grid())
     - choose_float(0, 2): choose_float(0, 2)
     >>> skrub.choose_float(0,2).default()
-    np.float64(1.0)
+    1.0
 
     We can set the default to another value:
 
@@ -955,7 +955,7 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
     - choose_int(0, 2): choose_int(0, 2)
     >>> skrub.choose_int(0,2).default()
-    np.int64(1)
+    1
 
     We can set the default to another value:
 

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -954,7 +954,7 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     >>> import skrub
     >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
     - choose_int(0, 2): choose_int(0, 2)
-    >>> skrub.choose_int().default()
+    >>> skrub.choose_int(0,2).default()
     np.int64(1)
 
     We can set the default to another value:

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -960,7 +960,7 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     We can set the default to another value:
 
     >>> skrub.choose_int(0, 2, default=0).default()
-    1.5
+    0
     """
     if n_steps is None:
         return NumericChoice(

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -954,7 +954,7 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     >>> import skrub
     >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
     - choose_int(0, 2): choose_int(0, 2)
-    >>> skrub.choose_bool().default()
+    >>> skrub.choose_int().default()
     np.int64(1)
 
     We can set the default to another value:

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -864,6 +864,19 @@ def choose_float(low, high, *, log=False, n_steps=None, name=None, default=None)
 
     optional :
         Choose between executing an operation or not.
+
+    Examples
+    --------
+    >>> import skrub
+    >>> print(skrub.choose_float(0,2).as_data_op().skb.describe_param_grid())
+    - choose_float(0, 2): choose_float(0, 2)
+    >>> skrub.choose_float().default()
+    np.float64(1.0)
+
+    We can set the default to another value:
+
+    >>> skrub.choose_float(0, 2, default=1.5).default()
+    1.5
     """
     if n_steps is None:
         return NumericChoice(
@@ -935,6 +948,19 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
 
     optional :
         Choose between executing an operation or not.
+
+    Examples
+    --------
+    >>> import skrub
+    >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
+    - choose_int(0, 2): choose_float(0, 2)
+    >>> skrub.choose_bool().default()
+    np.int64(1)
+
+    We can set the default to another value:
+
+    >>> skrub.choose_int(0, 2, default=0).default()
+    1.5
     """
     if n_steps is None:
         return NumericChoice(

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -870,7 +870,7 @@ def choose_float(low, high, *, log=False, n_steps=None, name=None, default=None)
     >>> import skrub
     >>> print(skrub.choose_float(0,2).as_data_op().skb.describe_param_grid())
     - choose_float(0, 2): choose_float(0, 2)
-    >>> skrub.choose_float().default()
+    >>> skrub.choose_float(0,2).default()
     np.float64(1.0)
 
     We can set the default to another value:

--- a/skrub/_data_ops/_choosing.py
+++ b/skrub/_data_ops/_choosing.py
@@ -870,12 +870,12 @@ def choose_float(low, high, *, log=False, n_steps=None, name=None, default=None)
     >>> import skrub
     >>> print(skrub.choose_float(0,2).as_data_op().skb.describe_param_grid())
     - choose_float(0, 2): choose_float(0, 2)
-    >>> skrub.choose_float(0,2).default()
+    >>> print(skrub.choose_float(0,2).default())
     1.0
 
     We can set the default to another value:
 
-    >>> skrub.choose_float(0, 2, default=1.5).default()
+    >>> print(skrub.choose_float(0, 2, default=1.5).default())
     1.5
     """
     if n_steps is None:
@@ -954,12 +954,12 @@ def choose_int(low, high, *, log=False, n_steps=None, name=None, default=None):
     >>> import skrub
     >>> print(skrub.choose_int(0,2).as_data_op().skb.describe_param_grid())
     - choose_int(0, 2): choose_int(0, 2)
-    >>> skrub.choose_int(0,2).default()
+    >>> print(skrub.choose_int(0,2).default())
     1
 
     We can set the default to another value:
 
-    >>> skrub.choose_int(0, 2, default=0).default()
+    >>> print(skrub.choose_int(0, 2, default=0).default())
     0
     """
     if n_steps is None:


### PR DESCRIPTION
Using the template of the `choose_bool` method's docstring, examples added to the docstrings of `choose_float` and `choose_int`.