### PR TITLE
Removed deprecated `how` parameter from `skb.apply`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ Changes
 
   :pr:`2222` by :user:`Ashwin V. Mohanan <ashwinvis>`, with guidance from
   :user:`Jérôme Dockès <jeromedockes>`.
+- Removed the parameter ``how`` of :meth:`DataOp.skb.apply`. :pr:`2281` by
+  :user:`Eloi Massoulié <emassoulie>`.
 
 
 Bugfixes

--- a/skrub/_data_ops/_data_ops.py
+++ b/skrub/_data_ops/_data_ops.py
@@ -51,7 +51,6 @@ from .._apply_to_cols import ApplyToCols
 from .._check_input import cast_column_names_to_strings
 from .._reporting._utils import strip_xml_declaration
 from .._utils import PassThrough, set_module, short_repr
-from .._wrap_transformer import wrap_transformer
 from . import _utils
 from ._choosing import get_chosen_or_default
 from ._utils import FITTED_PREDICTOR_METHODS, NULL, attribute_error
@@ -838,14 +837,12 @@ for op_name in _UNARY_OPS:
     setattr(DataOp, op_name, _make_unary_op(op_name))
 
 
-def _check_wrap_params(cols, exclude_cols, how, allow_reject, reason):
+def _check_wrap_params(cols, exclude_cols, allow_reject, reason):
     msg = None
     if not isinstance(cols, type(s.all())):
         msg = f"`cols` must be `all()` (the default) when {reason}"
     if exclude_cols is not None:
         msg = f"`exclude_cols` must be None (the default) when {reason}"
-    elif how not in ["auto", "no_wrap"]:
-        msg = f"`how` must be 'auto' (the default) or 'no_wrap' when {reason}"
     elif allow_reject:
         msg = f"`allow_reject` must be False (the default) when {reason}"
     if msg is not None:
@@ -876,7 +873,7 @@ def _check_estimator_type(estimator):
     )
 
 
-def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X):
+def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, allow_reject, X):
     """
     Wrap the estimator passed to .skb.apply in ApplyToCols if needed.
     """
@@ -885,16 +882,6 @@ def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X
             "The parameter 'no_wrap' of .skb.apply() must be a Boolean, "
             f"got: {no_wrap!r}."
         )
-    valid = ["auto", "cols", "frame", "no_wrap"]
-    if how not in valid:
-        raise ValueError(f"`how` must be one of {valid}. Got: {how!r}")
-    if how != "auto":
-        warnings.warn(
-            "The 'how' parameter of .skb.apply() has been deprecated "
-            "and will  be removed in a future release. "
-            f"Use the 'no_wrap' parameter instead. Got how={how!r}",
-            FutureWarning,
-        )
 
     if estimator in [None, "passthrough"]:
         estimator = PassThrough()
@@ -902,13 +889,10 @@ def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X
     _check_estimator_type(estimator)
 
     def _check(reason):
-        _check_wrap_params(cols, exclude_cols, how, allow_reject, reason)
+        _check_wrap_params(cols, exclude_cols, allow_reject, reason)
 
     if no_wrap:
         _check("`no_wrap` is True")
-        return estimator
-    if how == "no_wrap":
-        _check("`how` is 'no_wrap'")
         return estimator
     if hasattr(estimator, "predict") or not hasattr(estimator, "transform"):
         _check("`estimator` is a predictor (not a transformer)")
@@ -916,17 +900,8 @@ def _wrap_estimator(estimator, cols, exclude_cols, no_wrap, how, allow_reject, X
     if not sbd.is_dataframe(X):
         _check("the input is not a DataFrame")
         return estimator
-    if how == "auto":
-        return ApplyToCols(
-            estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject
-        )
-    columnwise = {"cols": True, "frame": False}[how]
-    return wrap_transformer(
-        estimator,
-        cols=cols,
-        exclude_cols=exclude_cols,
-        allow_reject=allow_reject,
-        columnwise=columnwise,
+    return ApplyToCols(
+        estimator, cols=cols, exclude_cols=exclude_cols, allow_reject=allow_reject
     )
 
 
@@ -1371,7 +1346,7 @@ class FreezeAfterFit(DataOpImpl):
 
 
 def _check_column_names(X):
-    # NOTE: could allow int column names when how='no_wrap', prob. not worth
+    # NOTE: could allow int column names when no_wrap=True, prob. not worth
     # the added complexity.
     #
     # TODO: maybe also forbid duplicates? use a reduced version of
@@ -1422,7 +1397,6 @@ class Apply(DataOpImpl):
         "cols",
         "exclude_cols",
         "no_wrap",
-        "how",
         "allow_reject",
         "unsupervised",
         "kwargs",
@@ -1461,14 +1435,12 @@ class Apply(DataOpImpl):
             cols = yield self.cols
             exclude_cols = yield self.exclude_cols
             no_wrap = yield self.no_wrap
-            how = yield self.how
             allow_reject = yield self.allow_reject
             self.estimator_ = _wrap_estimator(
                 estimator=estimator,
                 cols=cols,
                 exclude_cols=exclude_cols,
                 no_wrap=no_wrap,
-                how=how,
                 allow_reject=allow_reject,
                 X=X,
             )

--- a/skrub/_data_ops/_skrub_namespace.py
+++ b/skrub/_data_ops/_skrub_namespace.py
@@ -156,7 +156,6 @@ class SkrubNamespace:
         cols=_SELECT_ALL_COLUMNS,
         exclude_cols=None,
         no_wrap=False,
-        how="auto",
         allow_reject=False,
         unsupervised=False,
         kwargs=None,
@@ -171,7 +170,6 @@ class SkrubNamespace:
                 X=self._data_op,
                 y=y,
                 no_wrap=no_wrap,
-                how=how,
                 allow_reject=allow_reject,
                 unsupervised=unsupervised,
                 kwargs=kwargs,
@@ -188,7 +186,6 @@ class SkrubNamespace:
         cols=_SELECT_ALL_COLUMNS,
         exclude_cols=None,
         no_wrap=False,
-        how="auto",
         allow_reject=False,
         unsupervised=False,
         fit_kwargs=None,
@@ -228,30 +225,6 @@ class SkrubNamespace:
             parameters. Passing ``no_wrap=True`` disables this wrapping in all
             cases. When ``no_wrap`` is True, ``cols`` and ``allow_reject``
             cannot be used.
-
-        how : "auto", "cols", "frame" or "no_wrap", optional
-            Deprecated. Use ``no_wrap`` instead.
-
-            How the estimator is applied. In most cases the default "auto"
-            is appropriate.
-
-            - "cols" means `estimator` is wrapped in a :class:`ApplyToEachCol`
-              transformer, which fits a separate clone of `estimator` each
-              column in `cols`. `estimator` must be a transformer (have a
-              ``fit_transform`` method).
-            - "frame" means `estimator` is wrapped in a :class:`ApplyToSubFrame`
-              transformer, which fits a single clone of `estimator` to the
-              selected part of the input dataframe. `estimator` must be a
-              transformer.
-            - "no_wrap" means no wrapping, `estimator` is applied directly to
-              the unmodified input.
-            - "auto" chooses the wrapping depending on the input and estimator.
-              If the input is not a dataframe or the estimator is not a
-              transformer, the "no_wrap" strategy is chosen. Otherwise if the
-              estimator has a ``__single_column_transformer__`` attribute,
-              "cols" is chosen. Otherwise "frame" is chosen.
-
-            .. deprecated:: 0.9.0
 
         allow_reject : bool, optional
             Whether the transformer can refuse to transform columns for which
@@ -467,7 +440,6 @@ class SkrubNamespace:
             cols=cols,
             exclude_cols=exclude_cols,
             no_wrap=no_wrap,
-            how=how,
             allow_reject=allow_reject,
             unsupervised=unsupervised,
             kwargs={

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -17,7 +17,6 @@ from sklearn.utils import check_random_state
 
 import skrub
 from skrub import selectors as s
-from skrub._apply_to_each_col import ApplyToEachCol
 from skrub._data_ops import _data_ops
 from skrub._utils import PassThrough
 
@@ -569,18 +568,16 @@ def test_data_op_impl():
         a.skb.eval()
 
 
-@pytest.mark.parametrize("why_no_wrap", ["numpy", "predictor", "no_wrap", "how"])
-@pytest.mark.parametrize("bad_param", ["cols", "exclude_cols", "how", "allow_reject"])
+@pytest.mark.parametrize("why_no_wrap", ["numpy", "predictor", "no_wrap"])
+@pytest.mark.parametrize("bad_param", ["cols", "exclude_cols", "allow_reject"])
 def test_apply_bad_params(why_no_wrap, bad_param):
     # When the estimator is a predictor or the input is a numpy array (not a
-    # dataframe) (or no_wrap=True, or how='no_wrap') the estimator can only be
+    # dataframe) (or no_wrap=True) the estimator can only be
     # applied to the full input without wrapping in ApplyToCols, ApplyToEachCol
     # or ApplyToSubFrame. In this case if the user passed a parameter that
     # would require wrapping, such as passing a value for `cols` that is not
-    # `all()`, or passing how='cols' or allow_reject=True, we get an error.
+    # `all()`, or passing allow_reject=True, we get an error.
 
-    if bad_param == "how" and why_no_wrap in ["no_wrap", "how"]:
-        return
     X_a, y_a = make_classification(random_state=0)
     X_df = pd.DataFrame(X_a, columns=[f"col_{i}" for i in range(X_a.shape[1])])
 
@@ -591,8 +588,7 @@ def test_apply_bad_params(why_no_wrap, bad_param):
     else:
         estimator = PassThrough()
         y = None
-    how = "no_wrap" if why_no_wrap == "how" else "auto"
-    # X is a numpy array: how must be no_wrap and selecting columns is not
+    # X is a numpy array: selecting columns is not
     # allowed.
     if bad_param == "cols":
         if why_no_wrap == "numpy":
@@ -608,7 +604,6 @@ def test_apply_bad_params(why_no_wrap, bad_param):
             exclude_cols = ["col_0"]
     else:
         exclude_cols = None
-    how = "cols" if bad_param == "how" else how
     allow_reject = True if bad_param == "allow_reject" else False
     no_wrap = True if why_no_wrap == "no_wrap" else False
 
@@ -616,41 +611,18 @@ def test_apply_bad_params(why_no_wrap, bad_param):
         (ValueError, RuntimeError),
         match=(
             r"(`cols` must be `all\(\)`|`exclude_cols` must be None|"
-            r"`how` must be 'auto'|`allow_reject` must be False)"
+            r"`allow_reject` must be False)"
         ),
     ):
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*how.*deprecated.*")
             X.skb.apply(
                 estimator,
                 y=y,
                 no_wrap=no_wrap,
-                how=how,
                 allow_reject=allow_reject,
                 cols=cols,
                 exclude_cols=exclude_cols,
             )
-
-
-def test_apply_how():
-    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    X = skrub.var("X", df)
-    t = PassThrough()
-    for how in ["cols", "frame", "no_wrap"]:
-        with pytest.warns(
-            FutureWarning,
-            match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
-        ):
-            assert list(X.skb.apply(t, how=how).skb.eval().columns) == ["a", "b"]
-    assert list(X.skb.apply(t, how="auto").skb.eval().columns) == ["a", "b"]
-    with pytest.raises(RuntimeError, match="`how` must be one of"):
-        X.skb.apply(t, how="bad value")
-    with pytest.warns(
-        FutureWarning,
-        match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
-    ):
-        wrapper = X.skb.apply(t, how="cols").skb.applied_estimator.skb.eval()
-        assert isinstance(wrapper, ApplyToEachCol)
 
 
 def test_apply_no_wrap():

--- a/skrub/_data_ops/tests/test_data_ops.py
+++ b/skrub/_data_ops/tests/test_data_ops.py
@@ -699,7 +699,7 @@ def test_apply_kwargs():
 
 
 def test_apply_transformer_kwargs():
-    # check kwargs get passed correctly to the transformer for all 'how' values.
+    # check kwargs get passed correctly to the transformer for all 'no_wrap' values.
     class T(BaseEstimator):
         def fit_transform(self, X, y=None, extra_f=None):
             assert extra_f == "kwarg for fit_transform"
@@ -713,21 +713,12 @@ def test_apply_transformer_kwargs():
         "fit_transform_kwargs": {"extra_f": "kwarg for fit_transform"},
         "transform_kwargs": {"extra_t": "kwarg for transform"},
     }
-    learner = (
-        skrub.var("df")
-        .skb.apply(T(), how="no_wrap", **kwargs)
-        .skb.apply(T(), how="cols", **kwargs)
-        .skb.apply(T(), how="frame", **kwargs)
-        .skb.make_learner()
-    )
+    learner = skrub.var("df").skb.apply(T(), no_wrap=True, **kwargs).skb.make_learner()
     df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
-    with pytest.warns(
-        FutureWarning,
-        match=re.escape("The 'how' parameter of .skb.apply() has been deprecated"),
-    ):
-        learner.fit({"df": df})
-        learner.fit_transform({"df": df})
-        learner.transform({"df": df})
+
+    learner.fit({"df": df})
+    learner.fit_transform({"df": df})
+    learner.transform({"df": df})
 
 
 def test_apply_kwargs_evaluation():


### PR DESCRIPTION
Addresses part of https://github.com/skrub-data/skrub/issues/2220

Every reference to the `how` parameter has been removed, and every piece of logic depending on its value adjusted.