### PR TITLE
MAINT - adding plausible analytics

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -252,6 +252,10 @@ html_theme_options = {
     #         "name": "PyData",
     #     },
     # ],
+    "analytics": {
+        "plausible_analytics_domain": "skrub-data.org",
+        "plausible_analytics_url": "https://views.scientific-python.org/js/script.js",
+    },
     "header_links_before_dropdown": 5,
     "icon_links": [
         {


### PR DESCRIPTION
This PR adds a Plausible script to pages to track analytics on the skrub website. 

I added the same line that's used in scikit-learn's configuration to conf.py: https://github.com/scikit-learn/scikit-learn/blob/2cc7893a2097be891426ca6a4d9ea2e14cf82b9c/doc/conf.py#L233

Building the docs locally shows the script embedded in the head of all pages in the documentation, but I don't know if merging this in main will be enough to trigger the tracking, or if we need to to a full release to rebuild the entire website. 

Paging @ogrisel and @lesteve to know if this is all that's done on scikit-learn's side