### PR TITLE
MAINT - Rename textencoder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,14 +43,17 @@ Changes
   containing the full X and y before splitting.
 
   :pr:`2213` by :user:`Jérôme Dockès <jeromedockes>`.
-
 - Added support in :func:`tabular_pipeline` for estimators instantiated from either
   :class:`tabicl.TabICLClassifier` or :class:`tabicl.TabICLRegressor` with recommended
   default parameters of :class:`TableVectorizer` as the first step, and the estimator
   as the second step.
-
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
+- Expanded dtypes accepted by the encoder `ToCategorical`. Now accepts `int` columns
+  by setting the new kwarg accept_numeric to ``"int"``. `float` columns are also now
+  accepted if ``accept_numeric="all"``. Previous default behavior is maintained by
+  setting ``accept_numeric=None``.
+  :pr:`2252` by :user:`Lisa McBride <lisaleemcb>`.
 
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,17 +43,14 @@ Changes
   containing the full X and y before splitting.
 
   :pr:`2213` by :user:`Jérôme Dockès <jeromedockes>`.
+
 - Added support in :func:`tabular_pipeline` for estimators instantiated from either
   :class:`tabicl.TabICLClassifier` or :class:`tabicl.TabICLRegressor` with recommended
   default parameters of :class:`TableVectorizer` as the first step, and the estimator
   as the second step.
+
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
-- Expanded dtypes accepted by the encoder `ToCategorical`. Now accepts `int` columns
-  by setting the new kwarg accept_numeric to ``"int"``. `float` columns are also now
-  accepted if ``accept_numeric="all"``. Previous default behavior is maintained by
-  setting ``accept_numeric=None``.
-  :pr:`2252` by :user:`Lisa McBride <lisaleemcb>`.
 
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,6 @@ Changes
   :class:`tabicl.TabICLClassifier` or :class:`tabicl.TabICLRegressor` with recommended
   default parameters of :class:`TableVectorizer` as the first step, and the estimator
   as the second step.
-
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
 
@@ -78,8 +77,8 @@ Bugfixes
 
 Deprecations
 ------------
-
-
+- The :class:`TextEncoder` has been renamed :class:`LLMEncoder`. It is still available
+  as an alias, but will be removed in a future release.
 
 
 Release 0.10.0

--- a/doc/_templates/index.html
+++ b/doc/_templates/index.html
@@ -109,8 +109,8 @@ fa-caret-down visible-small-screen"></i></p>
         (<a class="reference internal"
         href="reference/generated/skrub.StringEncoder.html#stringencoder"
         title="skrub.StringEncoder"><code class="xref py py-class docutils literal notranslate"><span class="pre">StringEncoder</span></code></a>,
-	<a class="reference internal" href="reference/generated/skrub.TextEncoder.html#textencoder"
-        title="skrub.TextEncoder"><code class="xref py py-class docutils literal notranslate"><span class="pre">TextEncoder</span></code></a>,
+	<a class="reference internal" href="reference/generated/skrub.LLMEncoder.html#LLMEncoder"
+        title="skrub.LLMEncoder"><code class="xref py py-class docutils literal notranslate"><span class="pre">LLMEncoder</span></code></a>,
 	<a class="reference internal" href="reference/generated/skrub.GapEncoder.html#gapencoder"
         title="skrub.GapEncoder"><code class="xref py py-class docutils literal notranslate"><span class="pre">GapEncoder</span></code></a>,
         and

--- a/doc/development/api_vs_testing.rst
+++ b/doc/development/api_vs_testing.rst
@@ -1,0 +1,208 @@
+.. _dev_api_vs_testing:
+
+Two layers, one purpose: the dispatch API and ``df_module``
+============================================================
+
+skrub has two distinct mechanisms for handling multiple dataframe backends:
+the dispatched *dataframe API* (``skrub/_dataframe``, ``skrub/_dispatch.py``) and
+the *``df_module`` fixture* (``skrub/conftest.py``). They look superficially
+similar — both abstract over pandas and polars — but they exist at different
+levels and serve different roles.  This guide explains the design rationale,
+where the boundary between them lies, and how to decide which to use.
+
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+
+The two layers at a glance
+---------------------------
+
++---------------------------+--------------------------------------+------------------------------------+
+|                           | Dispatch API                         | ``df_module`` fixture              |
++===========================+======================================+====================================+
+| **Where**                 | ``skrub/_dataframe/_common.py``,     | ``skrub/conftest.py``              |
+|                           | ``skrub/_dispatch.py``               |                                    |
++---------------------------+--------------------------------------+------------------------------------+
+| **When it runs**          | Production — at import time and      | Test time — under pytest only      |
+|                           | when skrub functions are called      |                                    |
++---------------------------+--------------------------------------+------------------------------------+
+| **What it abstracts**     | *How* to perform an operation        | *How* to construct inputs and      |
+|                           | (fill nulls, get shape, cast, …)     | assert outputs in a test           |
++---------------------------+--------------------------------------+------------------------------------+
+| **Who uses it**           | skrub transformers, encoders,        | Test functions                     |
+|                           | utility functions                    |                                    |
++---------------------------+--------------------------------------+------------------------------------+
+| **Mechanism**             | ``functools.singledispatch`` +        | pytest ``@fixture(params=…)``      |
+|                           | ``specialize`` decorator             |                                    |
++---------------------------+--------------------------------------+------------------------------------+
+| **Result of abstraction** | A single call site (``sbd.fill_nulls``) | A single test body runs 3 times |
+|                           | works for any backend                | (one per configuration)            |
++---------------------------+--------------------------------------+------------------------------------+
+
+
+The dataframe API: writing library-agnostic production code
+-----------------------------------------------------------
+
+The dataframe API solves a problem that arises *at runtime*: a transformer
+receives a DataFrame or a Series whose backend is not known at the time the
+code was written.  The ``@dispatch`` / ``specialize`` mechanism routes the
+call to the correct implementation based on the actual type of the object.
+
+Call sites in production code are completely library-agnostic:
+
+.. code-block:: python
+
+    import skrub._dataframe as sbd
+
+    def _process(col):
+        if sbd.has_nulls(col):
+            col = sbd.fill_nulls(col, 0)
+        return sbd.to_float32(col)
+
+Neither ``pandas`` nor ``polars`` is imported here.  The correct
+implementation — ``col.fillna(0)`` for pandas or ``col.fill_null(0)`` for
+polars — is selected automatically.
+
+The key properties of the dataframe API:
+
+* It is **production code** that ships as part of skrub's package.
+* It is imported and executed whenever a user calls a skrub estimator.
+* It says nothing about *how to build* a DataFrame or *how to assert equality*;
+  it only defines *operations* on existing objects.
+* It must handle real user data — arbitrary DataFrames that arrive from outside
+  skrub.
+
+
+``df_module``: testing library-agnostic code
+---------------------------------------------
+
+``df_module`` solves a different problem: when a test needs to construct
+inputs, call a function, and check the output, it must do so in a way that
+works for all three configurations.  ``df_module`` provides a uniform
+interface for these test-time concerns.
+
+A test using ``df_module`` is collected once and run three times by pytest:
+
+.. code-block:: python
+
+    def test_fill_nulls(df_module):
+        col = df_module.make_column("x", [1.0, None, 3.0])
+        result = sbd.fill_nulls(col, 0.0)
+        expected = df_module.make_column("x", [1.0, 0.0, 3.0])
+        df_module.assert_column_equal(result, expected)
+
+``df_module.make_column`` builds a ``pd.Series`` (numpy dtypes), a
+``pd.Series`` (nullable dtypes), or a ``pl.Series`` depending on the
+parameter.  ``df_module.assert_column_equal`` delegates to the right
+``*.testing`` module.  No ``if`` branches, no duplication.
+
+The key properties of ``df_module``:
+
+* It is **test infrastructure** that lives in ``conftest.py`` and is never
+  imported in production code.
+* It is only active when pytest runs.
+* It knows how to *construct* DataFrames and *assert equality*, not how to
+  perform arbitrary operations on them.
+* It works with controlled, synthetic data, not real user data.
+
+
+Why not collapse them?
+----------------------
+
+The two layers could theoretically be merged — for example, ``df_module``
+could use ``sbd.*`` to build its example objects.  There are deliberate
+reasons not to do this.
+
+**``df_module`` does not build on the dataframe API.**
+    ``df_module`` is part of the test bootstrap.  If it relied on ``sbd.*``
+    internally, a bug in the dispatch layer would corrupt the test inputs
+    themselves, making it impossible to distinguish "the function under test is
+    broken" from "the test fixture is broken".  Using the backends' own
+    constructors (``pd.DataFrame.from_dict``, ``pl.from_dict``, …) keeps the
+    fixture independent.
+
+**The dataframe API does not know about test concerns.**
+    The dispatch API is a production abstraction over dataframe *operations*.
+    Concepts like "an example DataFrame with four rows and mixed dtypes" or
+    "assert that two Series are equal up to dtype" are test concerns, not
+    operation concerns.  Mixing them would blur the boundary between production
+    and test code.
+
+**Three configurations, not two libraries.**
+    The dataframe API dispatches on ``pandas.DataFrame`` vs ``polars.DataFrame``
+    — two cases.  The test suite has three configurations: pandas-numpy-dtypes,
+    pandas-nullable-dtypes, and polars.  The extra pandas configuration catches
+    dtype-specific bugs that would be invisible if tests only ran against one
+    pandas variant.  The dataframe layer has no notion of "which pandas",
+    because from a runtime perspective both are ``pd.DataFrame``; only the test
+    layer needs to distinguish them.
+
+
+Decision guide
+--------------
+
+Use this table to decide where new code or infrastructure belongs.
+
++-----------------------------------------------+-----------------------------------+
+| Situation                                     | What to do                        |
++===============================================+===================================+
+| I need to perform a dataframe operation in    | Use ``sbd.*``.  If the function   |
+| a transformer or utility function.            | does not exist yet, add it to     |
+|                                               | ``_common.py`` (see               |
+|                                               | :ref:`dev_dataframe_api`).        |
++-----------------------------------------------+-----------------------------------+
+| I need to perform an operation that is        | Define a local ``@dispatch``      |
+| specific to one module (e.g. a helper in      | function in that module.  Do not  |
+| ``_datetime_encoder.py``) and has no reuse    | add it to ``_common.py``.         |
+| outside it.                                   |                                   |
++-----------------------------------------------+-----------------------------------+
+| I need to write a test for code that touches  | Use ``df_module``.                |
+| a DataFrame or column.                        |                                   |
++-----------------------------------------------+-----------------------------------+
+| I need a test that must run only for pandas.  | Use ``pd_module`` instead of      |
+|                                               | ``df_module``.                    |
++-----------------------------------------------+-----------------------------------+
+| I need a test that must run only for polars.  | Use ``pl_module`` (auto-skips if  |
+|                                               | polars is not installed).         |
++-----------------------------------------------+-----------------------------------+
+| I need to construct a backend-appropriate     | Use ``df_module.make_dataframe``  |
+| DataFrame in a test.                          | or ``df_module.make_column``.     |
++-----------------------------------------------+-----------------------------------+
+| I need a dtype value in a test that works     | Use ``df_module.dtypes["float64"]``|
+| across configurations.                        | (or whichever key you need).      |
++-----------------------------------------------+-----------------------------------+
+| I need to assert equality in a test.          | Use ``df_module.assert_frame_equal``|
+|                                               | or ``df_module.assert_column_equal``.|
++-----------------------------------------------+-----------------------------------+
+| I am unsure whether a new operation belongs   | If other transformers would       |
+| in ``_common.py`` or should be local.         | benefit from it: ``_common.py``.  |
+|                                               | If it is specific to one class:   |
+|                                               | local ``@dispatch``.              |
++-----------------------------------------------+-----------------------------------+
+
+A concrete heuristic: if you are writing code that will run when a user calls
+``TableVectorizer().fit_transform(df)``, use the dataframe API.  If you are
+writing code that only runs under ``pytest``, use ``df_module``.
+
+
+Parallel structure
+------------------
+
+Despite their different purposes, the two layers do mirror each other in one
+respect: both have a "all backends" path and a "specific backend" escape hatch.
+
+In the **dataframe API**:
+
+* ``sbd.fill_nulls(col, 0)`` — generic, works for any backend.
+* ``@fill_nulls.specialize("pandas", argument_type="Column")`` — pandas-specific
+  implementation, invoked automatically.
+
+In the **test fixture**:
+
+* ``df_module`` — generic, runs for every configuration.
+* ``pd_module`` / ``pl_module`` — fixed to one backend, used when the test
+  itself is backend-specific.
+
+The design principle is the same in both cases: write the general case once
+and isolate backend differences to dedicated, clearly labelled places.

--- a/doc/development/dataframe_api.rst
+++ b/doc/development/dataframe_api.rst
@@ -1,0 +1,358 @@
+.. _dev_dataframe_api:
+
+The dispatch-based dataframe API
+=================================
+
+skrub targets both pandas and polars as first-class backends.  Rather than
+scattering ``if pandas … else polars …`` branches throughout the codebase, all
+dataframe and column operations are funnelled through a thin dispatch layer that
+selects the right implementation at call time.  This guide explains how that
+layer works and how to extend it.
+
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+
+Motivation
+----------
+
+The naive approach to multi-backend support is to branch on the library name
+wherever an operation is performed:
+
+.. code-block:: python
+
+    # don't do this
+    if isinstance(col, pd.Series):
+        result = col.fillna(0)
+    else:
+        result = col.fill_null(0)
+
+This pattern is fragile: the same check must be repeated everywhere, adding a
+third backend means touching every branch, and tests must cover every path
+explicitly.  The dispatch layer inverts the design: each operation is defined
+once as a *generic function*, and the concrete implementation is registered
+separately per library.  Call sites stay library-agnostic.
+
+.. code-block:: python
+
+    import skrub._dataframe as sbd
+
+    result = sbd.fill_nulls(col, 0)   # works for pandas Series or polars Series
+
+
+How dispatching works
+---------------------
+
+The mechanism lives in ``skrub/_dispatch.py`` and is built on top of the
+standard library's :func:`functools.singledispatch`.
+
+``functools.singledispatch`` selects an implementation based on the *type* of
+the first argument.  The wrinkle is that some backends (currently polars) are
+optional dependencies: you cannot import ``polars.DataFrame`` to register a
+specialisation if polars is not installed.  The ``dispatch`` decorator works
+around this by accepting the library name as a string and resolving types only
+when the library is actually importable.
+
+The type registry
+~~~~~~~~~~~~~~~~~
+
+Internally, ``_dispatch.py`` maintains a registry mapping library names to
+their concrete types:
+
+.. code-block:: text
+
+    "pandas" → {
+        "DataFrame": (pandas.DataFrame,),
+        "Column":    (pandas.Series,),
+    }
+
+    "polars" → {
+        "DataFrame": (polars.DataFrame,),
+        "LazyFrame": (polars.LazyFrame,),
+        "EagerFrame": (polars.DataFrame,),
+        "Column":    (polars.Series,),
+    }
+
+These string names (``"DataFrame"``, ``"Column"``, ``"LazyFrame"``) are what
+you pass to ``specialize``'s ``argument_type`` keyword.
+
+The ``@dispatch`` decorator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applying ``@dispatch`` to a function converts it into a generic function and
+adds a ``specialize`` attribute:
+
+.. code-block:: python
+
+    from skrub._dispatch import dispatch, raise_dispatch_unregistered_type
+
+    @dispatch
+    def fill_nulls(col, value):
+        raise_dispatch_unregistered_type(col, kind="Series")
+
+The default body is the fallback that runs when no specialisation has been
+registered for the argument's type.  The idiomatic choice is to raise a
+descriptive error with ``raise_dispatch_unregistered_type``, though some
+functions use a safe no-op default (e.g. ``reset_index`` which is a pandas
+concept and simply returns ``obj`` unchanged for everything else).
+
+Registering specialisations with ``specialize``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    @fill_nulls.specialize("pandas", argument_type="Column")
+    def _fill_nulls_pandas(col, value):
+        return col.fillna(value)
+
+    @fill_nulls.specialize("polars", argument_type="Column")
+    def _fill_nulls_polars(col, value):
+        return col.fill_null(value)
+
+``specialize`` takes two arguments:
+
+* **Library name** (``"pandas"`` or ``"polars"``): the concrete implementations
+  are looked up only if that library is importable; otherwise the decorator
+  is a no-op and the function is never registered.
+* **``argument_type``** (optional): one of the string keys in the type registry,
+  or a tuple of them.  Omitting it registers the specialisation for *all* types
+  in that library (DataFrame, Column, and LazyFrame for polars).
+
++----------------------------------+------------------------------------------------+
+| ``argument_type``                | Registers for                                  |
++==================================+================================================+
+| ``None`` (default)               | All types in the library                       |
++----------------------------------+------------------------------------------------+
+| ``"DataFrame"``                  | DataFrame class only                           |
++----------------------------------+------------------------------------------------+
+| ``"Column"``                     | Series class only                              |
++----------------------------------+------------------------------------------------+
+| ``"LazyFrame"``                  | polars LazyFrame only                          |
++----------------------------------+------------------------------------------------+
+| ``("DataFrame", "Column")``      | Both DataFrame and Series                      |
++----------------------------------+------------------------------------------------+
+
+The **last** registered specialisation wins for a given type; there is no
+priority ordering based on specificity.  This means that if you register a
+specialisation for all pandas types and then later register one for
+``"Column"`` only, the second one will override the first for Series objects.
+
+Naming convention
+~~~~~~~~~~~~~~~~~
+
+Specialised implementations follow the pattern
+``_<generic_name>_<library>`` for library-wide specialisations, or
+``_<generic_name>_<library>_<type>`` when the ``argument_type`` is scoped:
+
+.. code-block:: python
+
+    _fill_nulls_pandas          # pandas-wide
+    _fill_nulls_polars          # polars-wide
+    _to_numpy_pandas_column     # pandas, Column only
+    _to_numpy_pandas_table      # pandas, DataFrame only
+
+The names are arbitrary and have no effect on dispatch; they are a
+documentation and searchability convention.
+
+Error messages
+~~~~~~~~~~~~~~
+
+``raise_dispatch_unregistered_type`` produces three distinct error messages:
+
+* **Unknown type**: "Expecting a Pandas or Polars <kind>, but got …"
+* **DataOp**: tells the caller to use ``.skb.eval()`` or ``.skb.apply_func()``
+  instead.
+* **LazyFrame**: tells the caller to call ``.collect()`` first.
+
+
+Using the API
+-------------
+
+Import convention
+~~~~~~~~~~~~~~~~~
+
+Throughout skrub, the module is imported under the alias ``sbd`` (or
+occasionally ``ns`` in older code and docstrings):
+
+.. code-block:: python
+
+    import skrub._dataframe as sbd
+
+This is a private module; it is not part of the public skrub API.
+
+Available functions
+~~~~~~~~~~~~~~~~~~~
+
+All public functions are re-exported from ``skrub/_dataframe/__init__.py``
+via ``from ._common import *``.  They are grouped conceptually in
+``_common.__all__``:
+
+**Type inspection**
+    ``dataframe_module_name``, ``is_pandas``, ``is_polars``,
+    ``is_dataframe``, ``is_lazyframe``, ``is_column``
+
+**Conversions**
+    ``to_list``, ``to_numpy``, ``to_pandas``,
+    ``make_dataframe_like``, ``make_column_like``, ``null_value_for``,
+    ``all_null_like``, ``concat``, ``is_column_list``, ``to_column_list``,
+    ``col``, ``col_by_idx``, ``collect``
+
+**Shape and metadata**
+    ``shape``, ``to_frame``, ``name``, ``column_names``, ``rename``,
+    ``set_column_names``, ``reset_index``, ``copy_index``, ``index``, ``drop``
+
+**Dtype inspection and casting**
+    ``dtype``, ``dtypes``, ``cast``, ``is_bool``, ``is_numeric``,
+    ``is_integer``, ``is_float``, ``to_float32``, ``is_string``, ``to_string``,
+    ``is_object``, ``is_any_date``, ``to_datetime``, ``is_duration``,
+    ``is_categorical``, ``to_categorical``, ``is_all_null``, ``is_empty_frame``,
+    ``is_pandas_extension_dtype``, ``pandas_convert_dtypes``, ``is_pandas_object``
+
+**Values**
+    ``all``, ``any``, ``sum``, ``min``, ``max``, ``std``, ``mean``,
+    ``pearson_corr``, ``sort``, ``value_counts``, ``quantile``,
+    ``is_null``, ``has_nulls``, ``drop_nulls``, ``fill_nulls``,
+    ``n_unique``, ``unique``, ``filter``, ``where``, ``where_row``,
+    ``sample``, ``head``, ``slice``, ``select_rows``, ``replace``,
+    ``with_columns``, ``abs``, ``total_seconds``, ``is_sorted``
+
+Example usage:
+
+.. code-block:: python
+
+    import skrub._dataframe as sbd
+
+    # Works for a pandas Series or a polars Series
+    col = ...
+    if sbd.has_nulls(col):
+        col = sbd.fill_nulls(col, 0)
+
+    # Works for a pandas DataFrame or a polars DataFrame
+    df = ...
+    n_rows, n_cols = sbd.shape(df)
+    names = sbd.column_names(df)
+
+
+Adding a function to ``_common.py``
+------------------------------------
+
+Step 1 — write the generic function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the function near related ones in ``skrub/_dataframe/_common.py``.
+The first argument must be the dataframe or column that will drive dispatch.
+
+.. code-block:: python
+
+    @dispatch
+    def clip(col, lower, upper):
+        """Clip values in a column to [lower, upper]."""
+        raise_dispatch_unregistered_type(col, kind="Series")
+
+If a sensible no-op default exists (e.g. the operation is pandas-specific),
+you can return ``obj`` or another safe value instead of raising.
+
+Step 2 — add specialisations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    @clip.specialize("pandas", argument_type="Column")
+    def _clip_pandas(col, lower, upper):
+        return col.clip(lower=lower, upper=upper)
+
+    @clip.specialize("polars", argument_type="Column")
+    def _clip_polars(col, lower, upper):
+        return col.clip(lower_bound=lower, upper_bound=upper)
+
+Step 3 — add to ``__all__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the function name to the ``__all__`` list at the top of ``_common.py``,
+in the appropriate section.
+
+Step 4 — write tests
+~~~~~~~~~~~~~~~~~~~~~
+
+Add a test in ``skrub/_dataframe/tests/test_common.py`` using the
+``df_module`` fixture (see :ref:`dev_testing`).
+
+.. code-block:: python
+
+    def test_clip(df_module):
+        col = df_module.make_column("x", [1, 5, 10, -3])
+        result = sbd.clip(col, lower=0, upper=7)
+        expected = df_module.make_column("x", [1, 5, 7, 0])
+        df_module.assert_column_equal(result, expected)
+
+
+Defining dispatched functions outside ``_common.py``
+------------------------------------------------------
+
+Not all dispatched functions belong in ``_common.py``.  If the operation is
+tightly coupled to a specific transformer or sub-module and has no use
+elsewhere, define it locally in that module.  Examples include
+``_is_date`` and ``_get_dt_feature`` in ``skrub/_datetime_encoder.py``, and
+``_str_replace`` in ``skrub/_to_float.py``.
+
+The pattern is identical to ``_common.py``, using the same ``dispatch`` and
+``raise_dispatch_unregistered_type`` imported from ``skrub._dispatch``:
+
+.. code-block:: python
+
+    # skrub/_my_transformer.py
+
+    from ._dispatch import dispatch, raise_dispatch_unregistered_type
+    import skrub._dataframe as sbd
+
+    @dispatch
+    def _extract_something(col):
+        raise_dispatch_unregistered_type(col, kind="Series")
+
+    @_extract_something.specialize("pandas", argument_type="Column")
+    def _extract_something_pandas(col):
+        # pandas-specific implementation
+        return col.str.extract(r"(\d+)")
+
+    @_extract_something.specialize("polars", argument_type="Column")
+    def _extract_something_polars(col):
+        # polars-specific implementation
+        return col.str.extract(r"(\d+)", group_index=0)
+
+A real example from ``skrub/_datetime_encoder.py``:
+
+.. code-block:: python
+
+    @dispatch
+    def _is_date(col):
+        from ._dispatch import raise_dispatch_unregistered_type
+        raise_dispatch_unregistered_type(col, kind="Series")
+
+    @_is_date.specialize("pandas", argument_type="Column")
+    def _is_date_pandas(col):
+        col = sbd.drop_nulls(col)
+        return (col.dt.normalize() == col).all()
+
+    @_is_date.specialize("polars", argument_type="Column")
+    def _is_date_polars(col):
+        return (col.dt.date() == col).all()
+
+Functions defined this way are **not** exported from ``skrub._dataframe``; they
+are module-private helpers.  Only add a function to ``_common.py`` and its
+``__all__`` when it is genuinely reusable across multiple parts of skrub.
+
+
+Rules for production code
+--------------------------
+
+* **Always use** ``sbd.*`` for dataframe or column operations; never call
+  ``df.method()`` directly outside a ``specialize`` block.
+* Keep the **first argument** as the dispatching argument (the dataframe or
+  column).  A function ``sample(n, df)`` would dispatch on ``n``, which is
+  wrong; it must be ``sample(df, n)``.
+* Inside a ``specialize`` block, it is safe to import the backend module and
+  call any of its methods — you are guaranteed the first argument is that
+  backend's type.
+* Outside a ``specialize`` block, never import polars unconditionally; polars
+  is an optional dependency.

--- a/doc/development/testing.rst
+++ b/doc/development/testing.rst
@@ -1,0 +1,329 @@
+.. _dev_testing:
+
+Testing with the ``df_module`` fixture
+=======================================
+
+skrub's test suite must verify that every dataframe-aware feature works
+correctly for all supported backends and dtype configurations.  Writing the
+same test three times would be tedious and error-prone, so the suite provides a
+parametrised fixture, ``df_module``, that multiplies a single test across all
+configurations automatically.
+
+This guide explains how ``df_module`` works, what attributes it provides, and
+how to write effective tests using it.
+
+.. contents:: Contents
+   :local:
+   :depth: 2
+
+
+Why a parametrised fixture
+---------------------------
+
+skrub supports three distinct configurations in practice:
+
+* **pandas with NumPy dtypes** (``pandas-numpy-dtypes``): the classical pandas
+  dtypes backed by NumPy arrays — e.g. ``np.float64``, ``np.int64``.  Integer
+  columns that contain ``None`` will be cast to ``float64`` because NumPy
+  integers cannot represent missing values.
+
+* **pandas with nullable extension dtypes** (``pandas-nullable-dtypes``):
+  pandas' own nullable types — e.g. ``pd.Float64Dtype()``, ``pd.Int64Dtype()``.
+  These represent missing values without promoting integer columns to float and
+  behave somewhat differently from NumPy-backed dtypes.
+
+* **polars** (``polars``): polars DataFrames and Series, which have their own
+  type system, naming conventions, and API.
+
+A test that only runs under one configuration may pass while silently failing
+under the other two.  The ``df_module`` fixture ensures that a single test
+function covers all three automatically.
+
+How pytest sees it: a test that requests ``df_module`` is collected once and
+run three times, once per parameter, producing independent pass/fail results.
+If polars is not installed, the polars parameter is absent and the test runs
+twice.
+
+
+Anatomy of ``df_module``
+-------------------------
+
+``df_module`` is defined in ``skrub/conftest.py`` and returns a
+:class:`types.SimpleNamespace` with a consistent set of attributes.  The
+attributes are designed to normalise the differences between libraries so test
+bodies need no ``if pandas / if polars`` branches (with few exceptions).
+
+The fixture signature:
+
+.. code-block:: python
+
+    @pytest.fixture(params=["pandas-numpy-dtypes", "pandas-nullable-dtypes", "polars"])
+    def df_module(request):
+        return _DATAFRAME_MODULES_INFO[request.param]
+
+Attributes
+~~~~~~~~~~
+
+``name`` — ``str``
+    The library name: ``"pandas"`` or ``"polars"``.  Useful when a test must
+    assert on the name or skip/branch based on the library.
+
+    .. code-block:: python
+
+        assert sbd.dataframe_module_name(df) == df_module.name
+
+``description`` — ``str``
+    The full configuration key: ``"pandas-numpy-dtypes"``,
+    ``"pandas-nullable-dtypes"``, or ``"polars"``.  Use this when you need to
+    distinguish between the two pandas configurations.
+
+``module`` — module object
+    The backend module itself (``pandas`` or ``polars``).  Useful if you need
+    to access constants or secondary helpers directly.
+
+``DataFrame`` — class
+    The DataFrame class for this configuration: ``pd.DataFrame`` or
+    ``pl.DataFrame``.
+
+``Column`` — class
+    The column/series class: ``pd.Series`` or ``pl.Series``.
+
+``make_dataframe(data: dict) → DataFrame``
+    Build a DataFrame from a column-name → values dictionary.  Under
+    ``pandas-nullable-dtypes`` it additionally calls ``.convert_dtypes()``, so
+    the resulting dtypes are the nullable extension types.
+
+    .. code-block:: python
+
+        df = df_module.make_dataframe({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+``make_column(name: str, values: list) → Column``
+    Build a single column.
+
+    .. code-block:: python
+
+        col = df_module.make_column("score", [1.0, 2.5, None])
+
+``assert_frame_equal(left, right, **kwargs)``
+    Assert that two DataFrames are equal, using the backend's own testing
+    helper (``pandas.testing.assert_frame_equal`` or
+    ``polars.testing.assert_frame_equal``).
+
+``assert_column_equal(left, right, **kwargs)``
+    Assert that two columns are equal.
+
+``empty_dataframe`` — DataFrame
+    A DataFrame with zero rows and zero columns.  Useful as a trivial input to
+    check that functions handle empty frames gracefully.
+
+``empty_column`` — Column
+    A column of length zero.
+
+``empty_lazyframe`` — polars LazyFrame
+    A lazy DataFrame with zero rows and zero columns.  **Only present for the
+    polars configuration**; accessing it on a pandas ``df_module`` will raise
+    ``AttributeError``.
+
+``example_dataframe`` — DataFrame
+    A ready-made DataFrame containing one column of each common dtype: integer
+    (with nulls), integer (without nulls), float, string, boolean (with nulls),
+    boolean (without nulls), datetime, and date.  The exact values are defined
+    by ``_example_data_dict`` in ``conftest.py``.  Use this when you want a
+    realistic multi-type frame without constructing one manually.
+
+``example_column`` — Column
+    The ``"float-col"`` column from ``example_dataframe`` (floats with one
+    ``None``).
+
+``dtypes`` — ``dict``
+    A mapping from dtype name (string) to the appropriate dtype value for this
+    configuration.  The keys are ``"float32"``, ``"float64"``, ``"int32"``,
+    ``"int64"``, and ``"category"``.
+
+    +----------+------------------+-------------------+-------------+
+    | Key      | numpy-dtypes     | nullable-dtypes   | polars      |
+    +==========+==================+===================+=============+
+    | float32  | ``np.float32``   | ``Float32Dtype``  | ``pl.Float32`` |
+    +----------+------------------+-------------------+-------------+
+    | float64  | ``np.float64``   | ``Float64Dtype``  | ``pl.Float64`` |
+    +----------+------------------+-------------------+-------------+
+    | int32    | ``np.int32``     | ``Int32Dtype``    | ``pl.Int32`` |
+    +----------+------------------+-------------------+-------------+
+    | int64    | ``np.int64``     | ``Int64Dtype``    | ``pl.Int64`` |
+    +----------+------------------+-------------------+-------------+
+    | category | ``CategoricalDtype`` | ``CategoricalDtype`` | ``pl.Categorical`` |
+    +----------+------------------+-------------------+-------------+
+
+
+Writing a basic test
+---------------------
+
+Here is a minimal test of a hypothetical ``my_transform`` function:
+
+.. code-block:: python
+
+    import skrub._dataframe as sbd
+
+    def test_my_transform(df_module):
+        # Build backend-appropriate inputs
+        col = df_module.make_column("x", [1.0, 2.0, None, 4.0])
+
+        result = my_transform(col)
+
+        expected = df_module.make_column("x", [1.0, 4.0, None, 16.0])
+        df_module.assert_column_equal(result, expected)
+
+A few rules of thumb:
+
+* Build inputs with ``df_module.make_dataframe`` / ``df_module.make_column``
+  so that dtypes are correct for the current configuration.
+* Assert with ``df_module.assert_frame_equal`` / ``df_module.assert_column_equal``
+  rather than hand-rolling equality checks.  These helpers understand
+  backend-specific equality semantics (e.g. null handling).
+* When you need to check a dtype, use ``df_module.dtypes["float64"]`` rather
+  than hard-coding ``np.float64``; the correct value depends on the
+  configuration.
+
+Using the ``dtypes`` dict
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Suppose you are testing a function that should return a float32 column:
+
+.. code-block:: python
+
+    def test_returns_float32(df_module):
+        col = df_module.make_column("x", [1, 2, 3])
+        result = sbd.to_float32(col)
+        assert sbd.dtype(result) == df_module.dtypes["float32"]
+
+
+Defining example dataframes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Depending on the test, it is normally better to define dataframes that are tailored
+for the desired test result. ``df_module.make_dataframe`` generates a dataframe for
+each module starting from a python dictionary:
+
+.. code-block:: python
+
+    def test_column_names(df_module):
+        df = df_module.make_dataframe({"a": [1, 2, 3], "b": [4, 5, 6]})
+        names = sbd.column_names(df)
+        assert "a" in names
+        assert "b" in names
+
+If multiple types are required for a given test, then ``example_dataframe`` can
+be used to avoid boilerplate:
+
+.. code-block:: python
+
+    def test_column_names(df_module):
+        df = df_module.example_dataframe
+        names = sbd.column_names(df)
+        assert "float-col" in names
+        assert "datetime-col" in names
+
+
+Related fixtures
+-----------------
+
+Several narrower fixtures complement ``df_module``.
+
+``pd_module``
+~~~~~~~~~~~~~
+
+Always the ``"pandas-numpy-dtypes"`` configuration.  Use when you need to test
+pandas-specific behaviour that is not part of the cross-backend API, or when
+the test only makes sense for pandas.
+
+.. code-block:: python
+
+    def test_pandas_index_is_reset(pd_module):
+        df = pd_module.make_dataframe({"a": [1, 2, 3]})
+        df.index = [10, 20, 30]
+        result = sbd.reset_index(df)
+        assert list(result.index) == [0, 1, 2]
+
+``pl_module``
+~~~~~~~~~~~~~
+
+The polars configuration.  If polars is not installed, the test is
+automatically skipped with ``pytest.skip``.  Use for polars-specific
+behaviour.
+
+.. code-block:: python
+
+    def test_lazyframe_is_rejected(pl_module):
+        lazy = pl_module.empty_lazyframe
+        with pytest.raises(TypeError, match="LazyFrames are not yet supported"):
+            sbd.shape(lazy)
+
+``all_dataframe_modules``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Returns the full ``dict`` mapping configuration name to namespace.  Use when
+you need to iterate over all configurations programmatically inside a single
+test body rather than through pytest parametrisation.
+
+``use_fit_transform``
+~~~~~~~~~~~~~~~~~~~~~
+
+A boolean fixture parametrised as ``[False, True]``.  Use it to run the same
+test through both ``fit`` + ``transform`` and ``fit_transform`` without
+duplicating the test body:
+
+.. code-block:: python
+
+    def test_encoder(df_module, use_fit_transform):
+        enc = MyEncoder()
+        if use_fit_transform:
+            result = enc.fit_transform(df_module.example_dataframe)
+        else:
+            result = enc.fit(df_module.example_dataframe).transform(
+                df_module.example_dataframe
+            )
+        ...
+
+
+Polars-specific considerations
+-------------------------------
+
+LazyFrames
+~~~~~~~~~~
+
+The ``df_module`` fixture provides an ``empty_lazyframe`` attribute only for
+the polars configuration.  Most skrub functions expect an *eager* DataFrame;
+passing a LazyFrame raises a ``TypeError`` with a message telling the caller
+to call ``.collect()``.  Test this behaviour explicitly if your function could
+receive a LazyFrame.
+
+The ``skip_polars_installed_without_pyarrow`` mark
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some polars operations (some date/time conversions, functions that involve the
+computation of column associations) require pyarrow.
+A mark is available to skip those tests when polars is installed but pyarrow
+is not:
+
+.. code-block:: python
+
+    from skrub.conftest import skip_polars_installed_without_pyarrow
+
+    @skip_polars_installed_without_pyarrow
+    def test_datetime_conversion(df_module):
+        ...
+
+Apply this mark to tests that call polars functionality backed by pyarrow.
+
+Where tests live
+-----------------
+
+Tests for transformers and their functions live in their respective test file:
+the code of the ``DatetimeEncoder`` is in ``skrub/_datetime_encoder.py``, while
+its tests are in ``skrub/tests/test_datetime_encoder.py``.
+
+Each submodule contains both the code and its tests. For example, the code for the
+dataframe API is in ``skrub/_dataframe``, while the relative tests are in
+``skrub/_dataframe/tests``. All tests can request ``df_module``: the fixture is
+visible to the entire ``skrub/`` test tree because it is defined in
+``skrub/conftest.py``.

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -37,7 +37,7 @@ Install
 
 **Deep learning dependencies**
 
-Deep-learning based encoders like :class:`TextEncoder` require installing optional
+Deep-learning based encoders like :class:`LLMEncoder` require installing optional
 dependencies to use them. The following will install
 `torch <https://pypi.org/project/torch/>`_,
 `transformers <https://pypi.org/project/transformers/>`_,
@@ -62,7 +62,7 @@ and `sentence-transformers <https://pypi.org/project/sentence-transformers/>`_.
 
 **Deep learning dependencies**
 
-Deep-learning based encoders like :class:`TextEncoder` require installing optional
+Deep-learning based encoders like :class:`LLMEncoder` require installing optional
 dependencies to use them. The following will install
 `torch <https://anaconda.org/pytorch/pytorch>`_,
 `transformers <https://anaconda.org/conda-forge/transformers>`_,
@@ -87,7 +87,7 @@ and `sentence-transformers <https://anaconda.org/conda-forge/sentence-transforme
 
 **Deep learning dependencies**
 
-Deep-learning based encoders like :class:`TextEncoder` require installing optional
+Deep-learning based encoders like :class:`LLMEncoder` require installing optional
 dependencies to use them. The following will install
 `torch <https://anaconda.org/pytorch/pytorch>`_,
 `transformers <https://anaconda.org/conda-forge/transformers>`_,
@@ -216,7 +216,7 @@ After that, your environment is ready for development!
 
 **Deep learning dependencies**
 
-Deep-learning based encoders like :class:`TextEncoder` require installing optional
+Deep-learning based encoders like :class:`LLMEncoder` require installing optional
 dependencies to use them. The following will install
 `torch <https://pypi.org/project/torch/>`_,
 `transformers <https://pypi.org/project/transformers/>`_,

--- a/doc/modules/column_level_featurizing/feature_engineering_categorical.rst
+++ b/doc/modules/column_level_featurizing/feature_engineering_categorical.rst
@@ -1,6 +1,6 @@
 
 .. |StringEncoder| replace:: :class:`~skrub.StringEncoder`
-.. |TextEncoder| replace:: :class:`~skrub.TextEncoder`
+.. |LLMEncoder| replace:: :class:`~skrub.LLMEncoder`
 .. |MinHashEncoder| replace:: :class:`~skrub.MinHashEncoder`
 .. |GapEncoder| replace:: :class:`~skrub.GapEncoder`
 .. |TableVectorizer| replace:: :class:`~skrub.TableVectorizer`
@@ -74,13 +74,13 @@ Choosing the right encoder for the job
   (`Latent Semantic Analysis <https://en.wikipedia.org/wiki/Latent_semantic_analysis>`_).
   This is the default encoder used by the |TableVectorizer| and the |tabular_pipeline|.
 
-- |TextEncoder|: **language model-based, strong on text but expensive to run**:
+- |LLMEncoder|: **language model-based, strong on text but expensive to run**:
   This encoder encodes string features using pretrained language models from the
   HuggingFace Hub. It is a wrapper around `sentence-transformers <https://sbert.net/>`_
   compatible with the scikit-learn API and usable in pipelines. Best for free-flowing
   text and when columns include context found in the pretrained model (e.g., names of
   cities etc.). Note that this encoder can take a very long time to train, especially
-  on large datasets and on CPU. The |TextEncoder| has additional dependencies that
+  on large datasets and on CPU. The |LLMEncoder| has additional dependencies that
   are not included in the standard skrub installation.
   Refer to :ref:`installation_instructions` for info on how to prepare the
   environment.
@@ -110,7 +110,7 @@ Choosing the right encoder for the job
       - Good
       - Good
       -
-    * - |TextEncoder|
+    * - |LLMEncoder|
       - Very slow
       - Mediocre to good
       - Very good

--- a/doc/modules/data_ops/ml_pipeline/applying_different_transformers.rst
+++ b/doc/modules/data_ops/ml_pipeline/applying_different_transformers.rst
@@ -8,7 +8,7 @@ It is possible to use skrub selectors to define which columns to apply
 transformers to, and then apply different transformers to different subsets of
 the data.
 
-For example, this can be useful to apply :class:`~skrub.TextEncoder` to columns
+For example, this can be useful to apply :class:`~skrub.LLMEncoder` to columns
 that contain free-flowing text, and :class:`~skrub.StringEncoder` to other string
 columns that contain categorical data such as country names.
 

--- a/doc/modules/data_ops/validation/tuning_validating_data_ops.rst
+++ b/doc/modules/data_ops/validation/tuning_validating_data_ops.rst
@@ -286,7 +286,7 @@ Avoiding computing predictions multiple times
 
 This section gives a few tips to avoid recomputing predictions, which is
 particularly important for pipelines for which inference is expensive, such as
-those using the :class:`TextEncoder` or Tabular Foundation Models such as
+those using the :class:`LLMEncoder` or Tabular Foundation Models such as
 `TabICL <https://tabicl.readthedocs.io/en/latest/>`_.
 
 When :meth:`DataOp.skb.with_scoring` is used, predictions are cached during

--- a/doc/modules/default_wrangling/table_vectorizer.rst
+++ b/doc/modules/default_wrangling/table_vectorizer.rst
@@ -5,7 +5,7 @@
 .. |StringEncoder| replace:: :class:`~skrub.StringEncoder`
 .. |OneHotEncoder| replace:: :class:`~sklearn.preprocessing.OneHotEncoder`
 .. |OrdinalEncoder| replace:: :class:`~sklearn.preprocessing.OrdinalEncoder`
-.. |TextEncoder| replace:: :class:`~skrub.TextEncoder`
+.. |LLMEncoder| replace:: :class:`~skrub.LLMEncoder`
 .. |ApplyToCols| replace:: :class:`~skrub.ApplyToCols`
 .. |ToCategorical| replace:: :class:`~skrub.ToCategorical`
 
@@ -59,15 +59,15 @@ using :func:`~skrub.set_config`.
 To change the encoder or alter default parameters, instantiate an encoder and pass
 it to |TableVectorizer|.
 
->>> from skrub import TableVectorizer, DatetimeEncoder, TextEncoder, SquashingScaler
+>>> from skrub import TableVectorizer, DatetimeEncoder, LLMEncoder, SquashingScaler
 
 >>> datetime_enc = DatetimeEncoder(periodic_encoding="circular")
->>> text_enc = TextEncoder()
+>>> text_enc = LLMEncoder()
 >>> num_enc = SquashingScaler()
 >>> table_vec = TableVectorizer(datetime=datetime_enc, high_cardinality=text_enc, numeric=num_enc)
 >>> table_vec
 TableVectorizer(datetime=DatetimeEncoder(periodic_encoding='circular'),
-                high_cardinality=TextEncoder(), numeric=SquashingScaler())
+                high_cardinality=LLMEncoder(), numeric=SquashingScaler())
 
 
 Besides the transformers provided by skrub, the |TableVectorizer| can also take

--- a/doc/tutorials/0000_getting_started.py
+++ b/doc/tutorials/0000_getting_started.py
@@ -20,7 +20,7 @@ the features we present in this example and the following ones.
 .. |DatetimeEncoder| replace:: :class:`~skrub.DatetimeEncoder`
 .. |ApplyToCols| replace:: :class:`~skrub.ApplyToCols`
 .. |StringEncoder| replace:: :class:`~skrub.StringEncoder`
-.. |TextEncoder| replace:: :class:`~skrub.TextEncoder`
+.. |LLMEncoder| replace:: :class:`~skrub.LLMEncoder`
 """
 
 # %%
@@ -187,7 +187,7 @@ StringEncoder(n_components=3).fit_transform(data["city"])
 
 # %%
 # If your data includes a lot of text, you may want to use the
-# |TextEncoder|,
+# |LLMEncoder|,
 # which uses pre-trained language models retrieved from the HuggingFace hub to
 # create meaningful text embeddings.
 # See :ref:`user_guide_encoders_index` for more details on all the categorical encoders

--- a/examples/01_encoding/0020_text_with_string_encoders.py
+++ b/examples/01_encoding/0020_text_with_string_encoders.py
@@ -14,8 +14,8 @@ available in skrub.
 .. |MinHashEncoder| replace::
      :class:`~skrub.MinHashEncoder`
 
-.. |TextEncoder| replace::
-     :class:`~skrub.TextEncoder`
+.. |LLMEncoder| replace::
+     :class:`~skrub.LLMEncoder`
 
 .. |StringEncoder| replace::
      :class:`~skrub.StringEncoder`
@@ -210,7 +210,7 @@ plot_box_results(results)
 # Remarkably, the vectors produced by the |MinHashEncoder| offer less predictive
 # power than those from the |GapEncoder| on this dataset.
 #
-# TextEncoder
+# LLMEncoder
 # ^^^^^^^^^^^
 # Let's now shift our focus to pre-trained deep learning encoders. Our previous
 # encoders are syntactic models that we trained directly on the toxicity dataset.
@@ -218,12 +218,12 @@ plot_box_results(results)
 # entries, we can instead use semantic models, such as BERT, which have been trained
 # on very large datasets.
 #
-# |TextEncoder| enables you to integrate any Sentence Transformer model from the
+# |LLMEncoder| enables you to integrate any Sentence Transformer model from the
 # Hugging Face Hub (or from your local disk) into your |pipeline| to transform a text
-# column in a dataframe. By default, |TextEncoder| uses the e5-small-v2 model.
-from skrub import TextEncoder
+# column in a dataframe. By default, |LLMEncoder| uses the e5-small-v2 model.
+from skrub import LLMEncoder
 
-text_encoder = TextEncoder(
+text_encoder = LLMEncoder(
     "sentence-transformers/paraphrase-albert-small-v2",
     device="cpu",
 )
@@ -233,14 +233,14 @@ text_encoder_pipe = make_pipeline(
     HistGradientBoostingClassifier(),
 )
 text_encoder_results = cross_validate(text_encoder_pipe, X, y, scoring="roc_auc")
-results.append(("TextEncoder", text_encoder_results))
+results.append(("LLMEncoder", text_encoder_results))
 
 plot_box_results(results)
 
 # %%
 # StringEncoder
 # ^^^^^^^^^^^^^
-# |TextEncoder| embeddings are very strong, but they are also quite expensive to
+# |LLMEncoder| embeddings are very strong, but they are also quite expensive to
 # use. A simpler, faster alternative for encoding strings is the |StringEncoder|,
 # which works by first performing a tf-idf (computing vectors of rescaled word
 # counts of the text `wiki <https://en.wikipedia.org/wiki/Tf%E2%80%93idf>`_), and then
@@ -262,7 +262,7 @@ plot_box_results(results)
 
 
 # %%
-# The performance of the |TextEncoder| is significantly stronger than that of
+# The performance of the |LLMEncoder| is significantly stronger than that of
 # the syntactic encoders, which is expected. But how long does it take to load
 # and vectorize text on a CPU using a Sentence Transformer model? Below, we display
 # the tradeoff between predictive accuracy and training time. Note that since we are
@@ -340,7 +340,7 @@ plot_performance_tradeoff(results)
 #
 # Conclusion
 # ----------
-# In conclusion, |TextEncoder| provides powerful vectorization for text, but at
+# In conclusion, |LLMEncoder| provides powerful vectorization for text, but at
 # the cost of longer computation times and the need for additional dependencies,
 # such as torch. |StringEncoder| represents a simpler alternative that can provide
 # good performance at a fraction of the cost of more complex methods.

--- a/skrub/__init__.py
+++ b/skrub/__init__.py
@@ -56,7 +56,7 @@ from ._squashing_scaler import SquashingScaler
 from ._string_encoder import StringEncoder
 from ._table_vectorizer import Cleaner, TableVectorizer
 from ._tabular_pipeline import tabular_pipeline
-from ._text_encoder import TextEncoder
+from ._text_encoder import LLMEncoder, TextEncoder
 from ._to_categorical import ToCategorical
 from ._to_datetime import ToDatetime, to_datetime
 from ._to_float import ToFloat
@@ -84,7 +84,7 @@ __all__ = [
     "ToFloat",
     "ToCategorical",
     "TableVectorizer",
-    "TextEncoder",
+    "LLMEncoder",
     "StringEncoder",
     "Cleaner",
     "DropSimilar",
@@ -119,4 +119,5 @@ __all__ = [
     "config_context",
     "SessionEncoder",
     "core",
+    "TextEncoder",
 ]

--- a/skrub/_data_ops/tests/test_choosing.py
+++ b/skrub/_data_ops/tests/test_choosing.py
@@ -232,17 +232,17 @@ def test_choice_repr():
     >>> skrub.choose_from(
     ...     [
     ...         skrub.StringEncoder(n_components=n_components),
-    ...         skrub.TextEncoder(n_components=n_components),
+    ...         skrub.LLMEncoder(n_components=n_components),
     ...     ]
     ... )
-    choose_from([StringEncoder(...), TextEncoder(...)])
+    choose_from([StringEncoder(...), LLMEncoder(...)])
     >>> skrub.choose_from(
     ...     {
     ...         "string": skrub.StringEncoder(n_components=n_components),
-    ...         "text": skrub.TextEncoder(n_components=n_components),
+    ...         "text": skrub.LLMEncoder(n_components=n_components),
     ...     }
     ... )
-    choose_from({'string': StringEncoder(...), 'text': TextEncoder(...)})
+    choose_from({'string': StringEncoder(...), 'text': LLMEncoder(...)})
 
     >>> skrub.choose_from([np.eye(3)])
     choose_from([ndarray(...)])

--- a/skrub/_gap_encoder.py
+++ b/skrub/_gap_encoder.py
@@ -131,7 +131,7 @@ class GapEncoder(TransformerMixin, SingleColumnTransformer):
         Encode string columns as a numeric array with the minhash method.
     SimilarityEncoder :
         Encode string columns as a numeric array with n-gram string similarity.
-    TextEncoder :
+    LLMEncoder :
         Encode string columns with a pretrained language model.
     StringEncoder
         Fast n-gram encoding of string columns.

--- a/skrub/_scaling_factor.py
+++ b/skrub/_scaling_factor.py
@@ -18,7 +18,7 @@ def scaling_factor(X):
     r"""Compute the total standard deviation scaler of X.
 
     This scaling factor is used to normalize the vectors outputs of
-    :class:`StringEncoder`, :class:`TextEncoder` and :class:`GapEncoder`. It is computed
+    :class:`StringEncoder`, :class:`LLMEncoder` and :class:`GapEncoder`. It is computed
     during ``fit`` and applied during ``transform``.
 
     Conceptually, this coefficient corresponds to the square root of the sum of the

--- a/skrub/_similarity_encoder.py
+++ b/skrub/_similarity_encoder.py
@@ -217,7 +217,7 @@ class SimilarityEncoder(OneHotEncoder):
     GapEncoder :
         Encodes dirty categories (strings) by constructing latent topics
         with continuous encoding.
-    TextEncoder :
+    LLMEncoder :
         Encode string columns with a pretrained language model.
     deduplicate :
         Deduplicate data by hierarchically clustering similar strings.

--- a/skrub/_string_encoder.py
+++ b/skrub/_string_encoder.py
@@ -84,7 +84,7 @@ class StringEncoder(TransformerMixin, SingleColumnTransformer):
         Encode string columns as a numeric array with the minhash method.
     GapEncoder :
         Encode string columns by constructing latent topics.
-    TextEncoder :
+    LLMEncoder :
         Encode string columns using pre-trained language models.
 
     Notes

--- a/skrub/_text_encoder.py
+++ b/skrub/_text_encoder.py
@@ -19,7 +19,7 @@ class ModelNotFound(ValueError):
     pass
 
 
-class TextEncoder(SingleColumnTransformer):
+class LLMEncoder(SingleColumnTransformer):
     """Encode string features by applying a pretrained language model \
         downloaded from the HuggingFace Hub.
 
@@ -80,28 +80,28 @@ class TextEncoder(SingleColumnTransformer):
     cache_folder : str, default=None
         Path to store models. By default ``~/skrub_data``.
         See :func:`skrub.datasets.get_data_dir`.
-        Note that when unpickling ``TextEncoder`` on another machine,
+        Note that when unpickling ``LLMEncoder`` on another machine,
         the ``cache_folder`` path needs to be accessible to store the downloaded model.
 
     store_weights_in_pickle : bool, default=False
         Whether or not to keep the loaded sentence-transformers model
-        in the ``TextEncoder`` when pickling.
+        in the ``LLMEncoder`` when pickling.
 
         - When set to False, the ``_estimator`` property is removed from
           the object to pickle, which significantly reduces the size of
           the serialized object. Note that when the serialized object is
-          unpickled on another machine, the ``TextEncoder`` will try to download
+          unpickled on another machine, the ``LLMEncoder`` will try to download
           the sentence-transformer model again from HuggingFace Hub.
           This process could fail if, for example, the machine doesn't have
           internet access. Additionally, if you use weights stored on disk
           that are *not* on the HuggingFace Hub (by passing a path to
           ``model_name``), these weights will not be pickled either.
           Therefore you would need to copy them to the machine where you
-          unpickle the ``TextEncoder``.
+          unpickle the ``LLMEncoder``.
         - When set to True, the ``_estimator`` property is included in
           the serialized object. Users deploying fine-tuned models stored on
           disk are recommended to use this option. Note that the machine
-          where the ``TextEncoder`` is unpickled must have the same device than
+          where the ``LLMEncoder`` is unpickled must have the same device than
           the machine where it was pickled.
 
     random_state : int, RandomState instance or None, default=None
@@ -168,11 +168,11 @@ class TextEncoder(SingleColumnTransformer):
     Examples
     --------
     >>> import pandas as pd
-    >>> from skrub import TextEncoder
+    >>> from skrub import LLMEncoder
 
     Let's encode video comments using only 2 embedding dimensions:
 
-    >>> enc = TextEncoder(
+    >>> enc = LLMEncoder(
     ...    model_name='intfloat/e5-small-v2', n_components=2
     ... )
     >>> X = pd.Series([
@@ -214,7 +214,7 @@ class TextEncoder(SingleColumnTransformer):
         self.verbose = verbose
 
     def fit_transform(self, column, y=None):
-        """Fit the TextEncoder from ``column``.
+        """Fit the LLMEncoder from ``column``.
 
         In practice, it loads the pre-trained model from disk and returns
         the embeddings of the column.
@@ -280,7 +280,7 @@ class TextEncoder(SingleColumnTransformer):
         return X_out
 
     def transform(self, column):
-        """Transform ``column`` using the TextEncoder.
+        """Transform ``column`` using the LLMEncoder.
 
         This method uses the embedding model loaded in memory during ``fit``
         or ``fit_transform``.
@@ -345,7 +345,7 @@ class TextEncoder(SingleColumnTransformer):
             st = import_optional_dependency(
                 "sentence_transformers",
                 extra=(
-                    "The TextEncoder requires sentence-transformers and its"
+                    "The LLMEncoder requires sentence-transformers and its"
                     " dependencies. Please see"
                     " https://skrub-data.org/stable/install.html#deep-learning-dependencies"
                     " for the installation guide."
@@ -374,7 +374,7 @@ class TextEncoder(SingleColumnTransformer):
                 "model identifier listed on 'https://huggingface.co/models'.\n "
                 "If this is a private repository, make sure to pass a token having "
                 "permission to this repo by setting this token as an environment "
-                "variable, and passing this variable to the TextEncoder as "
+                "variable, and passing this variable to the LLMEncoder as "
                 "`token_env_variable=<your_token_env_variable>`"
             ) from e
         return estimator
@@ -452,3 +452,25 @@ class TextEncoder(SingleColumnTransformer):
             f"{self.input_name_}_{str(i).zfill(num_digits)}"
             for i in range(self.n_components_)
         ]
+
+
+class TextEncoder(LLMEncoder):
+    """
+    Deprecated: Use :class:`~skrub.LLMEncoder` instead.
+
+    .. deprecated:: 0.11
+        The ``TextEncoder`` has been renamed to ``LLMEncoder``, and will be removed
+        in a future release.
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        import warnings
+
+        warnings.warn(
+            "TextEncoder is deprecated and will be removed in a future release. "
+            "Use LLMEncoder instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/skrub/_to_categorical.py
+++ b/skrub/_to_categorical.py
@@ -9,7 +9,7 @@ class ToCategorical(SingleColumnTransformer):
     Convert a string column to Categorical dtype.
 
     This transformer ensures that a given string or categorical column has
-    Categorical dtype. This is done to mark columns to be treated as categorical
+    Categorical dtype so that it is treated as categorical
     by downstream transformers and learners.
 
     Notes
@@ -26,9 +26,14 @@ class ToCategorical(SingleColumnTransformer):
     a polars column with dtype ``String``, is converted to a categorical
     column. Categorical columns are passed through.
 
+    If ``accept_numeric`` is set to ``"all"``, then both integer and float
+    columns are accepted and converted to categorical. If it is set to ``"int"``,
+    then only integer columns are accepted. The default value is ``"int"``.
+
     Any other type of column is rejected by raising a ``RejectColumn``
     exception. **Note:** the ``TableVectorizer`` only sends string or
-    categorical columns to its ``low_cardinality_transformer``. Therefore it is
+    categorical columns to its ``low_cardinality_transformer``, regardless
+    of the inputted value of ``accept_numeric``. Therefore it is
     always safe to use a ``ToCategorical`` instance as the
     ``low_cardinality_transformer``.
 
@@ -88,6 +93,16 @@ class ToCategorical(SingleColumnTransformer):
         ...
     skrub.core.RejectColumn: Column 'c' does not contain strings.
 
+    Unless ``accept_numeric`` is set to ``"int"`` or ``"all"``, in which case integer
+    columns are accepted in the former case, and both integer and float columns are
+    accepted in the latter:
+
+    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'), accept_numeric="all")
+    0    1.1
+    1    2.2
+    Name: c, dtype: category
+    Categories (2, float64): [1.1, 2.2]
+
     ``object`` columns that do not contain only strings are also rejected:
 
     >>> s = pd.Series(['one', 1], name='c')
@@ -143,13 +158,19 @@ class ToCategorical(SingleColumnTransformer):
     True
     """
 
-    def fit_transform(self, column, y=None):
+    def fit_transform(self, column, accept_numeric="int", y=None):
         """Fit the encoder and transform a column.
 
         Parameters
         ----------
         column : pandas or polars Series
             The input to transform.
+
+        accept_numeric : str, default="int"
+            How to handle numeric columns. If "int", will convert integer
+            columns to categorical. If "all", both float and integer columns
+            will be accepted. If None, no numeric
+            columns will be accepted.
 
         y : None
             Ignored.
@@ -163,9 +184,17 @@ class ToCategorical(SingleColumnTransformer):
 
         if sbd.is_categorical(column):
             return column
-        if not sbd.is_string(column):
-            raise RejectColumn(f"Column {sbd.name(column)!r} does not contain strings.")
-        return sbd.to_categorical(column)
+        elif sbd.is_string(column):
+            return sbd.to_categorical(column)
+        elif sbd.is_integer(column) and accept_numeric in ("int", "all"):
+            return sbd.to_categorical(column)
+        elif sbd.is_float(column) and accept_numeric == "all":
+            return sbd.to_categorical(column)
+        else:
+            raise RejectColumn(
+                f"Column {sbd.name(column)!r} does not contain strings "
+                "or numerical data (if accept_numeric is 'int' or 'all')."
+            )
 
     def transform(self, column):
         """Transform a column.

--- a/skrub/_to_categorical.py
+++ b/skrub/_to_categorical.py
@@ -9,7 +9,7 @@ class ToCategorical(SingleColumnTransformer):
     Convert a string column to Categorical dtype.
 
     This transformer ensures that a given string or categorical column has
-    Categorical dtype so that it is treated as categorical
+    Categorical dtype. This is done to mark columns to be treated as categorical
     by downstream transformers and learners.
 
     Notes
@@ -26,14 +26,9 @@ class ToCategorical(SingleColumnTransformer):
     a polars column with dtype ``String``, is converted to a categorical
     column. Categorical columns are passed through.
 
-    If ``accept_numeric`` is set to ``"all"``, then both integer and float
-    columns are accepted and converted to categorical. If it is set to ``"int"``,
-    then only integer columns are accepted. The default value is ``"int"``.
-
     Any other type of column is rejected by raising a ``RejectColumn``
     exception. **Note:** the ``TableVectorizer`` only sends string or
-    categorical columns to its ``low_cardinality_transformer``, regardless
-    of the inputted value of ``accept_numeric``. Therefore it is
+    categorical columns to its ``low_cardinality_transformer``. Therefore it is
     always safe to use a ``ToCategorical`` instance as the
     ``low_cardinality_transformer``.
 
@@ -93,16 +88,6 @@ class ToCategorical(SingleColumnTransformer):
         ...
     skrub.core.RejectColumn: Column 'c' does not contain strings.
 
-    Unless ``accept_numeric`` is set to ``"int"`` or ``"all"``, in which case integer
-    columns are accepted in the former case, and both integer and float columns are
-    accepted in the latter:
-
-    >>> to_cat.fit_transform(pd.Series([1.1, 2.2], name='c'), accept_numeric="all")
-    0    1.1
-    1    2.2
-    Name: c, dtype: category
-    Categories (2, float64): [1.1, 2.2]
-
     ``object`` columns that do not contain only strings are also rejected:
 
     >>> s = pd.Series(['one', 1], name='c')
@@ -158,19 +143,13 @@ class ToCategorical(SingleColumnTransformer):
     True
     """
 
-    def fit_transform(self, column, accept_numeric="int", y=None):
+    def fit_transform(self, column, y=None):
         """Fit the encoder and transform a column.
 
         Parameters
         ----------
         column : pandas or polars Series
             The input to transform.
-
-        accept_numeric : str, default="int"
-            How to handle numeric columns. If "int", will convert integer
-            columns to categorical. If "all", both float and integer columns
-            will be accepted. If None, no numeric
-            columns will be accepted.
 
         y : None
             Ignored.
@@ -184,17 +163,9 @@ class ToCategorical(SingleColumnTransformer):
 
         if sbd.is_categorical(column):
             return column
-        elif sbd.is_string(column):
-            return sbd.to_categorical(column)
-        elif sbd.is_integer(column) and accept_numeric in ("int", "all"):
-            return sbd.to_categorical(column)
-        elif sbd.is_float(column) and accept_numeric == "all":
-            return sbd.to_categorical(column)
-        else:
-            raise RejectColumn(
-                f"Column {sbd.name(column)!r} does not contain strings "
-                "or numerical data (if accept_numeric is 'int' or 'all')."
-            )
+        if not sbd.is_string(column):
+            raise RejectColumn(f"Column {sbd.name(column)!r} does not contain strings.")
+        return sbd.to_categorical(column)
 
     def transform(self, column):
         """Transform a column.

--- a/skrub/tests/test_scaling_factor.py
+++ b/skrub/tests/test_scaling_factor.py
@@ -43,7 +43,7 @@ def test_nonfinite():
         StringEncoder(n_components=2),
         GapEncoder(n_components=2),
         pytest.param(
-            skrub.TextEncoder(
+            skrub.LLMEncoder(
                 model_name="sentence-transformers/paraphrase-albert-small-v2",
                 n_components=2,
                 device="cpu",

--- a/skrub/tests/test_text_encoder.py
+++ b/skrub/tests/test_text_encoder.py
@@ -22,9 +22,9 @@ from numpy.testing import assert_array_equal
 from sklearn.base import clone
 
 import skrub._dataframe as sbd
-from skrub import LLMEncoder, TableVectorizer
+from skrub import TableVectorizer
 from skrub._single_column_transformer import RejectColumn
-from skrub._text_encoder import ModelNotFound
+from skrub._text_encoder import LLMEncoder, ModelNotFound, TextEncoder
 
 
 @pytest.fixture
@@ -248,3 +248,13 @@ def test_categorical_features(df_module, encoder):
 
     out = encoder.fit(df["categorical"][:4]).transform(df["categorical"][4:])
     assert len(sbd.column_names(out)) == 30
+
+
+def test_deprecated_text_encoder_warning(df_module):
+    # We need to define a new encoder with the proper class rather than reusing
+    # the fixture (which is a LLMEncoder)
+    with pytest.warns(DeprecationWarning, match="TextEncoder is deprecated.*"):
+        TextEncoder(
+            model_name="sentence-transformers/paraphrase-albert-small-v2",
+            device="cpu",
+        )

--- a/skrub/tests/test_text_encoder.py
+++ b/skrub/tests/test_text_encoder.py
@@ -22,7 +22,7 @@ from numpy.testing import assert_array_equal
 from sklearn.base import clone
 
 import skrub._dataframe as sbd
-from skrub import TableVectorizer, TextEncoder
+from skrub import LLMEncoder, TableVectorizer
 from skrub._single_column_transformer import RejectColumn
 from skrub._text_encoder import ModelNotFound
 
@@ -40,7 +40,7 @@ def encoder():
       See https://github.com/actions/runner-images/issues/9918 for more details.
     """
     pytest.importorskip("sentence_transformers")
-    return TextEncoder(
+    return LLMEncoder(
         model_name="sentence-transformers/paraphrase-albert-small-v2",
         device="cpu",
     )
@@ -50,16 +50,16 @@ def test_missing_import_error(monkeypatch):
     """Test that a clear error is raised when sentence_transformers is missing.
 
     We mock the missing dependency by hiding it from sys.modules, then verify
-    that TextEncoder.fit() raises an ImportError with a helpful message.
+    that LLMEncoder.fit() raises an ImportError with a helpful message.
     """
     monkeypatch.setitem(sys.modules, "sentence_transformers", None)
 
-    st = TextEncoder()  # Direct creation to avoid importorskip
+    st = LLMEncoder()  # Direct creation to avoid importorskip
     x = pd.Series(["oh no"])
 
     err_msg = (
         "Missing optional dependency 'sentence_transformers'.*"
-        "TextEncoder requires sentence-transformers.*"
+        "LLMEncoder requires sentence-transformers.*"
         "install\\.html#deep-learning-dependencies"
     )
     with pytest.raises(ImportError, match=err_msg):
@@ -147,7 +147,7 @@ def test_wrong_parameters(encoder):
 def test_verbose_default():
     """The default verbose level is 0 (silent), consistent with the rest of
     skrub (e.g. GapEncoder, TableReport)."""
-    assert TextEncoder().verbose == 0
+    assert LLMEncoder().verbose == 0
 
 
 @pytest.mark.parametrize(
@@ -165,7 +165,7 @@ def test_verbose_controls_progress_bar(df_module, verbose, expected_show_progres
             return np.zeros((len(X), 3))
 
     X = df_module.make_column("", ["hello", "hola"])
-    encoder = TextEncoder(n_components=None, verbose=verbose)
+    encoder = LLMEncoder(n_components=None, verbose=verbose)
     encoder._estimator = FakeEstimator()
     encoder.fit_transform(X)
 

--- a/skrub/tests/test_to_categorical.py
+++ b/skrub/tests/test_to_categorical.py
@@ -13,21 +13,9 @@ def test_to_categorical(df_module):
     # categorial columns are accepted
     assert ToCategorical().fit_transform(out) is out
     assert ToCategorical().fit(out).transform(out) is out
-    # default behaviour accepts integer and string
-    # columns, but not float
-    i = df_module.make_column("c", [1, 2, None])
-    assert ToCategorical().fit_transform(i, accept_numeric="int")
-    assert ToCategorical().fit(i).transform(i, accept_numeric="int")
-    # unless accept_numeric is None, in which case
-    # only string and categorical columns are accepted
-    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
-        ToCategorical().fit_transform(i, accept_numeric=None)
-    # if accept_numeric is set to "all", then both integer and
-    # float columns are accepted
+    # non-string, non-categorical columns are rejected
     f = df_module.make_column("c", [1.1, 2.2, None])
-    assert ToCategorical().fit_transform(f, accept_numeric="all")
-    # if accept_numeric != "all", then float columns are rejected
-    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
-        ToCategorical().fit_transform(f)
+    with pytest.raises(RejectColumn, match=".*does not contain strings"):
+        ToCategorical().fit(f)
     # but once accepted during fit, transform works on any column
     assert sbd.is_categorical(ToCategorical().fit(s).transform(f))

--- a/skrub/tests/test_to_categorical.py
+++ b/skrub/tests/test_to_categorical.py
@@ -13,9 +13,21 @@ def test_to_categorical(df_module):
     # categorial columns are accepted
     assert ToCategorical().fit_transform(out) is out
     assert ToCategorical().fit(out).transform(out) is out
-    # non-string, non-categorical columns are rejected
+    # default behaviour accepts integer and string
+    # columns, but not float
+    i = df_module.make_column("c", [1, 2, None])
+    assert ToCategorical().fit_transform(i, accept_numeric="int")
+    assert ToCategorical().fit(i).transform(i, accept_numeric="int")
+    # unless accept_numeric is None, in which case
+    # only string and categorical columns are accepted
+    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
+        ToCategorical().fit_transform(i, accept_numeric=None)
+    # if accept_numeric is set to "all", then both integer and
+    # float columns are accepted
     f = df_module.make_column("c", [1.1, 2.2, None])
-    with pytest.raises(RejectColumn, match=".*does not contain strings"):
-        ToCategorical().fit(f)
+    assert ToCategorical().fit_transform(f, accept_numeric="all")
+    # if accept_numeric != "all", then float columns are rejected
+    with pytest.raises(RejectColumn, match=".*does not contain strings or*"):
+        ToCategorical().fit_transform(f)
     # but once accepted during fit, transform works on any column
     assert sbd.is_categorical(ToCategorical().fit(s).transform(f))


### PR DESCRIPTION
This PR renames the TextEncoder to LLMEncoder. 

I renamed all instances of TextEncoder (with the exception of what's in the changelog), added a deprecation warning and the relative test.

Since I had to modify the content of the `_text_encoder.py` file, I thought it would be better to first merge this PR and then open a separate PR to rename the file, to keep the diff simple. 

