### PR TITLE
DOC - adding proper meta tags to the API docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -648,3 +648,81 @@ for rst_template_name, rst_target_name, kwargs in rst_templates:
     # Render the template and write to the target
     w_path = Path(".") / f"{rst_target_name}.rst"
     w_path.write_text(t.render(**kwargs), encoding="utf-8")
+
+
+# -- Per-page meta descriptions for API pages ---------------------------------
+# Inject <meta name="description"> on every generated API page using the first
+# line of each object's docstring, so search engines show a useful snippet
+# instead of picking up inherited notes or other incidental text.
+#
+# API descriptions are loaded into the _api_descriptions dictionary from the first
+# line of each object's docstring. This is done by the _capture_docstring_summary,
+# which is called by Sphinx when processing each object's docstring.
+#
+# Then, when it's time to generate the HTML for each API page, the
+# _inject_meta_description function will add the corresponding meta description
+# to the page's context.
+_api_descriptions = {}
+
+
+def _capture_docstring_summary(app, what, name, obj, options, lines):
+    """Store the first non-empty docstring line keyed by qualified name.
+
+    Only the first call for a given name is stored so that the object's own
+    docstring takes precedence over later calls made for gallery content or
+    inherited members.
+    """
+    if name in _api_descriptions:
+        return
+    for line in lines:
+        stripped = line.strip()
+        if stripped:
+            _api_descriptions[name] = stripped
+            break
+
+
+def _inject_meta_description(app, pagename, templatename, context, doctree):
+    """Add a meta description to generated API pages.
+
+    Runs before sphinxext.opengraph (priority 499 < default 500).
+
+    We write the tag directly into context['metatags'] (the HTML string of
+    RST .. meta:: nodes) so that opengraph's get_meta_description() check
+    finds it and skips writing its own gallery-derived description.
+    We also set og:description via context['meta'] so the OGP tag is correct.
+    """
+    # Only inject meta descriptions for API pages under "reference/generated/".
+    # Other pages (user guide, gallery etc.) are not affected.
+    if not pagename.startswith("reference/generated/"):
+        return
+    # pagename is e.g. "reference/generated/skrub.StringEncoder"
+    # qualname then is e.g. "skrub.StringEncoder"
+    qualname = pagename[len("reference/generated/") :]
+    description = _api_descriptions.get(qualname)
+    if not description:
+        return
+
+    import html as _html
+
+    # Prepend a <meta name="description"> to metatags so that opengraph sees
+    # it and skips fallback, which picked up the gallery's blurb
+    # (checked at line 152 of sphinxext/opengraph/__init__.py before
+    # meta_tags['description'] is set).
+    tag = (
+        f'<meta name="description" '
+        f'content="{_html.escape(description, quote=True)}" />\n'
+    )
+
+    context["metatags"] = tag + context.get("metatags", "")
+
+    # Also override og:description via context['meta']; opengraph merges any
+    # og:* keys from there into its output tags (line 248).
+    meta = dict(context.get("meta", {}) or {})
+    meta["og:description"] = description
+    context["meta"] = meta
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", _capture_docstring_summary)
+    # Priority 499 ensures this fires before sphinxext.opengraph (default 500).
+    app.connect("html-page-context", _inject_meta_description, priority=499)


### PR DESCRIPTION
This PR modifies how API pages are rendered by sphinx so that their HTML includes `meta` tags that contain the first line of the docstrings as description.

This is because search engines rely on meta tags to describe the content of a page as their search summary (see https://developers.google.com/search/docs/appearance/snippet). 

Without this PR, the description was 

```
content="Gallery examples: Getting Started with skrub Quick overview of DataOps Hands-On with Column Selection and Transformers SquashingScaler: Robust numerical preprocessing for neural networks Sessions i..."
```

which is not useful at all, and is indeed the same description for all pages. 
