### PR TITLE
feat: add `accept_numeric` kwarg to `ToCategorical`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,14 +43,17 @@ Changes
   containing the full X and y before splitting.
 
   :pr:`2213` by :user:`Jérôme Dockès <jeromedockes>`.
-
 - Added support in :func:`tabular_pipeline` for estimators instantiated from either
   :class:`tabicl.TabICLClassifier` or :class:`tabicl.TabICLRegressor` with recommended
   default parameters of :class:`TableVectorizer` as the first step, and the estimator
   as the second step.
-
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
+- Expanded dtypes accepted by the encoder `ToCategorical`. Now accepts `int` columns
+  by setting the new kwarg accept_numeric to ``"int"``. `float` columns are also now
+  accepted if ``accept_numeric="all"``. Previous default behavior is maintained by
+  setting ``accept_numeric=None``.
+  :pr:`2252` by :user:`Lisa McBride <lisaleemcb>`.
 
 
 Bugfixes

--- a/skrub/_to_categorical.py
+++ b/skrub/_to_categorical.py
@@ -9,7 +9,7 @@ class ToCategorical(SingleColumnTransformer):
     Convert a string column to Categorical dtype.
 
     This transformer ensures that a given string or categorical column has
-    Categorical dtype. This is done to mark columns to be treated as categorical
+    Categorical dtype so that it is treated as categorical
     by downstream transformers and learners.
 
     Notes
@@ -26,9 +26,14 @@ class ToCategorical(SingleColumnTransformer):
     a polars column with dtype ``String``, is converted to a categorical
     column. Categorical columns are passed through.
 
+    If ``accept_numeric`` is set to ``"all"``, then both integer and float
+    columns are accepted and converted to categorical. If it is set to ``"int"``,
+    then only integer columns are accepted. The default value is ``"int"``.
+
     Any other type of column is rejected by raising a ``RejectColumn``
     exception. **Note:** the ``TableVectorizer`` only sends string or
-    categorical columns to its ``low_cardinality_transformer``. Therefore it is
+    categorical columns to its ``low_cardinality_transformer``, regardless
+    of the inputted value of ``accept_numeric``. Therefore it is
     always safe to use a ``ToCategorical`` instance as the
     ``low_cardinality_transformer``.
 
@@ -88,6 +93,16 @@ class ToCategorical(SingleColumnTransformer):
         ...
     skrub.core.RejectColumn: Column 'c' does not contain strings.
 
+    Unless ``accept_numeric`` is set to ``"int"`` or ``"all"``, in which case integer
+    columns are accepted in the former case, and both integer and float columns are
+    accepted in the latter:
+
+    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'), accept_numeric="all")
+    0    1.1
+    1    2.2
+    Name: c, dtype: category
+    Categories (2, float64): [1.1, 2.2]
+
     ``object`` columns that do not contain only strings are also rejected:
 
     >>> s = pd.Series(['one', 1], name='c')
@@ -143,13 +158,19 @@ class ToCategorical(SingleColumnTransformer):
     True
     """
 
-    def fit_transform(self, column, y=None):
+    def fit_transform(self, column, accept_numeric="int", y=None):
         """Fit the encoder and transform a column.
 
         Parameters
         ----------
         column : pandas or polars Series
             The input to transform.
+
+        accept_numeric : str, default="int"
+            How to handle numeric columns. If "int", will convert integer
+            columns to categorical. If "all", both float and integer columns
+            will be accepted. If None, no numeric
+            columns will be accepted.
 
         y : None
             Ignored.
@@ -163,9 +184,17 @@ class ToCategorical(SingleColumnTransformer):
 
         if sbd.is_categorical(column):
             return column
-        if not sbd.is_string(column):
-            raise RejectColumn(f"Column {sbd.name(column)!r} does not contain strings.")
-        return sbd.to_categorical(column)
+        elif sbd.is_string(column):
+            return sbd.to_categorical(column)
+        elif sbd.is_integer(column) and accept_numeric in ("int", "all"):
+            return sbd.to_categorical(column)
+        elif sbd.is_float(column) and accept_numeric == "all":
+            return sbd.to_categorical(column)
+        else:
+            raise RejectColumn(
+                f"Column {sbd.name(column)!r} does not contain strings "
+                "or numerical data (if accept_numeric is 'int' or 'all')."
+            )
 
     def transform(self, column):
         """Transform a column.

--- a/skrub/_to_categorical.py
+++ b/skrub/_to_categorical.py
@@ -99,18 +99,17 @@ class ToCategorical(SingleColumnTransformer):
     >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'))
     Traceback (most recent call last):
         ...
-    skrub.core.RejectColumn: Column 'c' does not contain strings or accepted...
+    skrub.core.RejectColumn: Column 'c' does not contain only strings...
 
-    Unless ``accept_numeric`` is set to ``"int"`` or ``"all"``, in which case integer
-    columns are accepted in the former case, and both integer and float columns are
-    accepted in the latter:
+    Unless ``accept_int`` is set to ``True``, in which case integer
+    columns are accepted:
 
-    >>> to_cat = ToCategorical(accept_numeric="all")
-    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'))
-    0    1.1
-    1    2.2
+    >>> to_cat = ToCategorical(accept_int=True)
+    >>> to_cat.fit_transform(pd.Series([1, 2], name='c'))
+    0    1
+    1    2
     Name: c, dtype: category
-    Categories (2, float64): [1.1, 2.2]
+    Categories (2, int64): [1, 2]
 
     ``object`` columns that do not contain only strings are also rejected:
 
@@ -118,7 +117,7 @@ class ToCategorical(SingleColumnTransformer):
     >>> to_cat.fit_transform(s)
     Traceback (most recent call last):
         ...
-    skrub.core.RejectColumn: Column 'c' does not contain strings or accepted...
+    skrub.core.RejectColumn: Column 'c' does not contain only strings...
 
     No special handling of ``StringDtype`` vs ``object`` columns is done, the
     behavior is the same as ``pd.astype('category')``: if the input uses the
@@ -167,8 +166,8 @@ class ToCategorical(SingleColumnTransformer):
     True
     """
 
-    def __init__(self, accept_numeric="int"):
-        self.accept_numeric = accept_numeric
+    def __init__(self, accept_int=False):
+        self.accept_int = accept_int
         super().__init__()
 
     def fit_transform(self, column, y=None):
@@ -190,17 +189,11 @@ class ToCategorical(SingleColumnTransformer):
 
         if sbd.is_categorical(column):
             return column
-        if (
-            sbd.is_string(column)
-            or sbd.is_integer(column)
-            and self.accept_numeric in ("int", "all")
-            or sbd.is_float(column)
-            and self.accept_numeric == "all"
-        ):
+        if sbd.is_string(column) or sbd.is_integer(column) and self.accept_int is True:
             return sbd.to_categorical(column)
         raise RejectColumn(
-            f"Column {sbd.name(column)!r} does not contain strings "
-            "or accepted numeric types (if accept_numeric is 'int' or 'all')."
+            f"Column {sbd.name(column)!r} does not contain only strings "
+            "or only integers (if accept_int is True)."
         )
 
     def transform(self, column):

--- a/skrub/_to_categorical.py
+++ b/skrub/_to_categorical.py
@@ -12,6 +12,14 @@ class ToCategorical(SingleColumnTransformer):
     Categorical dtype so that it is treated as categorical
     by downstream transformers and learners.
 
+    Parameters
+    ----------
+    accept_numeric : str, default="int"
+        How to handle numeric columns. If "int", will convert integer
+        columns to categorical. If "all", both float and integer columns
+        will be accepted. If `None`, no numeric
+        columns will be accepted.
+
     Notes
     -----
     The main benefit of converting columns to categorical is that categorical
@@ -91,13 +99,14 @@ class ToCategorical(SingleColumnTransformer):
     >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'))
     Traceback (most recent call last):
         ...
-    skrub.core.RejectColumn: Column 'c' does not contain strings.
+    skrub.core.RejectColumn: Column 'c' does not contain strings or accepted...
 
     Unless ``accept_numeric`` is set to ``"int"`` or ``"all"``, in which case integer
     columns are accepted in the former case, and both integer and float columns are
     accepted in the latter:
 
-    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'), accept_numeric="all")
+    >>> to_cat = ToCategorical(accept_numeric="all")
+    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'))
     0    1.1
     1    2.2
     Name: c, dtype: category
@@ -109,7 +118,7 @@ class ToCategorical(SingleColumnTransformer):
     >>> to_cat.fit_transform(s)
     Traceback (most recent call last):
         ...
-    skrub.core.RejectColumn: Column 'c' does not contain strings.
+    skrub.core.RejectColumn: Column 'c' does not contain strings or accepted...
 
     No special handling of ``StringDtype`` vs ``object`` columns is done, the
     behavior is the same as ``pd.astype('category')``: if the input uses the
@@ -158,19 +167,16 @@ class ToCategorical(SingleColumnTransformer):
     True
     """
 
-    def fit_transform(self, column, accept_numeric="int", y=None):
+    def __init__(self, accept_numeric="int"):
+        self.accept_numeric = accept_numeric
+        super().__init__()
+
+    def fit_transform(self, column, y=None):
         """Fit the encoder and transform a column.
 
         Parameters
         ----------
         column : pandas or polars Series
-            The input to transform.
-
-        accept_numeric : str, default="int"
-            How to handle numeric columns. If "int", will convert integer
-            columns to categorical. If "all", both float and integer columns
-            will be accepted. If None, no numeric
-            columns will be accepted.
 
         y : None
             Ignored.
@@ -184,17 +190,18 @@ class ToCategorical(SingleColumnTransformer):
 
         if sbd.is_categorical(column):
             return column
-        elif sbd.is_string(column):
+        if (
+            sbd.is_string(column)
+            or sbd.is_integer(column)
+            and self.accept_numeric in ("int", "all")
+            or sbd.is_float(column)
+            and self.accept_numeric == "all"
+        ):
             return sbd.to_categorical(column)
-        elif sbd.is_integer(column) and accept_numeric in ("int", "all"):
-            return sbd.to_categorical(column)
-        elif sbd.is_float(column) and accept_numeric == "all":
-            return sbd.to_categorical(column)
-        else:
-            raise RejectColumn(
-                f"Column {sbd.name(column)!r} does not contain strings "
-                "or numerical data (if accept_numeric is 'int' or 'all')."
-            )
+        raise RejectColumn(
+            f"Column {sbd.name(column)!r} does not contain strings "
+            "or accepted numeric types (if accept_numeric is 'int' or 'all')."
+        )
 
     def transform(self, column):
         """Transform a column.

--- a/skrub/tests/test_to_categorical.py
+++ b/skrub/tests/test_to_categorical.py
@@ -13,9 +13,21 @@ def test_to_categorical(df_module):
     # categorial columns are accepted
     assert ToCategorical().fit_transform(out) is out
     assert ToCategorical().fit(out).transform(out) is out
-    # non-string, non-categorical columns are rejected
+    # default behaviour accepts integer and string
+    # columns, but not float
+    i = df_module.make_column("c", [1, 2, None])
+    assert ToCategorical().fit_transform(i, accept_numeric="int")
+    assert ToCategorical().fit(i).transform(i, accept_numeric="int")
+    # unless accept_numeric is None, in which case
+    # only string and categorical columns are accepted
+    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
+        ToCategorical().fit_transform(i, accept_numeric=None)
+    # if accept_numeric is set to "all", then both integer and
+    # float columns are accepted
     f = df_module.make_column("c", [1.1, 2.2, None])
-    with pytest.raises(RejectColumn, match=".*does not contain strings"):
-        ToCategorical().fit(f)
+    assert ToCategorical().fit_transform(f, accept_numeric="all")
+    # if accept_numeric != "all", then float columns are rejected
+    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
+        ToCategorical().fit_transform(f)
     # but once accepted during fit, transform works on any column
     assert sbd.is_categorical(ToCategorical().fit(s).transform(f))

--- a/skrub/tests/test_to_categorical.py
+++ b/skrub/tests/test_to_categorical.py
@@ -5,7 +5,7 @@ from skrub._single_column_transformer import RejectColumn
 from skrub._to_categorical import ToCategorical
 
 
-def test_to_categorical(df_module):
+def test_to_categorical_pass(df_module):
     s = df_module.make_column("c", ["a", "b", None])
     assert not sbd.is_categorical(s)
     out = ToCategorical().fit_transform(s)
@@ -16,18 +16,37 @@ def test_to_categorical(df_module):
     # default behaviour accepts integer and string
     # columns, but not float
     i = df_module.make_column("c", [1, 2, None])
-    assert ToCategorical().fit_transform(i, accept_numeric="int")
-    assert ToCategorical().fit(i).transform(i, accept_numeric="int")
-    # unless accept_numeric is None, in which case
-    # only string and categorical columns are accepted
-    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
-        ToCategorical().fit_transform(i, accept_numeric=None)
-    # if accept_numeric is set to "all", then both integer and
-    # float columns are accepted
+    expected = sbd.to_categorical(i)
+    df_module.assert_column_equal(
+        ToCategorical(accept_numeric="int").fit_transform(i), expected
+    )
+    df_module.assert_column_equal(
+        ToCategorical(accept_numeric="int").fit(i).transform(i), expected
+    )
+    # unless accept_numeric is "float", in which case floats are accepted
     f = df_module.make_column("c", [1.1, 2.2, None])
-    assert ToCategorical().fit_transform(f, accept_numeric="all")
-    # if accept_numeric != "all", then float columns are rejected
-    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
-        ToCategorical().fit_transform(f)
-    # but once accepted during fit, transform works on any column
+    expected = sbd.to_categorical(f)
+    df_module.assert_column_equal(
+        ToCategorical(accept_numeric="all").fit_transform(f), expected
+    )
+    df_module.assert_column_equal(
+        ToCategorical(accept_numeric="all").fit(f).transform(f), expected
+    )
+    # but once accepted during fit, transform works on any column regardless
+    # of dtype
     assert sbd.is_categorical(ToCategorical().fit(s).transform(f))
+
+
+@pytest.mark.parametrize(
+    "accept_numeric,values",
+    [
+        ("int", [1.1, 2.2, None]),  # float rejected when accept_numeric="int"
+        (None, [1, 2, None]),  # int rejected when accept_numeric=None
+        (None, [1.1, 2.2, None]),  # float rejected when accept_numeric=None
+    ],
+)
+def test_to_categorical_reject(df_module, accept_numeric, values):
+    # reject columns based on accept_numeric parameter
+    col = df_module.make_column("c", values)
+    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
+        ToCategorical(accept_numeric=accept_numeric).fit_transform(col)

--- a/skrub/tests/test_to_categorical.py
+++ b/skrub/tests/test_to_categorical.py
@@ -13,40 +13,35 @@ def test_to_categorical_pass(df_module):
     # categorial columns are accepted
     assert ToCategorical().fit_transform(out) is out
     assert ToCategorical().fit(out).transform(out) is out
-    # default behaviour accepts integer and string
-    # columns, but not float
+    # default behaviour accepts string columns
+    expected = sbd.to_categorical(s)
+    df_module.assert_column_equal(ToCategorical().fit_transform(s), expected)
+    df_module.assert_column_equal(ToCategorical().fit(s).transform(s), expected)
+    # also accepts int columns if accept_int is True
     i = df_module.make_column("c", [1, 2, None])
     expected = sbd.to_categorical(i)
     df_module.assert_column_equal(
-        ToCategorical(accept_numeric="int").fit_transform(i), expected
+        ToCategorical(accept_int=True).fit_transform(i), expected
     )
     df_module.assert_column_equal(
-        ToCategorical(accept_numeric="int").fit(i).transform(i), expected
+        ToCategorical(accept_int=True).fit(i).transform(i), expected
     )
-    # unless accept_numeric is "float", in which case floats are accepted
-    f = df_module.make_column("c", [1.1, 2.2, None])
-    expected = sbd.to_categorical(f)
-    df_module.assert_column_equal(
-        ToCategorical(accept_numeric="all").fit_transform(f), expected
-    )
-    df_module.assert_column_equal(
-        ToCategorical(accept_numeric="all").fit(f).transform(f), expected
-    )
-    # but once accepted during fit, transform works on any column regardless
+    # once accepted during fit, transform works on any column regardless
     # of dtype
+    f = df_module.make_column("c", [1.1, 2.2, None])
     assert sbd.is_categorical(ToCategorical().fit(s).transform(f))
 
 
 @pytest.mark.parametrize(
-    "accept_numeric,values",
+    "accept_int,values",
     [
-        ("int", [1.1, 2.2, None]),  # float rejected when accept_numeric="int"
-        (None, [1, 2, None]),  # int rejected when accept_numeric=None
-        (None, [1.1, 2.2, None]),  # float rejected when accept_numeric=None
+        (False, [1.1, 2.2, None]),  # float rejected always
+        (True, [1.1, 2.2, None]),  # float rejected always
+        (False, [1, 2, None]),  # int rejected when accept_int=False
     ],
 )
-def test_to_categorical_reject(df_module, accept_numeric, values):
-    # reject columns based on accept_numeric parameter
+def test_to_categorical_reject(df_module, accept_int, values):
+    # reject columns based on accept_int parameter
     col = df_module.make_column("c", values)
-    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
-        ToCategorical(accept_numeric=accept_numeric).fit_transform(col)
+    with pytest.raises(RejectColumn, match=".*does not contain only strings*"):
+        ToCategorical(accept_int=accept_int).fit_transform(col)


### PR DESCRIPTION
The encoder `ToCategorical` now also accepts type `int` columns, in addition to `str` and categorical dtypes via setting the new kwarg `accept_numeric`  to `'int'`.  In addition, `float` columns will be accepted if `accept_numeric='all'`. 

As currently implemented, the new default is `accept_numeric='int'` which means that columns of strings, categoricals, and ints will be marked as categorical after performing `fit_transform`. **Note** this is different from the current default behaviour, which only accepts strings, and categoricals, and will raise an error otherwise. The current default can be recovered by setting `accept_numeric=None`.

The rationale for the new default is that integers are used in many datasets to represent categories. But this would make it a breaking change for direct users, so perhaps we should discuss.

However, note that this change in the default would not affect the behaviour of the `TableVectorizer`, as the numerical columns are currently not selected to be sent to the `ToCategorical` encoder. Thanks to @rcap107 for beaucoup help with understanding its behaviour.

PS Also changed the docstring to make it more concise.
