### PR TITLE
FIX - keep aux_table column order for default cols in AggJoiner and MultiAggJoiner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,11 @@ Bugfixes
   ``"spline"``, and no longer fits an unused ``weekday`` periodic encoder when
   ``resolution`` is finer than ``"hour"``. :pr:`2240` by
   :user:`Achraf Ez <Hrafz>`.
+- When ``cols`` was not provided, :class:`AggJoiner` and :class:`MultiAggJoiner`
+  selected the columns to aggregate through a Python ``set``, so the order of the
+  aggregated output columns varied between runs. They now keep the order in which
+  the columns appear in the auxiliary table. This has been fixed in :pr:`2250` by
+  :user:`Dylan Pulver <dylanpulver>`.
 
 Deprecations
 ------------

--- a/skrub/_agg_joiner.py
+++ b/skrub/_agg_joiner.py
@@ -226,7 +226,8 @@ class AggJoiner(TransformerMixin, SkrubBaseEstimator):
     cols : str or iterable of str, default=None
         Select the columns from the auxiliary dataframe to use as values during
         the aggregation operations.
-        By default, `cols` are all columns from `aux_table`, except `aux_key`.
+        By default, `cols` are all columns from `aux_table`, except `aux_key`,
+        in the order in which they appear in `aux_table`.
 
     suffix : str, default=""
         Suffix to append to the `aux_table`'s column names. You can use it
@@ -326,9 +327,10 @@ class AggJoiner(TransformerMixin, SkrubBaseEstimator):
         _join_utils.check_missing_columns(self._aux_table, self._aux_key, "'aux_table'")
 
         self._cols = _utils.atleast_1d_or_none(self.cols)
-        # If no `cols` provided, all columns but `aux_key` are used.
+        # If no `cols` provided, all columns but `aux_key` are used, in the
+        # order in which they appear in `aux_table`.
         if self.cols is None:
-            self._cols = list(set(self._aux_table.columns) - set(self._aux_key))
+            self._cols = (~s.cols(*self._aux_key)).expand(self._aux_table)
         _join_utils.check_missing_columns(self._aux_table, self._cols, "'aux_table'")
 
         self._operations, self._suffix = check_other_inputs(

--- a/skrub/_multi_agg_joiner.py
+++ b/skrub/_multi_agg_joiner.py
@@ -5,6 +5,7 @@ The MultiAggJoiner extends AggJoiner to multiple auxiliary tables.
 from sklearn.base import TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
+from skrub import selectors as s
 from skrub._agg_joiner import AggJoiner
 from skrub._dataframe import _common as sbd
 from skrub._utils import _is_array_like
@@ -98,7 +99,8 @@ class MultiAggJoiner(TransformerMixin, SkrubBaseEstimator):
 
         If set to `None`, `cols` is set to a list of lists. For each table
         in `aux_tables`, the corresponding list will be all columns of that table,
-        except the `aux_keys` associated with that table.
+        except the `aux_keys` associated with that table, in the order in which
+        they appear in that table.
 
     suffixes : iterable of str, default=None
         Suffixes to append to the `aux_tables`' column names.
@@ -360,11 +362,12 @@ class MultiAggJoiner(TransformerMixin, SkrubBaseEstimator):
             or if `cols` is not of a valid type, of if all `cols`
             are not present in the corresponding aux_table.
         """
-        # If no `cols` provided, all columns but `aux_keys` are used.
+        # If no `cols` provided, all columns but `aux_keys` are used, in the
+        # order in which they appear in each aux table.
         cols = self.cols
         if cols is None:
             cols = [
-                list(set(table.columns) - set(key))
+                (~s.cols(*key)).expand(table)
                 for table, key in zip(self._aux_tables, self._aux_keys)
             ]
         else:

--- a/skrub/tests/test_agg_joiner.py
+++ b/skrub/tests/test_agg_joiner.py
@@ -408,7 +408,51 @@ def test_agg_joiner_default_cols(main_table):
         aux_table=main_table, operations="mode", key=["movieId", "userId"]
     )
     agg_joiner.fit(main_table)
-    assert sorted(agg_joiner._cols) == ["genre", "rating"]
+    # The columns keep the order they have in `aux_table`, not a sorted or
+    # otherwise arbitrary one.
+    assert agg_joiner._cols == ["rating", "genre"]
+
+
+def test_agg_joiner_default_cols_order(df_module):
+    """Check that default `cols` follow `aux_table`'s column order.
+
+    The order used to depend on set iteration, so it varied with
+    ``PYTHONHASHSEED`` and the aggregated columns came out in a different
+    order from one run to the next.
+    """
+    aux_table = df_module.make_dataframe(
+        {
+            "userId": [1, 1, 2],
+            "rating": [4.0, 3.0, 5.0],
+            "year": [1999, 2000, 2001],
+            "budget": [10.0, 20.0, 30.0],
+            "votes": [7.0, 8.0, 9.0],
+            "runtime": [90.0, 100.0, 110.0],
+            "screens": [1.0, 2.0, 3.0],
+        }
+    )
+    main_table = df_module.make_dataframe({"userId": [1, 2]})
+
+    agg_joiner = AggJoiner(aux_table=aux_table, operations="mean", key="userId")
+    aggregated = agg_joiner.fit_transform(main_table)
+
+    assert agg_joiner._cols == [
+        "rating",
+        "year",
+        "budget",
+        "votes",
+        "runtime",
+        "screens",
+    ]
+    assert sbd.column_names(aggregated) == [
+        "userId",
+        "rating_mean",
+        "year_mean",
+        "budget_mean",
+        "votes_mean",
+        "runtime_mean",
+        "screens_mean",
+    ]
 
 
 def test_agg_joiner_correct_cols(df_module, main_table):

--- a/skrub/tests/test_multi_agg_joiner.py
+++ b/skrub/tests/test_multi_agg_joiner.py
@@ -348,10 +348,12 @@ def test_default_cols(main_table, df_module):
         keys=[["userId", "movieId"], ["userId"]],
     )
     multi_agg_joiner.fit(main_table)
-    expected_cols = [["genre", "rating"], ["genre", "movieId", "rating"]]
-
-    for col_group, expected_group in zip(multi_agg_joiner._cols, expected_cols):
-        assert sorted(col_group) == expected_group
+    # The columns keep the order they have in each aux table, not a sorted or
+    # otherwise arbitrary one.
+    assert multi_agg_joiner._cols == [
+        ["rating", "genre"],
+        ["movieId", "rating", "genre"],
+    ]
 
 
 def test_correct_cols(main_table, df_module):


### PR DESCRIPTION
# Bug Fix Pull Request

## Description

`AggJoiner` and `MultiAggJoiner` derive their default `cols` from a set difference, so the aggregated columns come out in a different order on each interpreter run. No existing issue; repro on `main` at 9fb3ac5:

```python
import pandas as pd
from skrub import AggJoiner

aux = pd.DataFrame({
    "userId": [1, 1, 2], "rating": [4.0, 3.0, 5.0], "year": [1999, 2000, 2001],
    "budget": [10.0, 20.0, 30.0], "votes": [7.0, 8.0, 9.0],
    "runtime": [90.0, 100.0, 110.0], "screens": [1.0, 2.0, 3.0],
})
aj = AggJoiner(aux, key="userId", operations=["mean"])
print(aj.fit(pd.DataFrame({"userId": [1, 2]}))._cols)
```

```
PYTHONHASHSEED=0  ['runtime', 'rating', 'screens', 'votes', 'year', 'budget']
PYTHONHASHSEED=1  ['year', 'screens', 'runtime', 'votes', 'budget', 'rating']
PYTHONHASHSEED=2  ['runtime', 'budget', 'screens', 'votes', 'year', 'rating']
```

The constraint on the replacement is that the default path has to agree with the explicit one. When `cols` is passed, `_cols` is the caller's list in the caller's order, so aux table order is the only choice that makes `cols=None` equivalent to passing every non-key column by hand.

That is why `sorted()` was rejected. It is deterministic, but it would give the default path an alphabetical order the explicit path never produces, and the two forms of the same request would disagree.

`(~s.cols(*key)).expand(table)` is the selector expression `aggregate()` uses in `_agg_joiner.py` for this same "everything but the key" selection. `Selector.expand` iterates `sbd.column_names`, which pins the result to the table's own order.

Behavior change worth naming: for `cols=None` the output column order moves for any run that happened to land on a different permutation. Per-column values are unchanged, and no order was reproducible before, so nothing could have depended on a particular one.

Residual: `aggregate()` also builds `num_only_op` from a set intersection, so the operations listed in that `AttributeError` are unordered too. That is message text rather than output, and it is untouched here.

## Checklist

- [ ] I have read the contributing guidelines
- [x] I have added tests that verify the bug fix
- [x] I have added an entry to CHANGES.rst describing the fix
- [x] My code follows the code style of this project
- [x] I have checked my code and corrected any misspellings

## How Has This Been Tested?

Full suite on this branch against a clean checkout of `main` at 9fb3ac5: 3029 passed vs 3026, with the same single pre-existing failure in both (`skrub/datasets/tests/test_fetching.py::test_warning_redownload_checksum_has_changed`, which downloads).

Reverting the two source hunks while keeping the tests: the new `test_agg_joiner_default_cols_order` fails on every `PYTHONHASHSEED` from 0 to 11, across all three `df_module` variants. The two pre-existing assertions that called `sorted()` were tightened to exact order; those are weaker detectors, catching the old behavior on 10 of 30 and 9 of 12 seeds respectively, because permutations of two or three columns often coincide with table order by chance.

ruff 0.14.4, the version pinned in `.pre-commit-config.yaml`, reports no check or format changes.

## AI Disclosure

- [x] This PR contains AI-generated code
    - [ ] I have tested the code generated in my PR
    - [ ] I have read and understood every line that has been generated by the AI agent
    - [ ] I can explain what the AI-generated code does
