### PR TITLE
MAINT: switch TextEncoder verbose from bool to int, fix documented default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,13 @@ New Features
 
 Changes
 -------
+- :class:`TextEncoder`'s ``verbose`` parameter is now an ``int`` instead of a
+  ``bool``, for consistency with :class:`GapEncoder`, :class:`TableReport` and
+  :func:`patch_display`, where ``verbose=0`` silences the progress bar and
+  ``verbose>=1`` shows it. The default is now ``0`` (it used to be ``False``,
+  while the docstring incorrectly documented it as ``True``). Passing a
+  boolean is still accepted for backward compatibility.
+  :pr:`2249` by :user:`Jayant-kernel <Jayant-kernel>`.
 - :func:`patch_display` now uses a minimal, faster TableReport without plots or
   column associations by default. The old behavior can still be achieved by calling
   ``patch_display(plot_distributions="auto", compute_associations="auto")``.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,11 +16,9 @@ New Features
 Changes
 -------
 - :class:`TextEncoder`'s ``verbose`` parameter is now an ``int`` instead of a
-  ``bool``, for consistency with :class:`GapEncoder`, :class:`TableReport` and
-  :func:`patch_display`, where ``verbose=0`` silences the progress bar and
-  ``verbose>=1`` shows it. The default is now ``0`` (it used to be ``False``,
-  while the docstring incorrectly documented it as ``True``). Passing a
-  boolean is still accepted for backward compatibility.
+  ``bool``, where ``verbose=0`` silences the progress bar and
+  ``verbose>=1`` shows it. The default is now ``0``. Passing a
+  boolean is still accepted.
   :pr:`2249` by :user:`Jayant-kernel <Jayant-kernel>`.
 - :func:`patch_display` now uses a minimal, faster TableReport without plots or
   column associations by default. The old behavior can still be achieved by calling

--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -108,9 +108,12 @@ class TextEncoder(SingleColumnTransformer):
         Used when the PCA dimension reduction mechanism is used, for reproducible
         results across multiple function calls.
 
-    verbose : bool, default=True
+    verbose : int, default=0
         Verbose level, controls whether to show a progress bar or not during
         ``transform``.
+
+        - verbose = 0 does not show a progress bar.
+        - verbose >= 1 shows a progress bar.
 
     Attributes
     ----------
@@ -198,7 +201,7 @@ class TextEncoder(SingleColumnTransformer):
         cache_folder=None,
         store_weights_in_pickle=False,
         random_state=None,
-        verbose=False,
+        verbose=0,
     ):
         self.model_name = model_name
         self.n_components = n_components
@@ -329,7 +332,7 @@ class TextEncoder(SingleColumnTransformer):
             unique_x,
             normalize_embeddings=False,
             batch_size=self.batch_size,
-            show_progress_bar=self.verbose,
+            show_progress_bar=bool(self.verbose),
         )[indices_x]
 
     @functools.cached_property
@@ -389,6 +392,11 @@ class TextEncoder(SingleColumnTransformer):
         if not (isinstance(self.batch_size, numbers.Integral) and self.batch_size > 0):
             raise ValueError(
                 f"Got batch_size={self.batch_size} but expected a positive integer"
+            )
+
+        if not (isinstance(self.verbose, numbers.Integral) and self.verbose >= 0):
+            raise ValueError(
+                f"Got verbose={self.verbose!r} but expected a non-negative integer"
             )
 
         if self.cache_folder is not None and not isinstance(

--- a/skrub/tests/test_text_encoder.py
+++ b/skrub/tests/test_text_encoder.py
@@ -15,6 +15,7 @@ warnings are being raised.
 import pickle
 import sys
 
+import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
@@ -135,6 +136,40 @@ def test_wrong_parameters(encoder):
 
     with pytest.raises(ValueError, match="Got model_name=1"):
         clone(encoder).set_params(model_name=1)._check_params()
+
+    with pytest.raises(ValueError, match="Got verbose=-1"):
+        clone(encoder).set_params(verbose=-1)._check_params()
+
+    with pytest.raises(ValueError, match="Got verbose='yes'"):
+        clone(encoder).set_params(verbose="yes")._check_params()
+
+
+def test_verbose_default():
+    """The default verbose level is 0 (silent), consistent with the rest of
+    skrub (e.g. GapEncoder, TableReport)."""
+    assert TextEncoder().verbose == 0
+
+
+@pytest.mark.parametrize(
+    "verbose, expected_show_progress_bar",
+    [(0, False), (1, True), (2, True), (False, False), (True, True)],
+)
+def test_verbose_controls_progress_bar(df_module, verbose, expected_show_progress_bar):
+    """``verbose`` (int or bool) is forwarded to sentence-transformers as the
+    boolean ``show_progress_bar`` flag."""
+    calls = []
+
+    class FakeEstimator:
+        def encode(self, X, **kwargs):
+            calls.append(kwargs["show_progress_bar"])
+            return np.zeros((len(X), 3))
+
+    X = df_module.make_column("", ["hello", "hola"])
+    encoder = TextEncoder(n_components=None, verbose=verbose)
+    encoder._estimator = FakeEstimator()
+    encoder.fit_transform(X)
+
+    assert calls == [expected_show_progress_bar]
 
 
 def test_wrong_model_name(encoder):


### PR DESCRIPTION
# Bug Fix Pull Request

## Description

`TextEncoder`'s `verbose` parameter was typed and defaulted as a `bool`, which was
inconsistent with the rest of skrub (`GapEncoder`, `TableReport`, `patch_display`),
where `verbose` is an `int` (`0` = silent, `>=1` = show progress). The docstring also
incorrectly documented the default as `True`, while the actual default was `False`.

This PR:
- Changes the default to `verbose=0` (`int`).
- Fixes the docstring to `verbose : int, default=0`, documenting the `0`/`>=1` levels.
- Adds a `_check_params` validation that `verbose` is a non-negative integer.
- Passes `show_progress_bar=bool(self.verbose)` at the sentence-transformers call site.

Backward compatible: `bool` is a subclass of `int` in Python, so existing code passing
`verbose=True`/`verbose=False` keeps working unchanged.

Closes #2131

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

`sentence-transformers` isn't available in my local dev environment, so I built an
isolated venv with skrub's core runtime + test dependencies (no `pixi` available here)
and ran:

- `skrub/tests/test_text_encoder.py` — the new `test_verbose_default` and
  `test_verbose_controls_progress_bar` (parametrized over `int`/`bool` values, using a
  stub estimator to assert the exact `show_progress_bar` value forwarded) pass; the rest
  of the suite collects cleanly and skips only on the missing optional dependency (no
  regressions).
- Directly exercised `_check_params()` for `verbose=-1` and `verbose="yes"` to confirm
  the new `ValueError` messages match what `test_wrong_parameters` asserts (that
  specific test itself is skipped locally since it needs `sentence-transformers`, but
  will run in CI).
- `ruff check` and `ruff format --check` on the changed files.

